### PR TITLE
Add blog CMS docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,6 +79,26 @@ Crie um arquivo `.env.local` na raiz e defina as seguintes variáveis:
 
 2. Utilize as variáveis `PB_ADMIN_EMAIL` e `PB_ADMIN_PASSWORD` para autenticar a aplicação.
 
+## Blog e CMS
+
+Os arquivos de conteúdo ficam dentro da pasta `posts/` na raiz do projeto. Cada
+arquivo `.mdx` representa um post do blog.
+
+Para criar ou editar posts pelo painel admin:
+
+1. Acesse `/admin` e realize o login.
+2. No menu lateral, clique em **Blog** e escolha **Novo Post** ou selecione um
+   existente para editar.
+3. Preencha título, resumo, categoria, thumbnail e o conteúdo em Markdown.
+4. Salve para publicar ou atualizar o post.
+
+Após salvar as alterações, execute o comando abaixo para gerar
+`/public/posts.json` com a lista de posts:
+
+```bash
+npm run generate-posts
+```
+
 
 ## Testes
 

--- a/logs/DOC_LOG.md
+++ b/logs/DOC_LOG.md
@@ -15,3 +15,4 @@
 ## [2025-06-07] Adicionado docs/design-system.md e links no README e AGENTS.
 ## [2025-06-07] Documentados tokens neutros e atualizados estilos globais.
 ## [2025-06-07] Documentada paleta 'error' no design-tokens.
+## [2025-06-07] Adicionada seção "Blog e CMS" ao README e script generate-posts no package.json.

--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
     "build": "next build",
     "start": "next start",
     "lint": "next lint",
+    "generate-posts": "node scripts/generatePostsJson.js",
     "test": "vitest",
     "storybook": "storybook dev -p 6006",
     "build-storybook": "storybook build"


### PR DESCRIPTION
## Summary
- document how to manage posts via admin panel
- add script `generate-posts`
- record documentation change
- track empty `posts/` folder

## Testing
- `npm run lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_68444bbcea9c832c9e28d5ecbe511aab