### PR TITLE
Add admin posts page with auth

### DIFF
--- a/app/admin/posts/editar/[slug]/page.tsx
+++ b/app/admin/posts/editar/[slug]/page.tsx
@@ -1,0 +1,43 @@
+"use client";
+
+import { useEffect } from "react";
+import { useRouter } from "next/navigation";
+import { useAuthContext } from "@/lib/context/AuthContext";
+
+export default function EditarPostPage({ params }: { params: { slug: string } }) {
+  const { user, isLoggedIn } = useAuthContext();
+  const router = useRouter();
+
+  useEffect(() => {
+    if (!isLoggedIn || !user) {
+      router.replace("/admin/login");
+    }
+  }, [isLoggedIn, user, router]);
+
+  return (
+    <main className="max-w-xl mx-auto px-4 py-8">
+      <h1 className="text-2xl font-bold mb-4">Editar Post</h1>
+      <p className="text-sm text-gray-600 mb-4">Slug: {params.slug}</p>
+      <form className="space-y-4">
+        <input
+          type="text"
+          placeholder="Título"
+          className="w-full border p-2 rounded"
+        />
+        <input type="date" className="w-full border p-2 rounded" />
+        <input
+          type="text"
+          placeholder="Categoria"
+          className="w-full border p-2 rounded"
+        />
+        <textarea
+          placeholder="Conteúdo MDX"
+          className="w-full border p-2 rounded h-40"
+        ></textarea>
+        <button type="submit" className="w-full bg-red-600 text-white py-2 rounded">
+          Salvar
+        </button>
+      </form>
+    </main>
+  );
+}

--- a/app/admin/posts/novo/page.tsx
+++ b/app/admin/posts/novo/page.tsx
@@ -1,0 +1,42 @@
+"use client";
+
+import { useEffect } from "react";
+import { useRouter } from "next/navigation";
+import { useAuthContext } from "@/lib/context/AuthContext";
+
+export default function NovoPostPage() {
+  const { user, isLoggedIn } = useAuthContext();
+  const router = useRouter();
+
+  useEffect(() => {
+    if (!isLoggedIn || !user) {
+      router.replace("/admin/login");
+    }
+  }, [isLoggedIn, user, router]);
+
+  return (
+    <main className="max-w-xl mx-auto px-4 py-8">
+      <h1 className="text-2xl font-bold mb-4">Novo Post</h1>
+      <form className="space-y-4">
+        <input
+          type="text"
+          placeholder="Título"
+          className="w-full border p-2 rounded"
+        />
+        <input type="date" className="w-full border p-2 rounded" />
+        <input
+          type="text"
+          placeholder="Categoria"
+          className="w-full border p-2 rounded"
+        />
+        <textarea
+          placeholder="Conteúdo MDX"
+          className="w-full border p-2 rounded h-40"
+        ></textarea>
+        <button type="submit" className="w-full bg-red-600 text-white py-2 rounded">
+          Salvar
+        </button>
+      </form>
+    </main>
+  );
+}

--- a/app/admin/posts/page.tsx
+++ b/app/admin/posts/page.tsx
@@ -1,0 +1,107 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { useRouter } from "next/navigation";
+import { useAuthContext } from "@/lib/context/AuthContext";
+import Link from "next/link";
+
+interface Post {
+  title: string;
+  slug: string;
+  date: string;
+  category?: string | null;
+}
+
+const POSTS_PER_PAGE = 10;
+
+export default function AdminPostsPage() {
+  const { user, isLoggedIn } = useAuthContext();
+  const router = useRouter();
+  const [posts, setPosts] = useState<Post[]>([]);
+  const [page, setPage] = useState(1);
+
+  useEffect(() => {
+    if (!isLoggedIn || !user) {
+      router.replace("/admin/login");
+    }
+  }, [isLoggedIn, user, router]);
+
+  useEffect(() => {
+    fetch("/posts.json")
+      .then((res) => res.json())
+      .then(setPosts)
+      .catch((err) => {
+        console.error("Erro ao carregar posts:", err);
+      });
+  }, []);
+
+  const totalPages = Math.ceil(posts.length / POSTS_PER_PAGE);
+  const paginated = posts.slice(
+    (page - 1) * POSTS_PER_PAGE,
+    page * POSTS_PER_PAGE
+  );
+
+  return (
+    <main className="max-w-4xl mx-auto px-4 py-8">
+      <div className="flex justify-between items-center mb-6">
+        <h1 className="text-2xl font-bold">Posts</h1>
+        <Link
+          href="/admin/posts/novo"
+          className="btn btn-primary bg-red-600 hover:bg-red-700"
+        >
+          + Novo Post
+        </Link>
+      </div>
+
+      <div className="overflow-x-auto rounded border border-gray-200 shadow-sm">
+        <table className="table-base">
+          <thead>
+            <tr>
+              <th>Título</th>
+              <th>Data</th>
+              <th>Categoria</th>
+              <th>Ações</th>
+            </tr>
+          </thead>
+          <tbody>
+            {paginated.map((post) => (
+              <tr key={post.slug}>
+                <td className="font-medium">{post.title}</td>
+                <td>{post.date}</td>
+                <td>{post.category || "—"}</td>
+                <td>
+                  <Link
+                    href={`/admin/posts/editar/${post.slug}`}
+                    className="text-blue-600 hover:underline"
+                  >
+                    Editar
+                  </Link>
+                </td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      </div>
+
+      <div className="flex justify-center items-center gap-4 mt-6">
+        <button
+          className="btn btn-secondary"
+          disabled={page === 1}
+          onClick={() => setPage((p) => Math.max(1, p - 1))}
+        >
+          Anterior
+        </button>
+        <span className="text-sm">
+          Página {page} de {totalPages}
+        </span>
+        <button
+          className="btn btn-secondary"
+          disabled={page === totalPages}
+          onClick={() => setPage((p) => Math.min(totalPages, p + 1))}
+        >
+          Próxima
+        </button>
+      </div>
+    </main>
+  );
+}

--- a/app/components/Header.tsx
+++ b/app/components/Header.tsx
@@ -1,5 +1,4 @@
 "use client";
-import { usePathname } from "next/navigation";
 
 import { useState } from "react";
 import { Menu, X } from "lucide-react";

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,6 +12,7 @@
         "@tippyjs/react": "^4.2.6",
         "chart.js": "^4.4.9",
         "file-saver": "^2.0.5",
+        "gray-matter": "^4.0.3",
         "lucide-react": "^0.511.0",
         "next": "15.3.2",
         "pocketbase": "^0.26.0",
@@ -4372,87 +4373,6 @@
         "tslib": "^2.8.0"
       }
     },
-    "node_modules/@testing-library/dom": {
-      "version": "10.4.0",
-      "resolved": "https://registry.npmjs.org/@testing-library/dom/-/dom-10.4.0.tgz",
-      "integrity": "sha512-pemlzrSESWbdAloYml3bAJMEfNh1Z7EduzqPKprCH5S341frlpYnUEW0H72dLxa6IsYr+mPno20GiSm+h9dEdQ==",
-      "dev": true,
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "@babel/code-frame": "^7.10.4",
-        "@babel/runtime": "^7.12.5",
-        "@types/aria-query": "^5.0.1",
-        "aria-query": "5.3.0",
-        "chalk": "^4.1.0",
-        "dom-accessibility-api": "^0.5.9",
-        "lz-string": "^1.5.0",
-        "pretty-format": "^27.0.2"
-      },
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@testing-library/dom/node_modules/ansi-regex": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
-      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
-      "dev": true,
-      "license": "MIT",
-      "peer": true,
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/@testing-library/dom/node_modules/ansi-styles": {
-      "version": "5.2.0",
-      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-5.2.0.tgz",
-      "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
-      "dev": true,
-      "license": "MIT",
-      "peer": true,
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
-      }
-    },
-    "node_modules/@testing-library/dom/node_modules/aria-query": {
-      "version": "5.3.0",
-      "resolved": "https://registry.npmjs.org/aria-query/-/aria-query-5.3.0.tgz",
-      "integrity": "sha512-b0P0sZPKtyu8HkeRAfCq0IfURZK+SuwMjY1UXGBU27wpAiTwQAIlq56IbIO+ytk/JjS1fMR14ee5WBBfKi5J6A==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "peer": true,
-      "dependencies": {
-        "dequal": "^2.0.3"
-      }
-    },
-    "node_modules/@testing-library/dom/node_modules/pretty-format": {
-      "version": "27.5.1",
-      "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-27.5.1.tgz",
-      "integrity": "sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ==",
-      "dev": true,
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "ansi-regex": "^5.0.1",
-        "ansi-styles": "^5.0.0",
-        "react-is": "^17.0.1"
-      },
-      "engines": {
-        "node": "^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0"
-      }
-    },
-    "node_modules/@testing-library/dom/node_modules/react-is": {
-      "version": "17.0.2",
-      "resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
-      "integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==",
-      "dev": true,
-      "license": "MIT",
-      "peer": true
-    },
     "node_modules/@testing-library/jest-dom": {
       "version": "6.6.3",
       "resolved": "https://registry.npmjs.org/@testing-library/jest-dom/-/jest-dom-6.6.3.tgz",
@@ -4530,14 +4450,6 @@
       "dependencies": {
         "tslib": "^2.4.0"
       }
-    },
-    "node_modules/@types/aria-query": {
-      "version": "5.0.4",
-      "resolved": "https://registry.npmjs.org/@types/aria-query/-/aria-query-5.0.4.tgz",
-      "integrity": "sha512-rfT93uj5s0PRL7EzccGMs3brplhcrghnDoV26NqKhCAS1hVo+WdNsPvE/yb6ilfr5hi2MEk6d5EWJTKdxg8jVw==",
-      "dev": true,
-      "license": "MIT",
-      "peer": true
     },
     "node_modules/@types/babel__core": {
       "version": "7.20.5",
@@ -4671,7 +4583,7 @@
       "version": "19.1.6",
       "resolved": "https://registry.npmjs.org/@types/react/-/react-19.1.6.tgz",
       "integrity": "sha512-JeG0rEWak0N6Itr6QUx+X60uQmN+5t3j9r/OVDtWzFXKaj6kD1BwJzOksD0FF6iWxZlbE1kB0q9vtnU2ekqa1Q==",
-      "devOptional": true,
+      "dev": true,
       "dependencies": {
         "csstype": "^3.0.2"
       }
@@ -4680,7 +4592,7 @@
       "version": "19.1.5",
       "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-19.1.5.tgz",
       "integrity": "sha512-CMCjrWucUBZvohgZxkjd6S9h0nZxXjzus6yDfUb+xLxYM7VvjKNH1tQrE9GWLql1XoOP4/Ds3bwFqShHUYraGg==",
-      "devOptional": true,
+      "dev": true,
       "peerDependencies": {
         "@types/react": "^19.0.0"
       }
@@ -7205,7 +7117,7 @@
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.1.3.tgz",
       "integrity": "sha512-M1uQkMl8rQK/szD0LNhtqxIPLpimGm8sOBwU7lLnCpSbTyY3yeU1Vc7l4KT5zT4s/yOxHH5O7tIuuLOCnLADRw==",
-      "devOptional": true
+      "dev": true
     },
     "node_modules/damerau-levenshtein": {
       "version": "1.0.8",
@@ -7361,17 +7273,6 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
-    "node_modules/dequal": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/dequal/-/dequal-2.0.3.tgz",
-      "integrity": "sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA==",
-      "dev": true,
-      "license": "MIT",
-      "peer": true,
-      "engines": {
-        "node": ">=6"
-      }
-    },
     "node_modules/des.js": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/des.js/-/des.js-1.1.0.tgz",
@@ -7444,14 +7345,6 @@
       "engines": {
         "node": ">=0.10.0"
       }
-    },
-    "node_modules/dom-accessibility-api": {
-      "version": "0.5.16",
-      "resolved": "https://registry.npmjs.org/dom-accessibility-api/-/dom-accessibility-api-0.5.16.tgz",
-      "integrity": "sha512-X7BJ2yElsnOJ30pZF4uIIDfBEVgF4XEBxL9Bxhy6dnrm5hkzqmsWHGTiHqRiITNhMyFLyAiWndIJP7Z1NTteDg==",
-      "dev": true,
-      "license": "MIT",
-      "peer": true
     },
     "node_modules/dom-converter": {
       "version": "0.2.0",
@@ -8316,7 +8209,6 @@
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.1.tgz",
       "integrity": "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A==",
-      "dev": true,
       "license": "BSD-2-Clause",
       "bin": {
         "esparse": "bin/esparse.js",
@@ -8431,6 +8323,18 @@
       },
       "funding": {
         "url": "https://github.com/sindresorhus/execa?sponsor=1"
+      }
+    },
+    "node_modules/extend-shallow": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+      "integrity": "sha512-zCnTtlxNoAiDc3gqY2aYAWFx7XWWiasuF2K8Me5WbN8otHKTUKBwjPtNpRs/rbUZm7KxWAaNj7P1a/p52GbVug==",
+      "license": "MIT",
+      "dependencies": {
+        "is-extendable": "^0.1.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/fast-deep-equal": {
@@ -9000,6 +8904,43 @@
       "integrity": "sha512-EtKwoO6kxCL9WO5xipiHTZlSzBm7WLT627TqC/uVRd0HKmq8NXyebnNYxDoBi7wt8eTWrUrKXCOVaFq9x1kgag==",
       "dev": true
     },
+    "node_modules/gray-matter": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/gray-matter/-/gray-matter-4.0.3.tgz",
+      "integrity": "sha512-5v6yZd4JK3eMI3FqqCouswVqwugaA9r4dNZB1wwcmrD02QkV5H0y7XBQW8QwQqEaZY1pM9aqORSORhJRdNK44Q==",
+      "license": "MIT",
+      "dependencies": {
+        "js-yaml": "^3.13.1",
+        "kind-of": "^6.0.2",
+        "section-matter": "^1.0.0",
+        "strip-bom-string": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=6.0"
+      }
+    },
+    "node_modules/gray-matter/node_modules/argparse": {
+      "version": "1.0.10",
+      "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
+      "integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
+      "license": "MIT",
+      "dependencies": {
+        "sprintf-js": "~1.0.2"
+      }
+    },
+    "node_modules/gray-matter/node_modules/js-yaml": {
+      "version": "3.14.1",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.14.1.tgz",
+      "integrity": "sha512-okMH7OXXJ7YrN9Ok3/SXrnu4iX9yOk+25nqX4imS2npuvTYDmo/QEZoqwZkYaIDk3jVvBOTOIEgEhaLOynBS9g==",
+      "license": "MIT",
+      "dependencies": {
+        "argparse": "^1.0.7",
+        "esprima": "^4.0.0"
+      },
+      "bin": {
+        "js-yaml": "bin/js-yaml.js"
+      }
+    },
     "node_modules/has-bigints": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/has-bigints/-/has-bigints-1.1.0.tgz",
@@ -9564,6 +9505,15 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/is-extendable": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/is-extendable/-/is-extendable-0.1.1.tgz",
+      "integrity": "sha512-5BMULNob1vgFX6EjQw5izWDxrecWK9AM72rugNr0TFldMOi0fj6Jk+zeKIt0xGj4cEfQIJth4w3OKWOJ4f+AFw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/is-extglob": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
@@ -10043,6 +9993,15 @@
         "json-buffer": "3.0.1"
       }
     },
+    "node_modules/kind-of": {
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.3.tgz",
+      "integrity": "sha512-dcS1ul+9tmeD95T+x28/ehLgd9mENa3LsvDTtzm3vyBEO7RPptvAD+t44WVXaUjTBRcrpFeFlC8WCruUR456hw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/language-subtag-registry": {
       "version": "0.3.23",
       "resolved": "https://registry.npmjs.org/language-subtag-registry/-/language-subtag-registry-0.3.23.tgz",
@@ -10201,17 +10160,6 @@
       "integrity": "sha512-VK5a2ydJ7xm8GvBeKLS9mu1pVK6ucef9780JVUjw6bAjJL/QXnd4Y0p7SPeOUMC27YhzNCZvm5d/QX0Tp3rc0w==",
       "peerDependencies": {
         "react": "^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0"
-      }
-    },
-    "node_modules/lz-string": {
-      "version": "1.5.0",
-      "resolved": "https://registry.npmjs.org/lz-string/-/lz-string-1.5.0.tgz",
-      "integrity": "sha512-h5bgJWpxJNswbU7qCrV0tIKQCaS3blPDrqKWx+QxzuzL1zGUzij9XCWLrSLsJPu5t+eWA/ycetzYAO5IOMcWAQ==",
-      "dev": true,
-      "license": "MIT",
-      "peer": true,
-      "bin": {
-        "lz-string": "bin/bin.js"
       }
     },
     "node_modules/magic-string": {
@@ -12505,6 +12453,19 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/section-matter": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/section-matter/-/section-matter-1.0.0.tgz",
+      "integrity": "sha512-vfD3pmTzGpufjScBh50YHKzEu2lxBWhVEHsNGoEXmCmn2hKGfeNLYMzCJpe8cD7gqX7TJluOVpBkAequ6dgMmA==",
+      "license": "MIT",
+      "dependencies": {
+        "extend-shallow": "^2.0.1",
+        "kind-of": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
     "node_modules/semver": {
       "version": "7.7.2",
       "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.2.tgz",
@@ -12794,6 +12755,12 @@
       "engines": {
         "node": ">=0.10.0"
       }
+    },
+    "node_modules/sprintf-js": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
+      "integrity": "sha512-D9cPgkvLlV3t3IzL0D0YLvGA9Ahk4PcvVwUbN0dSGr1aP0Nrt4AEnTUbuGvquEC0mA64Gqt1fzirlRs5ibXx8g==",
+      "license": "BSD-3-Clause"
     },
     "node_modules/ssf": {
       "version": "0.11.2",
@@ -13281,6 +13248,15 @@
       "dev": true,
       "engines": {
         "node": ">=4"
+      }
+    },
+    "node_modules/strip-bom-string": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/strip-bom-string/-/strip-bom-string-1.0.0.tgz",
+      "integrity": "sha512-uCC2VHvQRYu+lMh4My/sFNmF2klFymLX1wHJeXnbEJERpV/ZsVuonzerjfrGpIGF7LBVa1O7i9kjiWvJiFck8g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/strip-final-newline": {

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
     "@tippyjs/react": "^4.2.6",
     "chart.js": "^4.4.9",
     "file-saver": "^2.0.5",
+    "gray-matter": "^4.0.3",
     "lucide-react": "^0.511.0",
     "next": "15.3.2",
     "pocketbase": "^0.26.0",

--- a/posts/primeiro-post.mdx
+++ b/posts/primeiro-post.mdx
@@ -1,0 +1,7 @@
+---
+title: "Primeiro Post"
+date: "2024-01-01"
+category: "Geral"
+---
+
+Conteúdo inicial do post.

--- a/posts/segundo-post.mdx
+++ b/posts/segundo-post.mdx
@@ -1,0 +1,7 @@
+---
+title: "Segundo Post"
+date: "2024-02-15"
+category: "Atualizações"
+---
+
+Outro conteúdo do post.

--- a/public/posts.json
+++ b/public/posts.json
@@ -1,0 +1,18 @@
+[
+  {
+    "title": "Segundo Post",
+    "slug": "segundo-post",
+    "summary": "",
+    "date": "2024-02-15",
+    "thumbnail": null,
+    "category": "Atualizações"
+  },
+  {
+    "title": "Primeiro Post",
+    "slug": "primeiro-post",
+    "summary": "",
+    "date": "2024-01-01",
+    "thumbnail": null,
+    "category": "Geral"
+  }
+]


### PR DESCRIPTION
## Summary
- implement new posts admin route with pagination
- add forms for creating and editing posts
- generate example posts and posts.json
- include gray-matter dependency

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68444bcef8b8832c9d9b0d57ca97d661