### PR TITLE
Adicionar rota /admin/login e corrigir redirecionamentos

### DIFF
--- a/app/admin/components/Header.tsx
+++ b/app/admin/components/Header.tsx
@@ -44,7 +44,7 @@ export default function Header() {
     pb.authStore.clear();
     localStorage.removeItem("pb_token");
     localStorage.removeItem("pb_user");
-    window.location.href = "/";
+    window.location.href = "/admin/login";
   };
 
   return (
@@ -143,7 +143,7 @@ export default function Header() {
 
           {!isLoggedIn && (
             <Link
-              href="/"
+              href="/admin/login"
               className="text-sm underline text-[#DCDCDC] hover:text-white cursor-pointer"
             >
               Entrar
@@ -213,7 +213,7 @@ export default function Header() {
 
             {!isLoggedIn && (
               <Link
-                href="/"
+                href="/admin/login"
                 onClick={() => setMenuAberto(false)}
                 className="text-left px-4 py-2 text-sm underline text-[#DCDCDC] hover:text-white"
               >

--- a/app/admin/erro/page.tsx
+++ b/app/admin/erro/page.tsx
@@ -19,7 +19,7 @@ export default function ErroPage() {
 
         <div className="pt-4">
           <Link
-            href="/"
+            href="/admin/login"
             className="inline-block bg-purple-600 text-white font-bold py-2 px-6 rounded-lg"
           >
             Voltar para o início

--- a/app/admin/lider-painel/page.tsx
+++ b/app/admin/lider-painel/page.tsx
@@ -50,7 +50,7 @@ export default function LiderDashboardPage() {
 
   useEffect(() => {
     if (!isLoggedIn || !user || user.role !== "lider") {
-      router.replace("/");
+      router.replace("/admin/login");
       return;
     }
 

--- a/app/admin/login/page.tsx
+++ b/app/admin/login/page.tsx
@@ -1,0 +1,5 @@
+import LoginForm from "../../components/LoginForm";
+
+export default function LoginPage() {
+  return <LoginForm />;
+}

--- a/app/admin/obrigado/page.tsx
+++ b/app/admin/obrigado/page.tsx
@@ -20,7 +20,7 @@ export default function ObrigadoPage() {
 
         <div className="pt-4">
           <Link
-            href="/"
+            href="/admin/login"
             className="inline-block bg-purple-600 text-white font-bold py-2 px-6 rounded-lg"
           >
             Voltar para o início

--- a/app/admin/page.tsx
+++ b/app/admin/page.tsx
@@ -1,5 +1,5 @@
-import LoginForm from "../components/LoginForm";
+import { redirect } from "next/navigation";
 
-export default function LoginPage() {
-  return <LoginForm />;
+export default function AdminIndex() {
+  redirect("/admin/login");
 }

--- a/app/admin/pedidos/page.tsx
+++ b/app/admin/pedidos/page.tsx
@@ -34,7 +34,7 @@ export default function PedidosPage() {
   // Redireciona se não for coordenador
   useEffect(() => {
     if (!isLoggedIn || !user) {
-      router.replace("/");
+      router.replace("/admin/login");
     }
   }, [isLoggedIn, user, router]);
 

--- a/app/admin/pendente/page.tsx
+++ b/app/admin/pendente/page.tsx
@@ -21,7 +21,7 @@ export default function PagamentoPendentePage() {
 
         <div className="pt-4">
           <Link
-            href="/"
+            href="/admin/login"
             className="inline-block bg-purple-600 text-white font-bold py-2 px-6 rounded-lg"
           >
             Voltar para o início

--- a/app/admin/perfil/page.tsx
+++ b/app/admin/perfil/page.tsx
@@ -35,7 +35,7 @@ export default function PerfilPage() {
 
   useEffect(() => {
     if (!pb.authStore.isValid) {
-      router.push("/login");
+      router.push("/admin/login");
       return;
     }
     const model = pb.authStore.model as unknown as UsuarioAuthModel;

--- a/app/admin/redefinir-senha/RedefinirSenhaClient.tsx
+++ b/app/admin/redefinir-senha/RedefinirSenhaClient.tsx
@@ -30,8 +30,8 @@ export default function RedefinirSenhaClient() {
       await pb
         .collection("usuarios")
         .confirmPasswordReset(token, novaSenha, confirmacao);
-      setMensagem("Senha redefinida com sucesso!");
-      setTimeout(() => router.push("/login"), 2000);
+        setMensagem("Senha redefinida com sucesso!");
+        setTimeout(() => router.push("/admin/login"), 2000);
     } catch {
       setErro("Não foi possível redefinir. O link pode ter expirado.");
     }

--- a/lib/hooks/useAuthGuard.ts
+++ b/lib/hooks/useAuthGuard.ts
@@ -21,7 +21,7 @@ export function useAuthGuard(
 
     if (!isLoggedIn || !temPermissao) {
       pb.authStore.clear();
-      router.replace("/");
+      router.replace("/admin/login");
     } else {
       setAuthChecked(true);
     }


### PR DESCRIPTION
## Notas
- Criada rota dedicada `/admin/login` reutilizando o mesmo `LoginForm`.
- Atualizados redirecionamentos e links que apontavam para `/login` ou `/` para utilizar `/admin/login`.
- Ajustado `Header` para redirecionar logout e botões de entrada para o novo caminho.
- Páginas de confirmação e erro agora voltam ao login correto.
- `useAuthGuard` e outras páginas internas também encaminham para `/admin/login`.

## Testes
- `npm run lint` *(falhou: `next` não encontrado)*

------
https://chatgpt.com/codex/tasks/task_e_6841f2fa7638832ca3fb2be91ef96a89