### PR TITLE
Update design system docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,8 +57,14 @@ Execute `npm run lint` para verificar problemas de código. Evite o uso de `any`
 
 ## Design System
 
-Confira a visão geral de tokens, tipografia e componentes em
-[docs/design-system.md](docs/design-system.md).
+Nosso design system centraliza cores, tipografia e espaçamentos em `globals.css`
+e `tailwind.config.js`, garantindo consistência visual em todo o painel. Os
+principais componentes possuem exemplos no Storybook para facilitar testes e
+documentação.
+
+Leia as diretrizes completas em [docs/design-system.md](docs/design-system.md)
+e consulte a tabela de tokens em
+[docs/design-tokens.md](docs/design-tokens.md).
 
 ## Variáveis de Ambiente
 

--- a/docs/design-system.md
+++ b/docs/design-system.md
@@ -45,3 +45,44 @@ Execute `npm run storybook` para iniciar a interface e explorar os exemplos.
 4. Rode `npm run lint` e `npm run storybook` para validar que tudo está funcionando.
 
 Manter os tokens padronizados garante consistência visual em todo o projeto.
+
+## Guia de Contribuição
+
+Siga estas etapas para colaborar com o design system.
+
+### Criar novos tokens
+
+1. Defina a variável em `app/globals.css` ou acrescente novas cores em
+   `tailwind.config.js`.
+2. Descreva o novo token em `docs/design-tokens.md` e atualize eventuais
+   trechos deste documento.
+3. Ajuste ou crie componentes que utilizem o token e registre a mudança em
+   `stories/`.
+
+### Exemplos de componentes
+
+Os componentes principais ficam em `stories/` e demonstram padrões de uso.
+Uma estrutura mínima de exemplo seria:
+
+```tsx
+// components/MeuBotao.tsx
+export function MeuBotao() {
+  return (
+    <button className="bg-[var(--accent)] p-[var(--space-sm)] rounded">
+      Ação
+    </button>
+  );
+}
+
+// stories/MeuBotao.stories.tsx
+import { MeuBotao } from '../components/MeuBotao';
+
+export default { title: 'Design System/MeuBotao', component: MeuBotao };
+
+export const Padrão = () => <MeuBotao />;
+```
+
+### Referências ao Storybook
+
+Execute `npm run storybook` para iniciar a interface e validar os componentes.
+Qualquer novo token ou componente deve ter uma história correspondente.

--- a/logs/DOC_LOG.md
+++ b/logs/DOC_LOG.md
@@ -16,3 +16,4 @@
 ## [2025-06-07] Documentados tokens neutros e atualizados estilos globais.
 ## [2025-06-07] Documentada paleta 'error' no design-tokens.
 ## [2025-06-07] Adicionada seção "Blog e CMS" ao README e script generate-posts no package.json.
+## [2025-06-07] README resumido sobre o design system e guia de contribuição adicionado ao docs/design-system.md.


### PR DESCRIPTION
## Summary
- expand Design System overview in README with links to both docs
- detail contribution workflow in docs/design-system.md
- log documentation update

## Testing
- `npm run lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_6844525a5390832c8960529ea0202292