### PR TITLE
Add Bebas Neue font

### DIFF
--- a/app/admin/inscricoes/page.tsx
+++ b/app/admin/inscricoes/page.tsx
@@ -100,13 +100,8 @@ export default function ListaInscricoesPage() {
     if (user.role === "coordenador") {
       pb.collection("campos")
         .getFullList({ sort: "nome" })
-        .then((res) => {
-          const nomes = res.map((c) =>
-            typeof c === "object" && c !== null && "nome" in c
-              ? String(c.nome)
-              : "Indefinido"
-          );
-          // Se ainda for usar camposDisponiveis no futuro:
+        .then(() => {
+          // TODO: adicionar camposDisponiveis futuramente
         })
         .catch(() => {});
     }

--- a/app/admin/layout.tsx
+++ b/app/admin/layout.tsx
@@ -1,11 +1,12 @@
 // app/layout.tsx
 import "@/app/globals.css";
 import LayoutWrapper from "./components/LayoutWrapper";
-import { Geist, Geist_Mono } from "next/font/google";
+import { Geist, Geist_Mono, Bebas_Neue } from "next/font/google";
 
 // Inicialize as fontes
 const geistSans = Geist({ subsets: ["latin"], variable: "--font-geist" });
 const geistMono = Geist_Mono({ subsets: ["latin"], variable: "--font-geist-mono" });
+const bebas = Bebas_Neue({ weight: "400", subsets: ["latin"], variable: "--font-bebas" });
 
 export const metadata = {
   title: "UMADEUS",
@@ -27,7 +28,7 @@ export default function RootLayout({
   children: React.ReactNode;
 }) {
   return (
-    <div className={`${geistSans.variable} ${geistMono.variable} antialiased`}>
+    <div className={`${geistSans.variable} ${geistMono.variable} ${bebas.variable} antialiased`}>
       <LayoutWrapper>{children}</LayoutWrapper>
     </div>
   );

--- a/app/globals.css
+++ b/app/globals.css
@@ -16,6 +16,8 @@
   --color-secondary: #2a1a1c; /* tonalidade complementar */
   --font-body: var(--font-geist);
   --font-heading: var(--font-geist);
+  /* Exposição da variável de fonte para uso global */
+  --font-bebas: "Bebas Neue", cursive;
   --space-xs: 0.25rem;
   --space-sm: 0.5rem;
   --space-md: 1rem;

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -3,11 +3,12 @@ import "./globals.css";
 import { AuthProvider } from "@/lib/context/AuthContext";
 import { ThemeProvider } from "@/lib/context/ThemeContext";
 import { ToastProvider } from "@/lib/context/ToastContext";
-import { Geist, Geist_Mono } from "next/font/google";
+import { Geist, Geist_Mono, Bebas_Neue } from "next/font/google";
 
 // Inicialize as fontes
 const geistSans = Geist({ subsets: ["latin"], variable: "--font-geist" });
 const geistMono = Geist_Mono({ subsets: ["latin"], variable: "--font-geist-mono" });
+const bebas = Bebas_Neue({ weight: "400", subsets: ["latin"], variable: "--font-bebas" });
 
 export const metadata = {
   title: "UMADEUS",
@@ -30,7 +31,7 @@ export default function RootLayout({
 }) {
   return (
     <html lang="pt-BR">
-      <body className={`font-sans antialiased ${geistSans.variable} ${geistMono.variable}`}>
+      <body className={`font-sans antialiased ${geistSans.variable} ${geistMono.variable} ${bebas.variable}`}>
         <ThemeProvider>
           <AuthProvider>
             <ToastProvider>

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -41,6 +41,9 @@ module.exports = {
         eerie_black: "#1e2019",
         platina: "#dcdcdc",
       },
+      fontFamily: {
+        bebas: 'var(--font-bebas)',
+      },
     },
   },
   plugins: [],


### PR DESCRIPTION
## Summary
- configure Bebas Neue with `next/font`
- expose `--font-bebas` variable and Tailwind utility
- include the new font on layouts
- fix lint issue in admin inscriptions page

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68444161b940832cacaf9e312a296c3f