### PR TITLE
Add Storybook stories for admin components

### DIFF
--- a/stories/AdminHeader.stories.tsx
+++ b/stories/AdminHeader.stories.tsx
@@ -1,0 +1,30 @@
+import type { Meta, StoryObj } from '@storybook/nextjs';
+import { within, expect } from 'storybook/test';
+import Header from '../app/admin/components/Header';
+import { AuthProvider } from '../lib/context/AuthContext';
+import { ThemeProvider } from '../lib/context/ThemeContext';
+
+const meta = {
+  title: 'Admin/Header',
+  component: Header,
+  decorators: [
+    (Story) => (
+      <ThemeProvider>
+        <AuthProvider>
+          <Story />
+        </AuthProvider>
+      </ThemeProvider>
+    ),
+  ],
+  tags: ['autodocs'],
+} satisfies Meta<typeof Header>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    await expect(canvas.getByRole('banner')).toBeInTheDocument();
+  },
+};

--- a/stories/BackToTopButton.stories.tsx
+++ b/stories/BackToTopButton.stories.tsx
@@ -1,0 +1,25 @@
+import type { Meta, StoryObj } from '@storybook/nextjs';
+import { within, expect } from 'storybook/test';
+import BackToTopButton from '../app/admin/components/BackToTopButton';
+
+const meta = {
+  title: 'Admin/BackToTopButton',
+  component: BackToTopButton,
+  tags: ['autodocs'],
+} satisfies Meta<typeof BackToTopButton>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {
+  render: () => (
+    <div style={{ height: '200vh', paddingTop: '350px' }}>
+      <BackToTopButton />
+    </div>
+  ),
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    window.scrollTo(0, 400);
+    await expect(canvas.getByRole('button', { name: /voltar ao topo/i })).toBeInTheDocument();
+  },
+};

--- a/stories/DashboardAnalytics.stories.tsx
+++ b/stories/DashboardAnalytics.stories.tsx
@@ -1,0 +1,41 @@
+import type { Meta, StoryObj } from '@storybook/nextjs';
+import { within, expect } from 'storybook/test';
+import DashboardAnalytics from '../app/admin/components/DashboardAnalytics';
+import { ThemeProvider } from '../lib/context/ThemeContext';
+
+const meta = {
+  title: 'Admin/DashboardAnalytics',
+  component: DashboardAnalytics,
+  decorators: [
+    (Story) => (
+      <ThemeProvider>
+        <Story />
+      </ThemeProvider>
+    ),
+  ],
+  argTypes: {
+    inscricoes: { control: 'object' },
+    pedidos: { control: 'object' },
+  },
+  tags: ['autodocs'],
+} satisfies Meta<typeof DashboardAnalytics>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {
+  args: {
+    inscricoes: [
+      { id: '1', created: '2024-01-01' },
+      { id: '2', created: '2024-01-02' },
+    ],
+    pedidos: [
+      { id: '1', created: '2024-01-01', valor: '100', status: 'pago', expand: { campo: { nome: 'Campo 1' } } },
+      { id: '2', created: '2024-01-02', valor: '50', status: 'pago', expand: { campo: { nome: 'Campo 1' } } },
+    ],
+  },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    await expect(canvas.getByRole('button', { name: /exportar csv/i })).toBeInTheDocument();
+  },
+};

--- a/stories/Footer.stories.tsx
+++ b/stories/Footer.stories.tsx
@@ -1,0 +1,30 @@
+import type { Meta, StoryObj } from '@storybook/nextjs';
+import { within, expect } from 'storybook/test';
+import Footer from '../app/admin/components/Footer';
+import { AuthProvider } from '../lib/context/AuthContext';
+import { ThemeProvider } from '../lib/context/ThemeContext';
+
+const meta = {
+  title: 'Admin/Footer',
+  component: Footer,
+  decorators: [
+    (Story) => (
+      <ThemeProvider>
+        <AuthProvider>
+          <Story />
+        </AuthProvider>
+      </ThemeProvider>
+    ),
+  ],
+  tags: ['autodocs'],
+} satisfies Meta<typeof Footer>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    await expect(canvas.getByText(/UMADEUS/i)).toBeInTheDocument();
+  },
+};

--- a/stories/LayoutWrapper.stories.tsx
+++ b/stories/LayoutWrapper.stories.tsx
@@ -1,0 +1,41 @@
+import type { Meta, StoryObj } from '@storybook/nextjs';
+import { within, expect } from 'storybook/test';
+import LayoutWrapper from '../app/admin/components/LayoutWrapper';
+import { AuthProvider } from '../lib/context/AuthContext';
+import { ThemeProvider } from '../lib/context/ThemeContext';
+
+const meta = {
+  title: 'Admin/LayoutWrapper',
+  component: LayoutWrapper,
+  decorators: [
+    (Story) => (
+      <ThemeProvider>
+        <AuthProvider>
+          <Story />
+        </AuthProvider>
+      </ThemeProvider>
+    ),
+  ],
+  argTypes: {
+    children: { control: 'text' },
+  },
+  tags: ['autodocs'],
+} satisfies Meta<typeof LayoutWrapper>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {
+  args: {
+    children: 'Conteúdo de exemplo',
+  },
+  render: ({ children }) => (
+    <LayoutWrapper>
+      <p>{children}</p>
+    </LayoutWrapper>
+  ),
+  play: async ({ canvasElement, args }) => {
+    const canvas = within(canvasElement);
+    await expect(canvas.getByText(args.children as string)).toBeInTheDocument();
+  },
+};

--- a/stories/LoginForm.stories.tsx
+++ b/stories/LoginForm.stories.tsx
@@ -1,0 +1,30 @@
+import type { Meta, StoryObj } from '@storybook/nextjs';
+import { within, expect } from 'storybook/test';
+import LoginForm from '../app/components/LoginForm';
+import { AuthProvider } from '../lib/context/AuthContext';
+import { ThemeProvider } from '../lib/context/ThemeContext';
+
+const meta = {
+  title: 'Components/LoginForm',
+  component: LoginForm,
+  decorators: [
+    (Story) => (
+      <ThemeProvider>
+        <AuthProvider>
+          <Story />
+        </AuthProvider>
+      </ThemeProvider>
+    ),
+  ],
+  tags: ['autodocs'],
+} satisfies Meta<typeof LoginForm>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    await expect(canvas.getByRole('button', { name: /entrar/i })).toBeInTheDocument();
+  },
+};

--- a/stories/NotificationBell.stories.tsx
+++ b/stories/NotificationBell.stories.tsx
@@ -1,0 +1,30 @@
+import type { Meta, StoryObj } from '@storybook/nextjs';
+import { within, expect } from 'storybook/test';
+import NotificationBell from '../app/admin/components/NotificationBell';
+import { AuthProvider } from '../lib/context/AuthContext';
+import { ThemeProvider } from '../lib/context/ThemeContext';
+
+const meta = {
+  title: 'Admin/NotificationBell',
+  component: NotificationBell,
+  decorators: [
+    (Story) => (
+      <ThemeProvider>
+        <AuthProvider>
+          <Story />
+        </AuthProvider>
+      </ThemeProvider>
+    ),
+  ],
+  tags: ['autodocs'],
+} satisfies Meta<typeof NotificationBell>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    await expect(canvas.getByRole('button', { name: /notifica/i })).toBeInTheDocument();
+  },
+};

--- a/stories/RedefinirSenhaModal.stories.tsx
+++ b/stories/RedefinirSenhaModal.stories.tsx
@@ -1,0 +1,33 @@
+import type { Meta, StoryObj } from '@storybook/nextjs';
+import { within, expect, fn } from 'storybook/test';
+import RedefinirSenhaModal from '../app/admin/components/RedefinirSenhaModal';
+import { ThemeProvider } from '../lib/context/ThemeContext';
+
+const meta = {
+  title: 'Admin/RedefinirSenhaModal',
+  component: RedefinirSenhaModal,
+  argTypes: {
+    onClose: { action: 'close' },
+  },
+  args: {
+    onClose: fn(),
+  },
+  decorators: [
+    (Story) => (
+      <ThemeProvider>
+        <Story />
+      </ThemeProvider>
+    ),
+  ],
+  tags: ['autodocs'],
+} satisfies Meta<typeof RedefinirSenhaModal>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    await expect(canvas.getByText(/Redefinir senha/i)).toBeInTheDocument();
+  },
+};

--- a/stories/TooltipIcon.stories.tsx
+++ b/stories/TooltipIcon.stories.tsx
@@ -1,0 +1,33 @@
+import type { Meta, StoryObj } from '@storybook/nextjs';
+import { within, expect, userEvent } from 'storybook/test';
+import TooltipIcon from '../app/admin/components/TooltipIcon';
+
+const meta = {
+  title: 'Admin/TooltipIcon',
+  component: TooltipIcon,
+  argTypes: {
+    label: { control: 'text' },
+  },
+  tags: ['autodocs'],
+} satisfies Meta<typeof TooltipIcon>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {
+  args: {
+    label: 'Texto do tooltip',
+  },
+  render: (args) => (
+    <TooltipIcon {...args}>
+      <button>?</button>
+    </TooltipIcon>
+  ),
+  play: async ({ canvasElement, args }) => {
+    const canvas = within(canvasElement);
+    const button = canvas.getByRole('button');
+    await expect(button).toBeInTheDocument();
+    await userEvent.hover(button);
+    await expect(canvas.getByText(args.label)).toBeInTheDocument();
+  },
+};


### PR DESCRIPTION
## Summary
- add Storybook stories for all admin components and login form
- stories use args/controls where applicable and basic play tests

## Testing
- `npm run lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_6842f7be764c832cb3b1975d202b9970