### PR TITLE
Fix toast keys and admin layout

### DIFF
--- a/app/admin/layout.tsx
+++ b/app/admin/layout.tsx
@@ -1,9 +1,6 @@
 // app/layout.tsx
 import { Geist, Geist_Mono } from "next/font/google";
 import "../globals.css";
-import { AuthProvider } from "@/lib/context/AuthContext";
-import { ThemeProvider } from "@/lib/context/ThemeContext";
-import { ToastProvider } from "@/lib/context/ToastContext";
 import LayoutWrapper from "./components/LayoutWrapper";
 
 const geistSans = Geist({ variable: "--font-geist-sans", subsets: ["latin"] });
@@ -32,18 +29,8 @@ export default function RootLayout({
   children: React.ReactNode;
 }) {
   return (
-    <html lang="pt-BR">
-      <body
-        className={`${geistSans.variable} ${geistMono.variable} antialiased`}
-      >
-        <ThemeProvider>
-          <AuthProvider>
-            <ToastProvider>
-              <LayoutWrapper>{children}</LayoutWrapper>
-            </ToastProvider>
-          </AuthProvider>
-        </ThemeProvider>
-      </body>
-    </html>
+    <div className={`${geistSans.variable} ${geistMono.variable} antialiased`}>
+      <LayoutWrapper>{children}</LayoutWrapper>
+    </div>
   );
 }

--- a/app/loja/layout.tsx
+++ b/app/loja/layout.tsx
@@ -16,12 +16,10 @@ export default function RootLayout({
   children: React.ReactNode;
 }) {
   return (
-    <html lang="pt-br">
-      <body className="bg-gradient-to-r from-black_bean via-[#5f1b1f] to-eerie_black animate-gradient-x text-platinum font-sans">
-        <Header />
-        <main className="flex flex-col min-h-screen pt-20">{children}</main>
-        <Footer />
-      </body>
-    </html>
+    <div className={`bg-gradient-to-r from-black_bean via-[#5f1b1f] to-eerie_black animate-gradient-x text-platinum font-sans ${inter.className}`}> 
+      <Header />
+      <main className="flex flex-col min-h-screen pt-20">{children}</main>
+      <Footer />
+    </div>
   );
 }

--- a/lib/context/ToastContext.tsx
+++ b/lib/context/ToastContext.tsx
@@ -14,10 +14,10 @@ const ToastContext = createContext<ToastContextType>({
 });
 
 export function ToastProvider({ children }: { children: React.ReactNode }) {
-  const [toasts, setToasts] = useState<{ id: number; message: string; type: ToastType }[]>([]);
+  const [toasts, setToasts] = useState<{ id: string; message: string; type: ToastType }[]>([]);
 
   const addToast = (message: string, type: ToastType) => {
-    const id = Date.now();
+    const id = crypto.randomUUID();
     setToasts((t) => [...t, { id, message, type }]);
     setTimeout(() => {
       setToasts((t) => t.filter((toast) => toast.id !== id));


### PR DESCRIPTION
## Summary
- ensure toast IDs are unique
- remove nested providers from admin layout to avoid duplicate context

## Testing
- `npx -y vitest run` *(fails: Cannot find module 'vitest/config')*
- `npm run lint` *(fails: next: not found)*

------
https://chatgpt.com/codex/tasks/task_e_6841e52c1a10832ca038ef2de2b8002e