### PR TITLE
Add stories for admin modals

### DIFF
--- a/logs/DOC_LOG.md
+++ b/logs/DOC_LOG.md
@@ -2,3 +2,4 @@
 
 ## [2025-06-06] Integração Asaas adicionada
 ## [2025-06-06] Adicionado docs/design-tokens.md com descrições de tokens e atualizados estilos globais.
+## [2025-06-06] Criados stories para DashboardResumo, ModalEditarPedido, ModalVisualizarPedido e ModalEditarPerfil.

--- a/stories/DashboardResumo.stories.tsx
+++ b/stories/DashboardResumo.stories.tsx
@@ -1,0 +1,53 @@
+import type { Meta, StoryObj } from '@storybook/nextjs';
+import { within, expect, fn } from 'storybook/test';
+import DashboardResumo from '../app/admin/dashboard/components/DashboardResumo';
+import { ThemeProvider } from '../lib/context/ThemeContext';
+
+const meta = {
+  title: 'Admin/DashboardResumo',
+  component: DashboardResumo,
+  argTypes: {
+    inscricoes: { control: 'object' },
+    pedidos: { control: 'object' },
+    filtroStatus: { control: 'text' },
+    setFiltroStatus: { action: 'change' },
+  },
+  args: {
+    inscricoes: [
+      {
+        id: '1',
+        status: 'confirmado',
+        expand: { campo: { nome: 'Campo 1' }, pedido: { status: 'pago', valor: 50 } },
+      },
+      {
+        id: '2',
+        status: 'pendente',
+        expand: { campo: { nome: 'Campo 2' }, pedido: { status: 'pendente', valor: 30 } },
+      },
+    ],
+    pedidos: [
+      { id: 'p1', status: 'pago', valor: '50', expand: { campo: { nome: 'Campo 1' } } },
+      { id: 'p2', status: 'pendente', valor: '30', expand: { campo: { nome: 'Campo 2' } } },
+    ],
+    filtroStatus: 'pago',
+    setFiltroStatus: fn(),
+  },
+  decorators: [
+    (Story) => (
+      <ThemeProvider>
+        <Story />
+      </ThemeProvider>
+    ),
+  ],
+  tags: ['autodocs'],
+} satisfies Meta<typeof DashboardResumo>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    await expect(canvas.getByText(/Total de Inscrições/i)).toBeInTheDocument();
+  },
+};

--- a/stories/ModalEditarPedido.stories.tsx
+++ b/stories/ModalEditarPedido.stories.tsx
@@ -1,0 +1,43 @@
+import type { Meta, StoryObj } from '@storybook/nextjs';
+import { within, expect, fn } from 'storybook/test';
+import ModalEditarPedido from '../app/admin/pedidos/componentes/ModalEditarPedido';
+import { ThemeProvider } from '../lib/context/ThemeContext';
+
+const meta = {
+  title: 'Admin/ModalEditarPedido',
+  component: ModalEditarPedido,
+  argTypes: {
+    onClose: { action: 'close' },
+    onSave: { action: 'save' },
+  },
+  args: {
+    pedido: {
+      id: '1',
+      produto: 'Produto X',
+      email: 'teste@example.com',
+      tamanho: 'M',
+      cor: 'Azul',
+      status: 'pendente',
+    },
+    onClose: fn(),
+    onSave: fn(),
+  },
+  decorators: [
+    (Story) => (
+      <ThemeProvider>
+        <Story />
+      </ThemeProvider>
+    ),
+  ],
+  tags: ['autodocs'],
+} satisfies Meta<typeof ModalEditarPedido>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    await expect(canvas.getByText(/Editar Pedido/i)).toBeInTheDocument();
+  },
+};

--- a/stories/ModalEditarPerfil.stories.tsx
+++ b/stories/ModalEditarPerfil.stories.tsx
@@ -1,0 +1,36 @@
+import type { Meta, StoryObj } from '@storybook/nextjs';
+import { within, expect, fn } from 'storybook/test';
+import ModalEditarPerfil from '../app/admin/perfil/components/ModalEditarPerfil';
+import { AuthProvider } from '../lib/context/AuthContext';
+import { ThemeProvider } from '../lib/context/ThemeContext';
+
+const meta = {
+  title: 'Admin/ModalEditarPerfil',
+  component: ModalEditarPerfil,
+  argTypes: {
+    onClose: { action: 'close' },
+  },
+  args: {
+    onClose: fn(),
+  },
+  decorators: [
+    (Story) => (
+      <ThemeProvider>
+        <AuthProvider>
+          <Story />
+        </AuthProvider>
+      </ThemeProvider>
+    ),
+  ],
+  tags: ['autodocs'],
+} satisfies Meta<typeof ModalEditarPerfil>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    await expect(canvas.getByText(/Editar Perfil/i)).toBeInTheDocument();
+  },
+};

--- a/stories/ModalVisualizarPedido.stories.tsx
+++ b/stories/ModalVisualizarPedido.stories.tsx
@@ -1,0 +1,34 @@
+import type { Meta, StoryObj } from '@storybook/nextjs';
+import { within, expect, fn } from 'storybook/test';
+import ModalVisualizarPedido from '../app/admin/inscricoes/componentes/ModalVisualizarPedido';
+import { ThemeProvider } from '../lib/context/ThemeContext';
+
+const meta = {
+  title: 'Admin/ModalVisualizarPedido',
+  component: ModalVisualizarPedido,
+  argTypes: {
+    onClose: { action: 'close' },
+  },
+  args: {
+    pedidoId: 'abc123',
+    onClose: fn(),
+  },
+  decorators: [
+    (Story) => (
+      <ThemeProvider>
+        <Story />
+      </ThemeProvider>
+    ),
+  ],
+  tags: ['autodocs'],
+} satisfies Meta<typeof ModalVisualizarPedido>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    await expect(canvas.getByText(/Detalhes do Pedido/i)).toBeInTheDocument();
+  },
+};


### PR DESCRIPTION
## Summary
- add stories for DashboardResumo and admin modals
- log documentation update

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6842fda8dbd0832c916321bc521a41a0