### PR TITLE
Fix inscricoes route and redirect

### DIFF
--- a/app/loja/page.tsx
+++ b/app/loja/page.tsx
@@ -152,7 +152,7 @@ export default function Home() {
               </p>
 
               <Link
-                href="/inscricoes"
+                href="/loja/inscricoes"
                 className="inline-block bg-cornell_red-600 hover:bg-cornell_red-700 text-white px-8 py-3 rounded-full font-semibold transition"
               >
                 Inscreva-se agora

--- a/next.config.ts
+++ b/next.config.ts
@@ -8,7 +8,7 @@ const nextConfig: NextConfig = {
   redirects: async () => [
     {
       source: "/inscricao",
-      destination: "/inscricao/congresso",
+      destination: "/loja/inscricoes",
       permanent: true,
     },
   ],


### PR DESCRIPTION
## Summary
- update home button link to `/loja/inscricoes`
- redirect old `/inscricao` path to the new `/loja/inscricoes`

## Testing
- `npm run lint` *(fails: next not found)*
- `npm run build` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_6841f7eeaa34832cb4ef2cdf5d13769f