### PR TITLE
Implement dark mode classes and update styles

### DIFF
--- a/app/admin/components/DashboardAnalytics.tsx
+++ b/app/admin/components/DashboardAnalytics.tsx
@@ -179,13 +179,13 @@ export default function DashboardAnalytics({ inscricoes, pedidos }: DashboardAna
         </button>
       </div>
       <div className="grid md:grid-cols-2 gap-6 mb-6">
-        <div className="bg-white/90 p-4 rounded-lg shadow">
+        <div className="card p-4">
           <h4 className="font-medium mb-2">Evolução de Inscrições</h4>
           <div className="aspect-video">
             <LineChart data={inscricoesChart} options={{ responsive: true, maintainAspectRatio: false }} />
           </div>
         </div>
-        <div className="bg-white/90 p-4 rounded-lg shadow">
+        <div className="card p-4">
           <h4 className="font-medium mb-2">Evolução de Pedidos</h4>
           <div className="aspect-video">
             <LineChart data={pedidosChart} options={{ responsive: true, maintainAspectRatio: false }} />
@@ -193,11 +193,11 @@ export default function DashboardAnalytics({ inscricoes, pedidos }: DashboardAna
         </div>
       </div>
       <div className="grid md:grid-cols-2 gap-6">
-        <div className="bg-white/90 p-4 rounded-lg shadow flex flex-col justify-center items-center">
+        <div className="card p-4 flex flex-col justify-center items-center">
           <p className="text-sm">Média de Valor por Pedido</p>
           <p className="text-2xl font-bold">R$ {mediaValor.toFixed(2).replace(".", ",")}</p>
         </div>
-        <div className="bg-white/90 p-4 rounded-lg shadow">
+        <div className="card p-4">
           <h4 className="font-medium mb-2">Arrecadação por Campo</h4>
           <div className="aspect-video">
             <BarChart data={arrecadacaoChart} options={{ responsive: true, maintainAspectRatio: false }} />

--- a/app/admin/dashboard/components/DashboardResumo.tsx
+++ b/app/admin/dashboard/components/DashboardResumo.tsx
@@ -94,7 +94,7 @@ export default function DashboardResumo({
   return (
     <>
       <div className="grid gap-4 md:grid-cols-3 mb-6">
-        <div className="bg-white/90 backdrop-blur p-4 rounded-lg shadow text-center">
+        <div className="card text-center">
           <div className="flex justify-center items-center gap-2 mb-1">
             <h2 className="text-sm font-bold">Total de Inscrições</h2>
             <Tippy content="Todas as inscrições feitas no sistema.">
@@ -106,7 +106,7 @@ export default function DashboardResumo({
           <p className="text-3xl font-bold">{inscricoes.length}</p>
         </div>
 
-        <div className="bg-white/90 backdrop-blur p-4 rounded-lg shadow text-center">
+        <div className="card text-center">
           <div className="flex justify-center items-center gap-2 mb-1">
             <h2 className="text-sm font-bold">Total de Pedidos</h2>
             <Tippy content="Todos os pedidos gerados.">
@@ -118,7 +118,7 @@ export default function DashboardResumo({
           <p className="text-3xl font-bold">{pedidos.length}</p>
         </div>
 
-        <div className="bg-white/90 backdrop-blur p-4 rounded-lg shadow text-center">
+        <div className="card text-center">
           <div className="flex justify-center items-center gap-2 mb-1">
             <h2 className="text-sm font-bold">Valor Total</h2>
             <Tippy content="Soma dos pedidos pagos com inscrições confirmadas.">
@@ -180,7 +180,7 @@ export default function DashboardResumo({
         </div>
 
         <div className="grid md:grid-cols-2 gap-6">
-          <div className="bg-white/90 p-5 rounded-xl shadow">
+          <div className="card p-5 rounded-xl">
             <div className="flex justify-between items-center mb-3">
               <h3 className="text-lg font-semibold text-gray-800 dark:text-gray-100">
                 Inscrições por Campo
@@ -199,7 +199,7 @@ export default function DashboardResumo({
             </div>
           </div>
 
-          <div className="bg-white/90 p-5 rounded-xl shadow">
+          <div className="card p-5 rounded-xl">
             <div className="flex justify-between items-center mb-3">
               <h3 className="text-lg font-semibold text-gray-800 dark:text-gray-100">
                 Pedidos por Campo

--- a/app/admin/lider-painel/page.tsx
+++ b/app/admin/lider-painel/page.tsx
@@ -137,21 +137,21 @@ export default function LiderDashboardPage() {
 
       {/* Cards Resumo */}
       <div className="grid gap-6 md:grid-cols-3 mb-10">
-        <div className="bg-white/90 backdrop-blur shadow rounded-lg p-6 text-center">
+        <div className="card p-6 text-center">
           <h2 className="text-lg font-semibold mb-2">Inscrições</h2>
           <p>Pendentes: {totais.inscricoes.pendente}</p>
           <p>Confirmadas: {totais.inscricoes.confirmado}</p>
           <p>Canceladas: {totais.inscricoes.cancelado}</p>
         </div>
 
-        <div className="bg-white/90 backdrop-blur shadow rounded-lg p-6 text-center">
+        <div className="card p-6 text-center">
           <h2 className="text-lg font-semibold mb-2">Pedidos</h2>
           <p>Pendentes: {totais.pedidos.pendente}</p>
           <p>Pagos: {totais.pedidos.pago}</p>
           <p>Cancelados: {totais.pedidos.cancelado}</p>
         </div>
 
-        <div className="bg-white/90 backdrop-blur shadow rounded-lg p-6 text-center">
+        <div className="card p-6 text-center">
           <h2 className="text-lg font-semibold mb-2">Total Arrecadado</h2>
           <p className="text-xl font-bold text-green-700">
             R$ {totais.pedidos.valorTotal.toFixed(2).replace(".", ",")}

--- a/app/admin/usuarios/page.tsx
+++ b/app/admin/usuarios/page.tsx
@@ -73,7 +73,7 @@ export default function UsuariosPage() {
       {loading ? (
         <p className="text-center text-gray-600">Carregando usuários...</p>
       ) : (
-        <div className="overflow-auto rounded-lg border border-gray-200 shadow-sm">
+        <div className="overflow-auto rounded-lg border bg-white border-gray-300 dark:bg-[#0c0d0a] dark:border-gray-700 shadow-sm">
           <table className="table-base">
             <thead>
               <tr>

--- a/app/globals.css
+++ b/app/globals.css
@@ -48,6 +48,11 @@ body {
   transition: background-color 0.5s ease, color 0.9s ease;
 }
 
+.dark body {
+  background: #0c0d0a;
+  color: var(--text-primary);
+}
+
 /* ==========================
    📦 Utilitários reutilizáveis
    ========================== */
@@ -72,7 +77,7 @@ body {
 }
 
 .card {
-  @apply bg-white/90 backdrop-blur rounded-lg shadow p-4;
+  @apply bg-white border border-gray-300 dark:bg-[#0c0d0a] dark:border-gray-700 rounded-lg shadow p-4;
 }
 
 .input-style {
@@ -80,7 +85,7 @@ body {
 }
 
 .table-base {
-  @apply min-w-full text-sm bg-white border border-gray-200;
+  @apply min-w-full text-sm bg-white border border-gray-300 text-gray-800 dark:bg-[#0c0d0a] dark:border-gray-700 dark:text-gray-100;
 }
 
 .table-base thead {
@@ -93,7 +98,7 @@ body {
 }
 
 .table-base tbody tr {
-  @apply border-b border-gray-100 hover:bg-gray-50 transition-colors;
+  @apply border-b border-gray-100 hover:bg-gray-50 dark:hover:bg-[#1a1b18] dark:border-gray-700 transition-colors;
 }
 
 /* ==========================

--- a/lib/context/ThemeContext.tsx
+++ b/lib/context/ThemeContext.tsx
@@ -24,6 +24,7 @@ export function ThemeProvider({ children }: { children: React.ReactNode }) {
   useEffect(() => {
     localStorage.setItem("theme", theme);
     document.documentElement.classList.toggle("dark", theme === "dark");
+    document.body.classList.toggle("dark", theme === "dark");
   }, [theme]);
 
   const toggleTheme = () => setTheme((t) => (t === "light" ? "dark" : "light"));

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -1,5 +1,6 @@
 /** @type {import('tailwindcss').Config} */
 module.exports = {
+  darkMode: "class",
   content: [
     "./app/**/*.{js,ts,jsx,tsx}",
     "./components/**/*.{js,ts,jsx,tsx}",


### PR DESCRIPTION
## Summary
- enable Tailwind class-based dark mode
- improve table contrast and card utilities
- update admin user table wrapper
- switch dashboard cards to use new `card` utility
- fix theme toggle so body updates with dark background

## Testing
- `npm run lint`
- `npx vitest run`


------
https://chatgpt.com/codex/tasks/task_e_68422d002640832c97520f547bf46b29