### PR TITLE
fix pocketbase client usage

### DIFF
--- a/app/admin/api/checkout/route.ts
+++ b/app/admin/api/checkout/route.ts
@@ -1,10 +1,9 @@
 import { NextRequest, NextResponse } from "next/server";
 import mercadopago from "mercadopago";
-import PocketBase from "pocketbase";
+import { createPocketBase } from "@/lib/pocketbase";
 
 export async function POST(req: NextRequest) {
-  const pb = new PocketBase("https://umadeus-production.up.railway.app");
-  pb.autoCancellation(false);
+  const pb = createPocketBase();
   const accessToken = process.env.MERCADO_PAGO_ACCESS_TOKEN;
   const siteUrl = process.env.NEXT_PUBLIC_SITE_URL || "http://localhost:3000";
 

--- a/app/admin/api/checkout/webhook/route.ts
+++ b/app/admin/api/checkout/webhook/route.ts
@@ -1,5 +1,5 @@
 import { NextRequest, NextResponse } from "next/server";
-import PocketBase from "pocketbase";
+import { createPocketBase } from "@/lib/pocketbase";
 import mercadopago from "mercadopago";
 
 mercadopago.configure({
@@ -7,8 +7,7 @@ mercadopago.configure({
 });
 
 export async function POST(req: NextRequest) {
-  const pb = new PocketBase("https://umadeus-production.up.railway.app");
-  pb.autoCancellation(false);
+  const pb = createPocketBase();
   try {
     const body = await req.json();
     const paymentId = body?.data?.id;

--- a/app/admin/api/inscricoes/route.ts
+++ b/app/admin/api/inscricoes/route.ts
@@ -1,5 +1,5 @@
 import { NextRequest, NextResponse } from "next/server";
-import PocketBase from "pocketbase";
+import { createPocketBase } from "@/lib/pocketbase";
 
 interface DadosInscricao {
   nome: string;
@@ -18,8 +18,7 @@ interface DadosInscricao {
 
 
 export async function POST(req: NextRequest) {
-  const pb = new PocketBase("https://umadeus-production.up.railway.app");
-  pb.autoCancellation(false);
+  const pb = createPocketBase();
   try {
     const body = await req.json();
     const {

--- a/app/admin/api/lider/[id]/route.ts
+++ b/app/admin/api/lider/[id]/route.ts
@@ -1,5 +1,5 @@
 import { NextRequest, NextResponse } from "next/server";
-import PocketBase from "pocketbase";
+import { createPocketBase } from "@/lib/pocketbase";
 
 export async function GET(req: NextRequest) {
   const url = new URL(req.nextUrl);
@@ -9,8 +9,7 @@ export async function GET(req: NextRequest) {
     return NextResponse.json({ erro: "ID ausente ou inválido." }, { status: 400 });
   }
 
-  const pbSafe = new PocketBase("https://umadeus-production.up.railway.app");
-  pbSafe.autoCancellation(false);
+  const pbSafe = createPocketBase();
 
   try {
     const lider = await pbSafe.collection("usuarios").getOne(id, {

--- a/app/admin/api/pedidos/routes.tsx
+++ b/app/admin/api/pedidos/routes.tsx
@@ -1,9 +1,8 @@
 import { NextRequest, NextResponse } from "next/server";
-import PocketBase from "pocketbase";
+import { createPocketBase } from "@/lib/pocketbase";
 
 export async function POST(req: NextRequest) {
-  const pb = new PocketBase("https://umadeus-production.up.railway.app");
-  pb.autoCancellation(false);
+  const pb = createPocketBase();
   try {
     const body = await req.json();
     const { inscricaoId } = body;

--- a/app/admin/api/recuperar-link/route.ts
+++ b/app/admin/api/recuperar-link/route.ts
@@ -1,11 +1,8 @@
 import { NextRequest, NextResponse } from "next/server";
-import PocketBase from "pocketbase";
+import { createPocketBase } from "@/lib/pocketbase";
 
 export async function POST(req: NextRequest) {
-  const pb = new PocketBase(
-    process.env.PB_URL || "https://umadeus-production.up.railway.app"
-  );
-  pb.autoCancellation(false);
+  const pb = createPocketBase();
   try {
     const { cpf, telefone } = await req.json();
 

--- a/lib/pocketbase.ts
+++ b/lib/pocketbase.ts
@@ -1,8 +1,6 @@
 import PocketBase from "pocketbase";
 
-const PB_URL =
-  process.env.NEXT_PUBLIC_PB_URL ||
-  "https://umadeus-production.up.railway.app";
+const PB_URL = process.env.NEXT_PUBLIC_PB_URL!;
 
 const basePb = new PocketBase(PB_URL);
 


### PR DESCRIPTION
## Summary
- centralize PocketBase client creation in all API routes
- rely on `NEXT_PUBLIC_PB_URL` for PocketBase base URL

## Testing
- `npm run lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_6841f92bfee0832c9a262055b695a5db