### PR TITLE
Remove PocketBase singleton

### DIFF
--- a/app/admin/api/checkout/route.ts
+++ b/app/admin/api/checkout/route.ts
@@ -2,10 +2,9 @@ import { NextRequest, NextResponse } from "next/server";
 import mercadopago from "mercadopago";
 import PocketBase from "pocketbase";
 
-const pb = new PocketBase("https://umadeus-production.up.railway.app");
-pb.autoCancellation(false);
-
 export async function POST(req: NextRequest) {
+  const pb = new PocketBase("https://umadeus-production.up.railway.app");
+  pb.autoCancellation(false);
   const accessToken = process.env.MERCADO_PAGO_ACCESS_TOKEN;
   const siteUrl = process.env.NEXT_PUBLIC_SITE_URL || "http://localhost:3000";
 

--- a/app/admin/api/checkout/webhook/route.ts
+++ b/app/admin/api/checkout/webhook/route.ts
@@ -2,14 +2,13 @@ import { NextRequest, NextResponse } from "next/server";
 import PocketBase from "pocketbase";
 import mercadopago from "mercadopago";
 
-const pb = new PocketBase("https://umadeus-production.up.railway.app");
-pb.autoCancellation(false);
-
 mercadopago.configure({
   access_token: process.env.MERCADO_PAGO_ACCESS_TOKEN!,
 });
 
 export async function POST(req: NextRequest) {
+  const pb = new PocketBase("https://umadeus-production.up.railway.app");
+  pb.autoCancellation(false);
   try {
     const body = await req.json();
     const paymentId = body?.data?.id;

--- a/app/admin/api/inscricoes/route.ts
+++ b/app/admin/api/inscricoes/route.ts
@@ -16,10 +16,10 @@ interface DadosInscricao {
   tamanho?: string;
 }
 
-const pb = new PocketBase("https://umadeus-production.up.railway.app");
-pb.autoCancellation(false);
 
 export async function POST(req: NextRequest) {
+  const pb = new PocketBase("https://umadeus-production.up.railway.app");
+  pb.autoCancellation(false);
   try {
     const body = await req.json();
     const {

--- a/app/admin/api/pedidos/routes.tsx
+++ b/app/admin/api/pedidos/routes.tsx
@@ -1,10 +1,9 @@
 import { NextRequest, NextResponse } from "next/server";
 import PocketBase from "pocketbase";
 
-const pb = new PocketBase("https://umadeus-production.up.railway.app");
-pb.autoCancellation(false);
-
 export async function POST(req: NextRequest) {
+  const pb = new PocketBase("https://umadeus-production.up.railway.app");
+  pb.autoCancellation(false);
   try {
     const body = await req.json();
     const { inscricaoId } = body;

--- a/app/admin/api/recuperar-link/route.ts
+++ b/app/admin/api/recuperar-link/route.ts
@@ -1,12 +1,11 @@
 import { NextRequest, NextResponse } from "next/server";
 import PocketBase from "pocketbase";
 
-const pb = new PocketBase(
-  process.env.PB_URL || "https://umadeus-production.up.railway.app"
-);
-pb.autoCancellation(false);
-
 export async function POST(req: NextRequest) {
+  const pb = new PocketBase(
+    process.env.PB_URL || "https://umadeus-production.up.railway.app"
+  );
+  pb.autoCancellation(false);
   try {
     const { cpf, telefone } = await req.json();
 

--- a/app/admin/components/Header.tsx
+++ b/app/admin/components/Header.tsx
@@ -3,7 +3,8 @@
 import Link from "next/link";
 import { usePathname } from "next/navigation";
 import { useAuthContext } from "@/lib/context/AuthContext";
-import pb from "@/lib/pocketbase";
+import { useMemo } from "react";
+import createPocketBase from "@/lib/pocketbase";
 import Image from "next/image";
 import { Menu, X, ChevronDown, User, Lock, LogOut, Sun, Moon } from "lucide-react";
 import { useState } from "react";
@@ -31,6 +32,7 @@ const getNavLinks = (role?: string) => {
 export default function Header() {
   const pathname = usePathname();
   const { isLoggedIn, user } = useAuthContext();
+  const pb = useMemo(() => createPocketBase(), []);
   const [menuAberto, setMenuAberto] = useState(false);
   const [perfilAberto, setPerfilAberto] = useState(false);
   const [mostrarModalSenha, setMostrarModalSenha] = useState(false);

--- a/app/admin/components/NotificationBell.tsx
+++ b/app/admin/components/NotificationBell.tsx
@@ -1,11 +1,12 @@
 "use client";
 
-import { useEffect, useState } from "react";
+import { useEffect, useState, useMemo } from "react";
 import { Bell, X } from "lucide-react";
-import pb from "@/lib/pocketbase";
+import createPocketBase from "@/lib/pocketbase";
 import type { Inscricao } from "@/types";
 
 export default function NotificationBell() {
+  const pb = useMemo(() => createPocketBase(), []);
   const [count, setCount] = useState(0);
   const [inscricoes, setInscricoes] = useState<Inscricao[]>([]);
   const [open, setOpen] = useState(false);

--- a/app/admin/components/RedefinirSenhaModal.tsx
+++ b/app/admin/components/RedefinirSenhaModal.tsx
@@ -1,11 +1,12 @@
 "use client";
 
-import { useState } from "react";
-import pb from "@/lib/pocketbase";
+import { useState, useMemo } from "react";
+import createPocketBase from "@/lib/pocketbase";
 import { useToast } from "@/lib/context/ToastContext";
 
 export default function RedefinirSenhaModal({ onClose }: { onClose: () => void }) {
   const [email, setEmail] = useState("");
+  const pb = useMemo(() => createPocketBase(), []);
   const { showSuccess, showError } = useToast();
 
   const handleResetRequest = async () => {

--- a/app/admin/globals.css
+++ b/app/admin/globals.css
@@ -1,0 +1,47 @@
+@tailwind base;
+@tailwind components;
+@tailwind utilities;
+
+/* ==========================
+   🎨 Variáveis de cor customizadas
+   ========================== */
+:root {
+  --background: #1e2019; /* eerie_black */
+  --foreground: #f9c5c7; /* cornell_red-900 */
+  --text-primary: #dcdcdc; /* Platinum */
+  --text-secondary: #ababab; /* jet-800 */
+  --accent: #b11116; /* cornell_red */
+}
+
+@media (prefers-color-scheme: dark) {
+  :root {
+    --background: #0c0d0a; /* eerie_black-200 */
+    --foreground: #f9c5c7; /* cornell_red-900 */
+    --text-primary: #dcdcdc; /* Platinum */
+    --text-secondary: #8c8c8c; /* jet-700 */
+    --accent: #e81920; /* cornell_red-600 */
+  }
+}
+
+body {
+  background: linear-gradient(
+    270deg,
+    #1e2019,
+    #2a1a1c,
+    #3b2a2b,
+    #1e2019,
+    #2a1a1c,
+    #1e2019
+  );
+  background-size: 500% 500%;
+  background-repeat: no-repeat;
+  animation: gradient-x 30s ease-in-out infinite;
+  color: var(--text-primary);
+  font-family: "Inter", Arial, Helvetica, sans-serif;
+  transition: background-color 0.s ease, color 0.9s ease;
+}
+
+/* 🧩 Input com estilo moderno e leve */
+.input-style {
+  @apply w-full px-4 py-3 rounded-lg border border-[#b3b3b3] bg-[#f0f0f0] text-sm text-eerie_black focus:outline-none focus:ring-2 focus:ring-cornell_red-600 transition;
+}

--- a/app/admin/inscricoes/componentes/ModalVisualizarPedido.tsx
+++ b/app/admin/inscricoes/componentes/ModalVisualizarPedido.tsx
@@ -1,7 +1,7 @@
 "use client";
-import { useEffect, useState } from "react";
+import { useEffect, useState, useMemo } from "react";
 import { X, Copy } from "lucide-react";
-import pb from "@/lib/pocketbase";
+import createPocketBase from "@/lib/pocketbase";
 
 interface Props {
   pedidoId: string;
@@ -30,6 +30,7 @@ type PedidoExpandido = {
 };
 
 export default function ModalVisualizarPedido({ pedidoId, onClose }: Props) {
+  const pb = useMemo(() => createPocketBase(), []);
   const [pedido, setPedido] = useState<PedidoExpandido | null>(null);
   const [loading, setLoading] = useState(true);
   const [reenviando, setReenviando] = useState(false);

--- a/app/admin/inscricoes/page.tsx
+++ b/app/admin/inscricoes/page.tsx
@@ -1,7 +1,7 @@
 "use client";
 
-import { useEffect, useState } from "react";
-import pb from "@/lib/pocketbase";
+import { useEffect, useState, useMemo } from "react";
+import createPocketBase from "@/lib/pocketbase";
 import { Copy } from "lucide-react";
 import { saveAs } from "file-saver";
 import ModalEditarInscricao from "./componentes/ModalEdit";
@@ -37,6 +37,7 @@ type Inscricao = {
 };
 
 export default function ListaInscricoesPage() {
+  const pb = useMemo(() => createPocketBase(), []);
   const [inscricoes, setInscricoes] = useState<Inscricao[]>([]);
   const [role, setRole] = useState("");
   const [linkPublico, setLinkPublico] = useState("");

--- a/app/admin/lider-painel/page.tsx
+++ b/app/admin/lider-painel/page.tsx
@@ -1,9 +1,9 @@
 "use client";
 
-import { useEffect, useRef, useState } from "react";
+import { useEffect, useRef, useState, useMemo } from "react";
 import { useRouter } from "next/navigation";
 import { useAuthContext } from "@/lib/context/AuthContext";
-import pb from "@/lib/pocketbase";
+import createPocketBase from "@/lib/pocketbase";
 import DashboardAnalytics from "../components/DashboardAnalytics";
 import type { Inscricao, Pedido } from "@/types";
 import {
@@ -36,6 +36,7 @@ ChartJS.register(
 export default function LiderDashboardPage() {
   const router = useRouter();
   const { user, isLoggedIn } = useAuthContext();
+  const pb = useMemo(() => createPocketBase(), []);
 
   const [inscricoes, setInscricoes] = useState<Inscricao[]>([]);
   const [pedidos, setPedidos] = useState<Pedido[]>([]);

--- a/app/admin/pedidos/page.tsx
+++ b/app/admin/pedidos/page.tsx
@@ -1,10 +1,10 @@
 "use client";
 
-import { useEffect, useState } from "react";
+import { useEffect, useState, useMemo } from "react";
 import { useRouter } from "next/navigation";
 import { useAuthContext } from "@/lib/context/AuthContext";
 import { Pedido } from "@/types";
-import pb from "@/lib/pocketbase";
+import createPocketBase from "@/lib/pocketbase";
 import { saveAs } from "file-saver";
 import ModalEditarPedido from "./componentes/ModalEditarPedido";
 import { useToast } from "@/lib/context/ToastContext";
@@ -12,6 +12,7 @@ import { useToast } from "@/lib/context/ToastContext";
 export default function PedidosPage() {
   const router = useRouter();
   const { user, isLoggedIn } = useAuthContext();
+  const pb = useMemo(() => createPocketBase(), []);
 
   const [pedidos, setPedidos] = useState<Pedido[]>([]);
   const [loading, setLoading] = useState(true);

--- a/app/admin/perfil/components/ModalEditarPerfil.tsx
+++ b/app/admin/perfil/components/ModalEditarPerfil.tsx
@@ -1,8 +1,8 @@
 "use client";
 
-import { useState } from "react";
+import { useState, useMemo } from "react";
 import { useAuthContext } from "@/lib/context/AuthContext";
-import pb from "@/lib/pocketbase";
+import createPocketBase from "@/lib/pocketbase";
 
 export default function ModalEditarPerfil({
   onClose,
@@ -10,6 +10,7 @@ export default function ModalEditarPerfil({
   onClose: () => void;
 }) {
   const { user } = useAuthContext();
+  const pb = useMemo(() => createPocketBase(), []);
   const [nome, setNome] = useState(String(user?.nome || ""));
   const [telefone, setTelefone] = useState(String(user?.telefone || ""));
   const [cpf, setCpf] = useState(String(user?.cpf || ""));

--- a/app/admin/perfil/page.tsx
+++ b/app/admin/perfil/page.tsx
@@ -1,7 +1,7 @@
 "use client";
 
-import { useEffect, useState } from "react";
-import pb from "@/lib/pocketbase";
+import { useEffect, useState, useMemo } from "react";
+import createPocketBase from "@/lib/pocketbase";
 import { useRouter } from "next/navigation";
 import ModalEditarPerfil from "./components/ModalEditarPerfil";
 
@@ -23,6 +23,7 @@ interface UsuarioAuthModel {
 
 export default function PerfilPage() {
   const router = useRouter();
+  const pb = useMemo(() => createPocketBase(), []);
   const [usuario, setUsuario] = useState<UsuarioAuthModel | null>(null);
   const [mostrarModal, setMostrarModal] = useState(false);
 

--- a/app/admin/redefinir-senha/RedefinirSenhaClient.tsx
+++ b/app/admin/redefinir-senha/RedefinirSenhaClient.tsx
@@ -1,12 +1,13 @@
 "use client";
 
-import { useState, useEffect } from "react";
+import { useState, useEffect, useMemo } from "react";
 import { useSearchParams, useRouter } from "next/navigation";
-import pb from "@/lib/pocketbase";
+import createPocketBase from "@/lib/pocketbase";
 
 export default function RedefinirSenhaClient() {
   const searchParams = useSearchParams();
   const router = useRouter();
+  const pb = useMemo(() => createPocketBase(), []);
   const token = searchParams.get("token") ?? "";
 
   const [novaSenha, setNovaSenha] = useState("");

--- a/app/globals.css
+++ b/app/globals.css
@@ -1,0 +1,47 @@
+@tailwind base;
+@tailwind components;
+@tailwind utilities;
+
+/* ==========================
+   🎨 Variáveis de cor customizadas
+   ========================== */
+:root {
+  --background: #1e2019; /* eerie_black */
+  --foreground: #f9c5c7; /* cornell_red-900 */
+  --text-primary: #dcdcdc; /* Platinum */
+  --text-secondary: #ababab; /* jet-800 */
+  --accent: #b11116; /* cornell_red */
+}
+
+@media (prefers-color-scheme: dark) {
+  :root {
+    --background: #0c0d0a; /* eerie_black-200 */
+    --foreground: #f9c5c7; /* cornell_red-900 */
+    --text-primary: #dcdcdc; /* Platinum */
+    --text-secondary: #8c8c8c; /* jet-700 */
+    --accent: #e81920; /* cornell_red-600 */
+  }
+}
+
+body {
+  background: linear-gradient(
+    270deg,
+    #1e2019,
+    #2a1a1c,
+    #3b2a2b,
+    #1e2019,
+    #2a1a1c,
+    #1e2019
+  );
+  background-size: 500% 500%;
+  background-repeat: no-repeat;
+  animation: gradient-x 30s ease-in-out infinite;
+  color: var(--text-primary);
+  font-family: "Inter", Arial, Helvetica, sans-serif;
+  transition: background-color 0.s ease, color 0.9s ease;
+}
+
+/* 🧩 Input com estilo moderno e leve */
+.input-style {
+  @apply w-full px-4 py-3 rounded-lg border border-[#b3b3b3] bg-[#f0f0f0] text-sm text-eerie_black focus:outline-none focus:ring-2 focus:ring-cornell_red-600 transition;
+}

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -4,7 +4,7 @@ import "./globals.css";
 import { AuthProvider } from "@/lib/context/AuthContext";
 import { ThemeProvider } from "@/lib/context/ThemeContext";
 import { ToastProvider } from "@/lib/context/ToastContext";
-import LayoutWrapper from "./components/LayoutWrapper";
+import LayoutWrapper from "./admin/components/LayoutWrapper";
 
 const geistSans = Geist({ variable: "--font-geist-sans", subsets: ["latin"] });
 const geistMono = Geist_Mono({

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -4,7 +4,7 @@ import { useEffect, useState } from "react";
 import { useRouter } from "next/navigation";
 import { useAuthContext } from "@/lib/context/AuthContext";
 import Image from "next/image";
-import RedefinirSenhaModal from "./components/RedefinirSenhaModal";
+import RedefinirSenhaModal from "./admin/components/RedefinirSenhaModal";
 
 export default function LoginPage() {
   const router = useRouter();

--- a/lib/getUserFromHeaders.ts
+++ b/lib/getUserFromHeaders.ts
@@ -1,10 +1,10 @@
 import type { NextRequest } from "next/server";
-import pb from "@/lib/pocketbase";
+import createPocketBase from "@/lib/pocketbase";
 import type { RecordModel } from "pocketbase";
 
 type AuthOk = {
   user: RecordModel;
-  pbSafe: typeof pb;
+  pbSafe: ReturnType<typeof createPocketBase>;
 };
 
 type AuthError = {
@@ -22,8 +22,9 @@ export function getUserFromHeaders(req: NextRequest): AuthOk | AuthError {
   try {
     const parsedUser = JSON.parse(rawUser) as RecordModel;
 
+    const pb = createPocketBase();
     pb.authStore.save(token, parsedUser);
-    pb.autoCancellation(false); 
+    pb.autoCancellation(false);
 
     return { user: parsedUser, pbSafe: pb };
   } catch {

--- a/lib/hooks/usePocketBase.ts
+++ b/lib/hooks/usePocketBase.ts
@@ -1,5 +1,6 @@
-import pb from "@/lib/pocketbase";
+import { useMemo } from "react";
+import createPocketBase from "@/lib/pocketbase";
 
 export default function usePocketBase() {
-  return pb;
+  return useMemo(() => createPocketBase(), []);
 }

--- a/lib/pocketbase.ts
+++ b/lib/pocketbase.ts
@@ -1,5 +1,26 @@
 import PocketBase from "pocketbase";
 
-const pb = new PocketBase("https://umadeus-production.up.railway.app");
+const PB_URL =
+  process.env.NEXT_PUBLIC_PB_URL ||
+  "https://umadeus-production.up.railway.app";
 
-export default pb;
+const basePb = new PocketBase(PB_URL);
+
+export function createPocketBase() {
+  if (typeof (basePb as any).clone === "function") {
+    return (basePb as any).clone();
+  }
+  const pb = new PocketBase(PB_URL);
+  pb.authStore.save(basePb.authStore.token, basePb.authStore.model);
+  return pb;
+}
+
+export function updateBaseAuth(token: string, model: any) {
+  basePb.authStore.save(token, model);
+}
+
+export function clearBaseAuth() {
+  basePb.authStore.clear();
+}
+
+export default createPocketBase;


### PR DESCRIPTION
## Summary
- avoid shared PocketBase instance
- provide `createPocketBase()` factory and use in hooks/components
- instantiate PocketBase in API handlers

## Testing
- `npm run lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_6841e6d6db10832c83b907691460c954