### PR TITLE
Fix role validation bug in user creation API

### DIFF
--- a/app/api/usuarios/route.ts
+++ b/app/api/usuarios/route.ts
@@ -59,7 +59,7 @@ export async function POST(req: NextRequest) {
       !password ||
       !passwordConfirm ||
       !campo ||
-      !["usuario", "lider"].includes(role)
+      !["usuario", "lider", "coordenador"].includes(role)
     ) {
       return NextResponse.json({ error: "Dados inválidos" }, { status: 400 });
     }


### PR DESCRIPTION
## Summary
- allow creating coordinator users via the API

## Testing
- `npx next lint` *(fails: E403 Forbidden)*
- `npx tsc --noEmit` *(fails: cannot find modules)*

------
https://chatgpt.com/codex/tasks/task_e_683fb0501608832cbb1eff5f765ebef5