### PR TITLE
Remove hardcoded checkout URL

### DIFF
--- a/app/api/checkout-link/route.ts
+++ b/app/api/checkout-link/route.ts
@@ -1,0 +1,14 @@
+import { NextResponse } from "next/server";
+
+export async function GET() {
+  const url = process.env.CAMISETA_CHECKOUT_URL;
+
+  if (!url) {
+    return NextResponse.json(
+      { error: "Checkout URL not configured" },
+      { status: 500 }
+    );
+  }
+
+  return NextResponse.json({ url });
+}

--- a/app/loja/produtos/page.tsx
+++ b/app/loja/produtos/page.tsx
@@ -44,8 +44,18 @@ export default function ProdutoPage() {
     setTimeout(() => (pauseRef.current = false), 10000);
   };
 
-  const checkoutLink =
-    "https://www.mercadopago.com.br/checkout/v1/redirect?preference-id=UMADEUS2025";
+  const [checkoutLink, setCheckoutLink] = useState<string>("#");
+
+  useEffect(() => {
+    fetch("/api/checkout-link")
+      .then((res) => res.json())
+      .then((data) => {
+        if (data?.url) setCheckoutLink(data.url);
+      })
+      .catch(() => {
+        /* link permanece como '#' */
+      });
+  }, []);
 
   return (
     <main className="text-platinum font-sans px-4 md:px-16 py-10">


### PR DESCRIPTION
## Summary
- add public API route to supply checkout link
- fetch checkout link dynamically on product page

## Testing
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6842fca5eee0832cbcc38b20c1061400