### PR TITLE
Add storybook stories for blog components

### DIFF
--- a/.storybook/main.ts
+++ b/.storybook/main.ts
@@ -14,7 +14,7 @@ const config: StorybookConfig = {
     "options": {}
   },
   "staticDirs": [
-    "..\\public"
+    "../public"
   ]
 };
 export default config;

--- a/app/blog/components/BlogSidebar.tsx
+++ b/app/blog/components/BlogSidebar.tsx
@@ -20,15 +20,14 @@ export default function BlogSidebar() {
   useEffect(() => {
     fetch("/posts.json")
       .then((res) => res.json())
-      .then((posts) => {
+      .then((posts: Post[]) => {
         setPopular(posts.slice(0, 3));
         const unique = [
-          ...new Set(posts.map((p: any) => p.category).filter(Boolean)),
-        ];
-        setCategories(unique as string[]);
-        unique;
+          ...new Set(posts.map((p) => p.category).filter(Boolean)),
+        ] as string[];
+        setCategories(unique);
       });
-  }, []);
+  }, [setPopular, setCategories]);
 
   return (
     <aside className="w-full lg:w-1/3 mt-16 lg:mt-0 lg:pl-10 space-y-12">

--- a/logs/DOC_LOG.md
+++ b/logs/DOC_LOG.md
@@ -9,3 +9,5 @@
 ## [2025-06-06] Adicionada variavel ASAAS_WEBHOOK_SECRET no README
 
 ## [2025-06-06] Removidos console.log das rotas da API admin e criado utilitario logger para padronizar logs. Impacto: reducao de ruido e melhoria na manutencao.
+## [2025-06-06] Adicionados stories do blog (Sidebar, HeroCarousel, PostSuggestions, NextPostButton e MiniPrecosPost).
+## [2025-06-06] Corrigidos stories do blog e configuracao do Storybook.

--- a/stories/BlogHeroCarousel.stories.tsx
+++ b/stories/BlogHeroCarousel.stories.tsx
@@ -1,0 +1,70 @@
+import type { Meta, StoryObj } from '@storybook/nextjs';
+import BlogHeroCarousel from '../app/blog/components/BlogHeroCarousel';
+import React, { useEffect } from 'react';
+
+interface Post {
+  title: string;
+  date: string;
+  summary: string;
+  slug: string;
+  thumbnail?: string | null;
+  category?: string | null;
+}
+
+const meta = {
+  title: 'Blog/HeroCarousel',
+  component: BlogHeroCarousel,
+  argTypes: {
+    posts: { control: 'object' },
+  },
+  args: {
+    posts: [
+      {
+        title: 'Primeiro Post',
+        date: '2024-01-01',
+        summary: 'Exemplo de resumo do post',
+        slug: 'primeiro-post',
+        thumbnail: 'https://placehold.co/600x400',
+        category: 'Novidades',
+      },
+      {
+        title: 'Segundo Post',
+        date: '2024-01-02',
+        summary: 'Outro resumo breve',
+        slug: 'segundo-post',
+        thumbnail: 'https://placehold.co/600x400',
+        category: 'Saúde',
+      },
+      {
+        title: 'Terceiro Post',
+        date: '2024-01-03',
+        summary: 'Mais um texto de exemplo',
+        slug: 'terceiro-post',
+        thumbnail: 'https://placehold.co/600x400',
+        category: 'Bem-estar',
+      },
+    ] as Post[],
+  },
+} satisfies Meta<typeof BlogHeroCarousel>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+const FetchWrapper = ({ posts, children }: { posts: Post[]; children: React.ReactNode }) => {
+  useEffect(() => {
+    const original = global.fetch;
+    global.fetch = () => Promise.resolve({ json: async () => posts });
+    return () => {
+      global.fetch = original;
+    };
+  }, [posts]);
+  return <>{children}</>;
+};
+
+export const Default: Story = {
+  render: ({ posts }) => (
+    <FetchWrapper posts={posts as Post[]}>
+      <BlogHeroCarousel />
+    </FetchWrapper>
+  ),
+};

--- a/stories/BlogSidebar.stories.tsx
+++ b/stories/BlogSidebar.stories.tsx
@@ -1,0 +1,63 @@
+import type { Meta, StoryObj } from '@storybook/nextjs';
+import BlogSidebar from '../app/blog/components/BlogSidebar';
+import React, { useEffect } from 'react';
+
+interface Post {
+  title: string;
+  slug: string;
+  thumbnail?: string | null;
+  category?: string | null;
+}
+
+const meta = {
+  title: 'Blog/Sidebar',
+  component: BlogSidebar,
+  argTypes: {
+    posts: { control: 'object' },
+  },
+  args: {
+    posts: [
+      {
+        title: 'Benefícios da Telemedicina',
+        slug: 'beneficios-telemedicina',
+        thumbnail: 'https://placehold.co/100',
+        category: 'Saúde',
+      },
+      {
+        title: 'Dicas de Bem-estar',
+        slug: 'dicas-bem-estar',
+        thumbnail: 'https://placehold.co/100',
+        category: 'Bem-estar',
+      },
+      {
+        title: 'Alimentação Equilibrada',
+        slug: 'alimentacao-equilibrada',
+        thumbnail: 'https://placehold.co/100',
+        category: 'Nutrição',
+      },
+    ] as Post[],
+  },
+} satisfies Meta<typeof BlogSidebar>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+const FetchWrapper = ({ posts, children }: { posts: Post[]; children: React.ReactNode }) => {
+  useEffect(() => {
+    const original = global.fetch;
+    global.fetch = () =>
+      Promise.resolve({ json: async () => posts });
+    return () => {
+      global.fetch = original;
+    };
+  }, [posts]);
+  return <>{children}</>;
+};
+
+export const Default: Story = {
+  render: ({ posts }) => (
+    <FetchWrapper posts={posts as Post[]}>
+      <BlogSidebar />
+    </FetchWrapper>
+  ),
+};

--- a/stories/MiniPrecosPost.stories.tsx
+++ b/stories/MiniPrecosPost.stories.tsx
@@ -1,0 +1,13 @@
+import type { Meta, StoryObj } from '@storybook/nextjs';
+import MiniPrecosPost from '../app/blog/components/MiniPrecosPost';
+
+const meta = {
+  title: 'Blog/MiniPrecosPost',
+  component: MiniPrecosPost,
+  tags: ['autodocs'],
+} satisfies Meta<typeof MiniPrecosPost>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {};

--- a/stories/NextPostButton.stories.tsx
+++ b/stories/NextPostButton.stories.tsx
@@ -1,0 +1,19 @@
+import type { Meta, StoryObj } from '@storybook/nextjs';
+import NextPostButton from '../app/blog/components/NextPostButton';
+
+const meta = {
+  title: 'Blog/NextPostButton',
+  component: NextPostButton,
+  argTypes: {
+    slug: { control: 'text' },
+  },
+  args: {
+    slug: 'proximo-post',
+  },
+  tags: ['autodocs'],
+} satisfies Meta<typeof NextPostButton>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {};

--- a/stories/PostSuggestions.stories.tsx
+++ b/stories/PostSuggestions.stories.tsx
@@ -1,0 +1,48 @@
+import type { Meta, StoryObj } from '@storybook/nextjs';
+import PostSuggestions from '../app/blog/components/PostSuggestions';
+
+interface Post {
+  slug: string;
+  title: string;
+  summary: string;
+  thumbnail: string;
+  category: string;
+}
+
+const meta = {
+  title: 'Blog/PostSuggestions',
+  component: PostSuggestions,
+  argTypes: {
+    posts: { control: 'object' },
+  },
+  args: {
+    posts: [
+      {
+        slug: 'bem-estar-no-trabalho',
+        title: 'Bem-estar no trabalho',
+        summary: 'Dicas para manter a saúde no escritório.',
+        thumbnail: 'https://placehold.co/400x300',
+        category: 'Saúde',
+      },
+      {
+        slug: 'dormir-melhor',
+        title: 'Como dormir melhor',
+        summary: 'Estratégias simples para aprimorar o sono.',
+        thumbnail: 'https://placehold.co/400x300',
+        category: 'Qualidade de vida',
+      },
+      {
+        slug: 'alimentacao-em-dia',
+        title: 'Alimentação em dia',
+        summary: 'Refeições saudáveis para o dia a dia.',
+        thumbnail: 'https://placehold.co/400x300',
+        category: 'Nutrição',
+      },
+    ] as Post[],
+  },
+} satisfies Meta<typeof PostSuggestions>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {};


### PR DESCRIPTION
## Summary
- add stories for blog sidebar, hero carousel, post suggestions and other blog widgets
- fix blog sidebar fetch typing and effect deps
- adjust storybook static directory path
- log documentation update about new stories

## Testing
- `npm run lint`
- `BROWSER=none npm run storybook` *(fails: Error: spawn none ENOENT)*

------
https://chatgpt.com/codex/tasks/task_e_6843236cdc70832ca6afad3a615ecba8