### PR TITLE
Portal landing page for admin vs loja

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -4,7 +4,6 @@ import "./globals.css";
 import { AuthProvider } from "@/lib/context/AuthContext";
 import { ThemeProvider } from "@/lib/context/ThemeContext";
 import { ToastProvider } from "@/lib/context/ToastContext";
-import LayoutWrapper from "./admin/components/LayoutWrapper";
 
 const geistSans = Geist({ variable: "--font-geist-sans", subsets: ["latin"] });
 const geistMono = Geist_Mono({
@@ -39,7 +38,7 @@ export default function RootLayout({
         <ThemeProvider>
           <AuthProvider>
             <ToastProvider>
-              <LayoutWrapper>{children}</LayoutWrapper>
+              {children}
             </ToastProvider>
           </AuthProvider>
         </ThemeProvider>

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,5 +1,13 @@
-import LoginForm from "./components/LoginForm";
+import Link from "next/link";
 
-export default function LoginPage() {
-  return <LoginForm />;
+export default function PortalPage() {
+  return (
+    <div className="min-h-screen flex flex-col items-center justify-center gap-6 bg-gray-900 text-gray-100">
+      <h1 className="text-3xl font-bold">Portal UMADEUS</h1>
+      <div className="flex gap-4">
+        <Link href="/loja" className="px-4 py-2 rounded bg-red-700 hover:bg-red-600">Loja</Link>
+        <Link href="/admin" className="px-4 py-2 rounded bg-gray-700 hover:bg-gray-600">Admin</Link>
+      </div>
+    </div>
+  );
 }


### PR DESCRIPTION
## Summary
- replace the root page with a simple portal linking to Loja and Admin
- keep the login form only on `/admin`
- simplify the global layout so only the admin pages use `LayoutWrapper`

## Testing
- `npm run lint` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6841f2ec78e0832c87a35e94e14870dd