### PR TITLE
Add client management to admin

### DIFF
--- a/.storybook/main.ts
+++ b/.storybook/main.ts
@@ -1,20 +1,18 @@
 import type { StorybookConfig } from '@storybook/nextjs';
 
 const config: StorybookConfig = {
-  "stories": [
-    "../stories/**/*.mdx",
-    "../stories/**/*.stories.@(js|jsx|mjs|ts|tsx)"
+  stories: [
+    '../stories/**/*.mdx',
+    '../stories/**/*.stories.@(js|jsx|mjs|ts|tsx)'
   ],
-  "addons": [
-    "@storybook/addon-onboarding",
-    "@storybook/addon-docs"
+  addons: [
+    '@storybook/addon-onboarding',
+    '@storybook/addon-docs'
   ],
-  "framework": {
-    "name": "@storybook/nextjs",
-    "options": {}
+  framework: {
+    name: '@storybook/nextjs',
+    options: {}
   },
-  "staticDirs": [
-    "..\\public"
-  ]
+  staticDirs: ['../public']
 };
 export default config;

--- a/app/admin/api/asaas/route.ts
+++ b/app/admin/api/asaas/route.ts
@@ -1,5 +1,6 @@
 import { NextRequest, NextResponse } from "next/server";
 import { createPocketBase } from "@/lib/pocketbase";
+import { logger } from "@/lib/logger";
 
 export async function POST(req: NextRequest) {
   const pb = createPocketBase();
@@ -15,7 +16,7 @@ export async function POST(req: NextRequest) {
 
   try {
     const { pedidoId, valor } = await req.json();
-    console.log("📦 Dados recebidos:", { pedidoId, valor });
+    logger.info("📦 Dados recebidos:", { pedidoId, valor });
 
     if (!pedidoId || valor === undefined || valor === null) {
       return NextResponse.json(
@@ -71,7 +72,7 @@ export async function POST(req: NextRequest) {
       postalCode: inscricao.cep || "41770055",
     };
 
-    console.log("📤 Enviando cliente:", clientePayload);
+    logger.info("📤 Enviando cliente:", clientePayload);
 
     // 🔹 Criar cliente no Asaas
     const clienteResponse = await fetch(`${baseUrl}/customers`, {
@@ -95,7 +96,7 @@ export async function POST(req: NextRequest) {
     }
 
     const cliente = JSON.parse(raw);
-    console.log("✅ Cliente criado:", cliente.id);
+    logger.info("✅ Cliente criado:", cliente.id);
 
     // 🔹 Criar cobrança
     const dueDate = new Date();
@@ -130,7 +131,7 @@ export async function POST(req: NextRequest) {
 
     const cobranca = await cobrancaResponse.json();
     const link = cobranca.invoiceUrl || cobranca.bankSlipUrl;
-    console.log("✅ Cobrança criada. Link:", link);
+    logger.info("✅ Cobrança criada. Link:", link);
 
     // 🔹 Atualizar pedido
     await pb.collection("pedidos").update(pedido.id, {

--- a/app/admin/clientes/components/ListaClientes.tsx
+++ b/app/admin/clientes/components/ListaClientes.tsx
@@ -1,0 +1,46 @@
+"use client";
+
+import { Inscricao } from "@/types";
+
+export interface ListaClientesProps {
+  clientes: Inscricao[];
+  onEdit: (cliente: Inscricao) => void;
+}
+
+export default function ListaClientes({ clientes, onEdit }: ListaClientesProps) {
+  return (
+    <div className="overflow-auto rounded-lg border bg-white border-gray-300 dark:bg-[#0c0d0a] dark:border-gray-700 shadow-sm">
+      <table className="table-base">
+        <thead>
+          <tr>
+            <th>Nome</th>
+            <th>Telefone</th>
+            <th>Status Pedido</th>
+            <th>Valor</th>
+            <th>Ações</th>
+          </tr>
+        </thead>
+        <tbody>
+          {clientes.map((c) => (
+            <tr key={c.id}>
+              <td className="font-medium">{c.nome}</td>
+              <td>{c.telefone}</td>
+              <td className="capitalize">
+                {c.expand?.pedido?.status ?? "—"}
+              </td>
+              <td>{c.expand?.pedido?.valor ?? "—"}</td>
+              <td>
+                <button
+                  onClick={() => onEdit(c)}
+                  className="text-blue-600 hover:underline text-sm"
+                >
+                  Editar
+                </button>
+              </td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    </div>
+  );
+}

--- a/app/admin/clientes/page.tsx
+++ b/app/admin/clientes/page.tsx
@@ -1,0 +1,67 @@
+"use client";
+
+import { useEffect, useState, useMemo } from "react";
+import createPocketBase from "@/lib/pocketbase";
+import ListaClientes from "./components/ListaClientes";
+import ModalEditarInscricao from "../inscricoes/componentes/ModalEdit";
+import type { Inscricao } from "@/types";
+import { useToast } from "@/lib/context/ToastContext";
+
+export default function ClientesPage() {
+  const pb = useMemo(() => createPocketBase(), []);
+  const { showError, showSuccess } = useToast();
+  const [clientes, setClientes] = useState<Inscricao[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [clienteEmEdicao, setClienteEmEdicao] = useState<Inscricao | null>(null);
+
+  useEffect(() => {
+    async function fetchClientes() {
+      try {
+        const lista = await pb.collection("inscricoes").getFullList<Inscricao>({
+          expand: "pedido",
+          sort: "-created",
+        });
+        setClientes(lista);
+      } catch (err) {
+        console.error("Erro ao carregar clientes", err);
+        showError("Erro ao carregar clientes");
+      } finally {
+        setLoading(false);
+      }
+    }
+
+    fetchClientes();
+  }, [pb, showError]);
+
+  const salvarEdicao = async (atualizada: Partial<Inscricao>) => {
+    if (!clienteEmEdicao) return;
+    try {
+      await pb.collection("inscricoes").update(clienteEmEdicao.id, atualizada);
+      setClientes((prev) =>
+        prev.map((c) => (c.id === clienteEmEdicao.id ? { ...c, ...atualizada } : c))
+      );
+      showSuccess("Cliente atualizado");
+    } catch (err) {
+      console.error("Erro ao salvar cliente", err);
+      showError("Erro ao salvar cliente");
+    } finally {
+      setClienteEmEdicao(null);
+    }
+  };
+
+  if (loading) return <p className="p-6 text-center text-sm">Carregando clientes...</p>;
+
+  return (
+    <main className="max-w-6xl mx-auto px-4 py-8">
+      <h1 className="heading">Clientes</h1>
+      <ListaClientes clientes={clientes} onEdit={setClienteEmEdicao} />
+      {clienteEmEdicao && (
+        <ModalEditarInscricao
+          inscricao={clienteEmEdicao}
+          onClose={() => setClienteEmEdicao(null)}
+          onSave={salvarEdicao}
+        />
+      )}
+    </main>
+  );
+}

--- a/app/loja/categorias/[slug]/page.tsx
+++ b/app/loja/categorias/[slug]/page.tsx
@@ -1,0 +1,12 @@
+interface Props {
+  params: { slug: string };
+}
+
+export default function CategoriaDetalhe({ params }: Props) {
+  return (
+    <main className="p-8 text-platinum font-sans">
+      <h1 className="text-3xl font-bold mb-6">Categoria: {params.slug}</h1>
+      <p>Página em construção.</p>
+    </main>
+  );
+}

--- a/app/loja/categorias/page.tsx
+++ b/app/loja/categorias/page.tsx
@@ -1,0 +1,21 @@
+export default function CategoriasPage() {
+  const categorias = [
+    { slug: 'camisetas', nome: 'Camisetas' },
+    { slug: 'acessorios', nome: 'Acessórios' },
+  ];
+
+  return (
+    <main className="p-8 text-platinum font-sans">
+      <h1 className="text-3xl font-bold mb-6">Categorias</h1>
+      <ul className="space-y-4">
+        {categorias.map((c) => (
+          <li key={c.slug}>
+            <a href={`/loja/categorias/${c.slug}`} className="text-yellow-400 hover:underline">
+              {c.nome}
+            </a>
+          </li>
+        ))}
+      </ul>
+    </main>
+  );
+}

--- a/app/loja/cliente/page.tsx
+++ b/app/loja/cliente/page.tsx
@@ -1,0 +1,19 @@
+export default function AreaCliente() {
+  const pedidos = [
+    { id: '1', status: 'pago' },
+    { id: '2', status: 'pendente' },
+  ];
+
+  return (
+    <main className="p-8 text-platinum font-sans">
+      <h1 className="text-3xl font-bold mb-6">Meus Pedidos</h1>
+      <ul className="space-y-2">
+        {pedidos.map((p) => (
+          <li key={p.id} className="border-b border-platinum/20 pb-2">
+            Pedido #{p.id} - {p.status}
+          </li>
+        ))}
+      </ul>
+    </main>
+  );
+}

--- a/app/loja/login/page.tsx
+++ b/app/loja/login/page.tsx
@@ -1,0 +1,8 @@
+export default function LojaLoginPage() {
+  return (
+    <main className="p-8 text-platinum font-sans">
+      <h1 className="text-3xl font-bold mb-6">Login do Cliente</h1>
+      <p>Funcionalidade em desenvolvimento.</p>
+    </main>
+  );
+}

--- a/logs/DOC_LOG.md
+++ b/logs/DOC_LOG.md
@@ -9,3 +9,5 @@
 ## [2025-06-06] Adicionada variavel ASAAS_WEBHOOK_SECRET no README
 
 ## [2025-06-06] Removidos console.log das rotas da API admin e criado utilitario logger para padronizar logs. Impacto: reducao de ruido e melhoria na manutencao.
+## [2025-06-06] Adicionadas stories para DashboardResumo e modais, criado esqueleto da área do cliente na loja e removidos console.log restantes.
+## [2025-06-06] Criada página de clientes no admin para editar dados e acompanhar pedidos.

--- a/stories/DashboardResumo.stories.tsx
+++ b/stories/DashboardResumo.stories.tsx
@@ -1,0 +1,44 @@
+import type { Meta, StoryObj } from '@storybook/nextjs';
+import { within, expect, fn } from 'storybook/test';
+import DashboardResumo from '../app/admin/dashboard/components/DashboardResumo';
+import { ThemeProvider } from '../lib/context/ThemeContext';
+
+const meta = {
+  title: 'Admin/DashboardResumo',
+  component: DashboardResumo,
+  decorators: [
+    (Story) => (
+      <ThemeProvider>
+        <Story />
+      </ThemeProvider>
+    ),
+  ],
+  argTypes: {
+    inscricoes: { control: 'object' },
+    pedidos: { control: 'object' },
+    filtroStatus: { control: 'text' },
+    setFiltroStatus: { action: 'setFiltroStatus' },
+  },
+  args: {
+    inscricoes: [
+      { id: '1', status: 'confirmado', expand: { pedido: { valor: '100', status: 'pago' } } },
+      { id: '2', status: 'pendente', expand: { pedido: { valor: '50', status: 'pendente' } } },
+    ],
+    pedidos: [
+      { id: '1', status: 'pago', valor: '100', expand: { campo: { nome: 'Campo 1' } } },
+      { id: '2', status: 'pendente', valor: '50', expand: { campo: { nome: 'Campo 2' } } },
+    ],
+    filtroStatus: 'pago',
+  },
+  tags: ['autodocs'],
+} satisfies Meta<typeof DashboardResumo>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    await expect(canvas.getByText(/Total de Inscrições/i)).toBeInTheDocument();
+  },
+};

--- a/stories/ListaClientes.stories.tsx
+++ b/stories/ListaClientes.stories.tsx
@@ -1,0 +1,53 @@
+import type { Meta, StoryObj } from '@storybook/nextjs';
+import { within, expect, fn } from 'storybook/test';
+import ListaClientes from '../app/admin/clientes/components/ListaClientes';
+import { ThemeProvider } from '../lib/context/ThemeContext';
+import type { Inscricao } from '../types';
+
+const exemplo: Inscricao = {
+  id: '1',
+  nome: 'João da Silva',
+  telefone: '11999999999',
+  status: 'confirmado',
+  produto: 'Kit Camisa + Pulseira',
+  genero: 'masculino',
+  evento: 'Conf 2025',
+  criado_por: '1',
+  campo: '1',
+  cpf: '12345678900',
+  email: 'joao@example.com',
+  expand: {
+    pedido: {
+      id: '10',
+      status: 'pago',
+      valor: '150',
+    },
+  },
+};
+
+const meta = {
+  title: 'Admin/ListaClientes',
+  component: ListaClientes,
+  decorators: [
+    (Story) => (
+      <ThemeProvider>
+        <Story />
+      </ThemeProvider>
+    ),
+  ],
+  args: {
+    clientes: [exemplo],
+    onEdit: fn(),
+  },
+  tags: ['autodocs'],
+} satisfies Meta<typeof ListaClientes>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    await expect(canvas.getByText(/João da Silva/i)).toBeInTheDocument();
+  },
+};

--- a/stories/ModalEditarPedido.stories.tsx
+++ b/stories/ModalEditarPedido.stories.tsx
@@ -1,0 +1,39 @@
+import type { Meta, StoryObj } from '@storybook/nextjs';
+import { within, expect, fn } from 'storybook/test';
+import ModalEditarPedido from '../app/admin/pedidos/componentes/ModalEditarPedido';
+import { ThemeProvider } from '../lib/context/ThemeContext';
+
+const meta = {
+  title: 'Admin/ModalEditarPedido',
+  component: ModalEditarPedido,
+  decorators: [
+    (Story) => (
+      <ThemeProvider>
+        <Story />
+      </ThemeProvider>
+    ),
+  ],
+  args: {
+    pedido: {
+      id: '1',
+      produto: 'Camisa',
+      email: 'teste@exemplo.com',
+      tamanho: 'M',
+      cor: 'Azul',
+      status: 'pendente',
+    },
+    onClose: fn(),
+    onSave: fn(),
+  },
+  tags: ['autodocs'],
+} satisfies Meta<typeof ModalEditarPedido>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    await expect(canvas.getByText(/Editar Pedido/i)).toBeInTheDocument();
+  },
+};

--- a/stories/ModalEditarPerfil.stories.tsx
+++ b/stories/ModalEditarPerfil.stories.tsx
@@ -1,0 +1,33 @@
+import type { Meta, StoryObj } from '@storybook/nextjs';
+import { within, expect, fn } from 'storybook/test';
+import ModalEditarPerfil from '../app/admin/perfil/components/ModalEditarPerfil';
+import { AuthProvider } from '../lib/context/AuthContext';
+import { ThemeProvider } from '../lib/context/ThemeContext';
+
+const meta = {
+  title: 'Admin/ModalEditarPerfil',
+  component: ModalEditarPerfil,
+  decorators: [
+    (Story) => (
+      <ThemeProvider>
+        <AuthProvider>
+          <Story />
+        </AuthProvider>
+      </ThemeProvider>
+    ),
+  ],
+  args: {
+    onClose: fn(),
+  },
+  tags: ['autodocs'],
+} satisfies Meta<typeof ModalEditarPerfil>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    await expect(canvas.getByText(/Editar Perfil/i)).toBeInTheDocument();
+  },
+};

--- a/stories/ModalVisualizarPedido.stories.tsx
+++ b/stories/ModalVisualizarPedido.stories.tsx
@@ -1,0 +1,31 @@
+import type { Meta, StoryObj } from '@storybook/nextjs';
+import { within, expect, fn } from 'storybook/test';
+import ModalVisualizarPedido from '../app/admin/inscricoes/componentes/ModalVisualizarPedido';
+import { ThemeProvider } from '../lib/context/ThemeContext';
+
+const meta = {
+  title: 'Admin/ModalVisualizarPedido',
+  component: ModalVisualizarPedido,
+  decorators: [
+    (Story) => (
+      <ThemeProvider>
+        <Story />
+      </ThemeProvider>
+    ),
+  ],
+  args: {
+    pedidoId: '1',
+    onClose: fn(),
+  },
+  tags: ['autodocs'],
+} satisfies Meta<typeof ModalVisualizarPedido>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    await expect(canvas.getByText(/Detalhes do Pedido/i)).toBeInTheDocument();
+  },
+};


### PR DESCRIPTION
## Summary
- fix corrupted Storybook main config
- list clients in the admin dashboard with edit modal
- create ListaClientes component with Storybook
- log documentation update about the new admin feature

## Testing
- `npm run lint` *(fails: next not found)*
- `npm run test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6842f6153180832cb46b33543440f307