### PR TITLE
Replace inline hex colors with theme tokens

### DIFF
--- a/app/admin/clientes/components/ListaClientes.tsx
+++ b/app/admin/clientes/components/ListaClientes.tsx
@@ -9,7 +9,7 @@ export interface ListaClientesProps {
 
 export default function ListaClientes({ clientes, onEdit }: ListaClientesProps) {
   return (
-    <div className="overflow-auto rounded-lg border bg-white border-gray-300 dark:bg-[#0c0d0a] dark:border-gray-700 shadow-sm">
+    <div className="overflow-auto rounded-lg border bg-white border-gray-300 dark:bg-neutral-950 dark:border-gray-700 shadow-sm">
       <table className="table-base">
         <thead>
           <tr>

--- a/app/admin/usuarios/page.tsx
+++ b/app/admin/usuarios/page.tsx
@@ -73,7 +73,7 @@ export default function UsuariosPage() {
       {loading ? (
         <p className="text-center text-gray-600">Carregando usuários...</p>
       ) : (
-        <div className="overflow-auto rounded-lg border bg-white border-gray-300 dark:bg-[#0c0d0a] dark:border-gray-700 shadow-sm">
+        <div className="overflow-auto rounded-lg border bg-white border-gray-300 dark:bg-neutral-950 dark:border-gray-700 shadow-sm">
           <table className="table-base">
             <thead>
               <tr>

--- a/app/blog/components/BlogHeroCarousel.tsx
+++ b/app/blog/components/BlogHeroCarousel.tsx
@@ -52,7 +52,7 @@ export default function BlogHeroCarousel() {
       {/* Desktop */}
       <div className="hidden md:flex relative z-10 items-end justify-between max-w-7xl mx-auto w-full h-full px-10 pb-24">
         <div className="w-1/2" />
-        <div className="w-full max-w-md bg-white text-[#333] p-8 rounded-2xl shadow-2xl">
+        <div className="w-full max-w-md bg-white text-neutral-800 p-8 rounded-2xl shadow-2xl">
           {post.category && (
             <span className="text-xs uppercase text-gray-500 font-semibold tracking-wide">
               {post.category}
@@ -73,7 +73,7 @@ export default function BlogHeroCarousel() {
 
       {/* Mobile */}
       <div className="md:hidden relative z-10 h-full flex flex-col justify-end items-center px-4 pb-6">
-        <div className="bg-white text-[#333] rounded-2xl shadow-xl p-5 w-full max-w-sm">
+        <div className="bg-white text-neutral-800 rounded-2xl shadow-xl p-5 w-full max-w-sm">
           {post.category && (
             <span className="text-xs uppercase text-gray-500 font-semibold tracking-wide">
               {post.category}

--- a/app/loja/layout.tsx
+++ b/app/loja/layout.tsx
@@ -16,7 +16,7 @@ export default function RootLayout({
   children: React.ReactNode;
 }) {
   return (
-    <div className={`bg-gradient-to-r from-black_bean via-[#5f1b1f] to-eerie_black animate-gradient-x text-platinum font-sans ${inter.className}`}> 
+    <div className={`bg-gradient-to-r from-black_bean via-neutral-800 to-eerie_black animate-gradient-x text-platinum font-sans ${inter.className}`}> 
       <Header />
       <main className="flex flex-col min-h-screen pt-20">{children}</main>
       <Footer />


### PR DESCRIPTION
## Summary
- use `text-neutral-800` in BlogHeroCarousel
- replace dark backgrounds with `dark:bg-neutral-950`
- adjust gradient in loja layout

## Testing
- `npm run lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_68444b060668832c99888ce0c3a3b3a7