### PR TITLE
Add price constants

### DIFF
--- a/app/admin/api/pedidos/routes.tsx
+++ b/app/admin/api/pedidos/routes.tsx
@@ -1,5 +1,6 @@
 import { NextRequest, NextResponse } from "next/server";
 import PocketBase from "pocketbase";
+import { PRECO_PULSEIRA, PRECO_KIT } from "@/lib/constants";
 
 export async function POST(req: NextRequest) {
   const pb = new PocketBase("https://umadeus-production.up.railway.app");
@@ -30,7 +31,7 @@ export async function POST(req: NextRequest) {
     const responsavelId = inscricao.expand?.criado_por;
 
     const valor =
-      inscricao.produto === "Somente Pulseira" ? 10.00 : 50.00;
+      inscricao.produto === "Somente Pulseira" ? PRECO_PULSEIRA : PRECO_KIT;
 
     const pedido = await pb.collection("pedidos").create({
       id_inscricao: inscricaoId,

--- a/app/admin/inscricoes/page.tsx
+++ b/app/admin/inscricoes/page.tsx
@@ -9,6 +9,7 @@ import ModalVisualizarPedido from "./componentes/ModalVisualizarPedido";
 import { CheckCircle, XCircle, Pencil, Trash2, Eye } from "lucide-react";
 import TooltipIcon from "../components/TooltipIcon";
 import { useToast } from "@/lib/context/ToastContext";
+import { PRECO_PULSEIRA, PRECO_KIT } from "@/lib/constants";
 
 const statusBadge = {
   pendente: "bg-yellow-100 text-yellow-800",
@@ -149,7 +150,9 @@ export default function ListaInscricoesPage() {
 
       // 🔹 2. Criar pedido com os dados da inscrição
       const valorPedido =
-        inscricao.produto === "Somente Pulseira" ? 10.00 : 50.00;
+        inscricao.produto === "Somente Pulseira"
+          ? PRECO_PULSEIRA
+          : PRECO_KIT;
 
       const pedido = await pb.collection("pedidos").create({
         id_inscricao: id,

--- a/lib/constants.ts
+++ b/lib/constants.ts
@@ -1,0 +1,2 @@
+export const PRECO_PULSEIRA = 10.0;
+export const PRECO_KIT = 50.0;


### PR DESCRIPTION
## Summary
- add `lib/constants.ts` containing pricing constants
- reuse constants in API and inscriptions pages

## Testing
- `npm run lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_6841f19bd334832c818697ef9647751f