### PR TITLE
Implement post upload route

### DIFF
--- a/app/admin/api/posts/route.ts
+++ b/app/admin/api/posts/route.ts
@@ -1,0 +1,75 @@
+import { NextRequest, NextResponse } from "next/server";
+import path from "path";
+import fs from "fs";
+import { writeFile, mkdir } from "fs/promises";
+import matter from "gray-matter";
+
+function slugify(text: string) {
+  return text
+    .toLowerCase()
+    .trim()
+    .replace(/[^a-z0-9\s-]/g, "")
+    .replace(/\s+/g, "-");
+}
+
+export async function POST(req: NextRequest) {
+  try {
+    const formData = await req.formData();
+    const title = formData.get("title")?.toString() || "";
+    const summary = formData.get("summary")?.toString() || "";
+    const category = formData.get("category")?.toString() || "";
+    const content = formData.get("content")?.toString() || "";
+    const file = formData.get("thumbnail") as File | null;
+
+    if (!title || !content) {
+      return NextResponse.json(
+        { error: "Título e conteúdo são obrigatórios." },
+        { status: 400 }
+      );
+    }
+
+    const slug = slugify(title);
+    let thumbnailUrl = "";
+
+    if (file) {
+      const bytes = await file.arrayBuffer();
+      const buffer = Buffer.from(bytes);
+      const uploadsDir = path.join(process.cwd(), "public", "uploads");
+
+      if (!fs.existsSync(uploadsDir)) {
+        await mkdir(uploadsDir, { recursive: true });
+      }
+
+      const ext = path.extname(file.name) || ".jpg";
+      const filename = `${slug}${ext}`;
+      const filepath = path.join(uploadsDir, filename);
+      await writeFile(filepath, buffer);
+      thumbnailUrl = `/uploads/${filename}`;
+    }
+
+    const postsDir = path.join(process.cwd(), "posts");
+    if (!fs.existsSync(postsDir)) {
+      await mkdir(postsDir, { recursive: true });
+    }
+
+    const frontMatter = {
+      title,
+      summary,
+      category,
+      date: new Date().toISOString(),
+      ...(thumbnailUrl && { thumbnail: thumbnailUrl }),
+    } as Record<string, string>;
+
+    const mdxContent = `${matter.stringify(content, frontMatter)}\n`;
+    const postPath = path.join(postsDir, `${slug}.mdx`);
+    await writeFile(postPath, mdxContent, "utf8");
+
+    return NextResponse.json({ slug, thumbnail: thumbnailUrl });
+  } catch (err) {
+    console.error("Erro ao salvar post:", err);
+    return NextResponse.json(
+      { error: "Erro ao salvar post." },
+      { status: 500 }
+    );
+  }
+}

--- a/app/components/Header.tsx
+++ b/app/components/Header.tsx
@@ -1,5 +1,4 @@
 "use client";
-import { usePathname } from "next/navigation";
 
 import { useState } from "react";
 import { Menu, X } from "lucide-react";

--- a/scripts/generatePostsJson.js
+++ b/scripts/generatePostsJson.js
@@ -21,7 +21,9 @@ function getPosts() {
       slug: filename.replace(/\.mdx$/, ""),
       summary: data.summary || "",
       date: data.date || "",
-      thumbnail: data.thumbnail || null,
+      thumbnail: data.thumbnail
+        ? `/uploads/${path.basename(data.thumbnail)}`
+        : null,
       category: data.category || null,
     };
   });


### PR DESCRIPTION
## Summary
- add API route to store blog posts and upload thumbnail files
- remove unused import in Header
- include image paths when generating posts JSON
- keep posts directory in repo

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_68444bcb9e2c832cb6dbadee8bf8257f