### PR TITLE
docs: update Asaas integration note

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,6 +71,8 @@ Crie um arquivo `.env.local` na raiz e defina as seguintes variáveis:
 - `ASAAS_WEBHOOK_SECRET` - segredo para validar webhooks do Asaas
 - `NEXT_PUBLIC_SITE_URL` - endereço do site (opcional)
 
+Esta integração realiza chamadas HTTP diretamente na API do Asaas, sem utilizar o SDK oficial.
+
 ## Conectando ao PocketBase
 
 

--- a/logs/DOC_LOG.md
+++ b/logs/DOC_LOG.md
@@ -16,3 +16,4 @@
 ## [2025-06-07] Documentados tokens neutros e atualizados estilos globais.
 ## [2025-06-07] Documentada paleta 'error' no design-tokens.
 ## [2025-06-07] Adicionada seção "Blog e CMS" ao README e script generate-posts no package.json.
+## [2025-06-07] README ajustado indicando uso de chamadas HTTP na API do Asaas, sem SDK.


### PR DESCRIPTION
## Summary
- clarify that Asaas integration uses HTTP API calls (no SDK)
- log the documentation change

## Testing
- `npm run lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_68445150ca28832c90160151be4b2254