### PR TITLE
Adiciona email ao tipo Inscricao

### DIFF
--- a/lib/flows/orderFlow.ts
+++ b/lib/flows/orderFlow.ts
@@ -63,9 +63,5 @@ export function criarPedido(inscricao: Inscricao): Pedido {
 }
 
 function dadosEmail(inscricao: Inscricao): string {
-  // tipo Inscricao não possui email, mas fluxo de API usa campo "email"
-  // aqui simulamos que email vem via expand
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  const anyInscricao: any = inscricao
-  return anyInscricao.email || 'sememail@teste.com'
+  return inscricao.email || 'sememail@teste.com'
 }

--- a/types/index.ts
+++ b/types/index.ts
@@ -2,6 +2,7 @@ export type Inscricao = {
   id: string;
   nome: string;
   telefone: string;
+  email?: string;
   status?: "pendente" | "aguardando_pagamento" | "confirmado" | "cancelado";
   tamanho?: string;
   produto?: string;


### PR DESCRIPTION
## Summary
- include optional `email` property in `Inscricao`
- remove `any` cast in `dadosEmail`

## Testing
- `npm run lint` *(fails: usePathname is defined but never used)*
- `npx vitest run`

------
https://chatgpt.com/codex/tasks/task_e_68444b323544832c8a20398b3c4fadcd