### PR TITLE
Fix ID param handling

### DIFF
--- a/app/admin/api/campos/[id]/route.ts
+++ b/app/admin/api/campos/[id]/route.ts
@@ -1,9 +1,11 @@
 import { NextRequest, NextResponse } from "next/server";
 import { getUserFromHeaders } from "@/lib/getUserFromHeaders";
 
-export async function PUT(req: NextRequest) {
-  const url = new URL(req.nextUrl);
-  const id = url.pathname.split("/").pop(); // /api/campos/[id]
+export async function PUT(
+  req: NextRequest,
+  { params }: { params: { id: string } }
+) {
+  const id = params.id;
 
   if (!id) {
     return NextResponse.json({ error: "ID ausente." }, { status: 400 });
@@ -37,9 +39,11 @@ export async function PUT(req: NextRequest) {
   }
 }
 
-export async function DELETE(req: NextRequest) {
-  const url = new URL(req.nextUrl);
-  const id = url.pathname.split("/").pop();
+export async function DELETE(
+  req: NextRequest,
+  { params }: { params: { id: string } }
+) {
+  const id = params.id;
 
   if (!id) {
     return NextResponse.json({ error: "ID ausente." }, { status: 400 });

--- a/app/admin/api/lider/[id]/route.ts
+++ b/app/admin/api/lider/[id]/route.ts
@@ -1,9 +1,11 @@
 import { NextRequest, NextResponse } from "next/server";
 import PocketBase from "pocketbase";
 
-export async function GET(req: NextRequest) {
-  const url = new URL(req.nextUrl);
-  const id = url.pathname.split("/").pop();
+export async function GET(
+  req: NextRequest,
+  { params }: { params: { id: string } }
+) {
+  const id = params.id;
 
   if (!id || id.trim() === "") {
     return NextResponse.json({ erro: "ID ausente ou inválido." }, { status: 400 });

--- a/app/admin/api/usuarios/[id]/route.ts
+++ b/app/admin/api/usuarios/[id]/route.ts
@@ -1,9 +1,11 @@
 import { NextRequest, NextResponse } from "next/server";
 import { getUserFromHeaders } from "@/lib/getUserFromHeaders";
 
-export async function GET(req: NextRequest) {
-  const url = new URL(req.nextUrl);
-  const id = url.pathname.split("/").pop();
+export async function GET(
+  req: NextRequest,
+  { params }: { params: { id: string } }
+) {
+  const id = params.id;
 
   if (!id || id.trim() === "") {
     return NextResponse.json(


### PR DESCRIPTION
## Summary
- update `GET`, `PUT` and `DELETE` handlers in `/app/admin/api/*/[id]/route.ts`
  to use `{ params: { id: string } }`
- remove `url.pathname.split` usage

## Testing
- `npm run lint` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6841f9140c88832c83644b1d2e3f9cb9