### PR TITLE
Atualiza cores para tokens do tema

### DIFF
--- a/app/admin/clientes/components/ListaClientes.tsx
+++ b/app/admin/clientes/components/ListaClientes.tsx
@@ -9,7 +9,7 @@ export interface ListaClientesProps {
 
 export default function ListaClientes({ clientes, onEdit }: ListaClientesProps) {
   return (
-    <div className="overflow-auto rounded-lg border bg-white border-gray-300 dark:bg-[#0c0d0a] dark:border-gray-700 shadow-sm">
+    <div className="overflow-auto rounded-lg border bg-white border-gray-300 dark:bg-neutral-950 dark:border-gray-700 shadow-sm">
       <table className="table-base">
         <thead>
           <tr>

--- a/app/admin/dashboard/components/DashboardResumo.tsx
+++ b/app/admin/dashboard/components/DashboardResumo.tsx
@@ -67,7 +67,7 @@ export default function DashboardResumo({
       {
         label: "Inscrições",
         data: inscricoes.map(() => 1),
-        backgroundColor: "#DCDCDD",
+        backgroundColor: "#7c3aed",
       },
     ],
   };
@@ -85,7 +85,7 @@ export default function DashboardResumo({
         {
           label: `Pedidos (${filtroStatus})`,
           data: Object.values(contagem),
-          backgroundColor: ["#DCDCDD", "#c94a4a", "#0ea5e9"],
+          backgroundColor: ["#7c3aed", "#dc2626", "#3b82f6"],
         },
       ],
     };

--- a/app/admin/usuarios/page.tsx
+++ b/app/admin/usuarios/page.tsx
@@ -73,7 +73,7 @@ export default function UsuariosPage() {
       {loading ? (
         <p className="text-center text-gray-600">Carregando usuários...</p>
       ) : (
-        <div className="overflow-auto rounded-lg border bg-white border-gray-300 dark:bg-[#0c0d0a] dark:border-gray-700 shadow-sm">
+        <div className="overflow-auto rounded-lg border bg-white border-gray-300 dark:bg-neutral-950 dark:border-gray-700 shadow-sm">
           <table className="table-base">
             <thead>
               <tr>

--- a/app/blog/components/BlogHeroCarousel.tsx
+++ b/app/blog/components/BlogHeroCarousel.tsx
@@ -52,7 +52,7 @@ export default function BlogHeroCarousel() {
       {/* Desktop */}
       <div className="hidden md:flex relative z-10 items-end justify-between max-w-7xl mx-auto w-full h-full px-10 pb-24">
         <div className="w-1/2" />
-        <div className="w-full max-w-md bg-white text-[#333] p-8 rounded-2xl shadow-2xl">
+        <div className="w-full max-w-md bg-white text-neutral-800 p-8 rounded-2xl shadow-2xl">
           {post.category && (
             <span className="text-xs uppercase text-gray-500 font-semibold tracking-wide">
               {post.category}
@@ -73,7 +73,7 @@ export default function BlogHeroCarousel() {
 
       {/* Mobile */}
       <div className="md:hidden relative z-10 h-full flex flex-col justify-end items-center px-4 pb-6">
-        <div className="bg-white text-[#333] rounded-2xl shadow-xl p-5 w-full max-w-sm">
+        <div className="bg-white text-neutral-800 rounded-2xl shadow-xl p-5 w-full max-w-sm">
           {post.category && (
             <span className="text-xs uppercase text-gray-500 font-semibold tracking-wide">
               {post.category}

--- a/app/globals.css
+++ b/app/globals.css
@@ -79,7 +79,7 @@ body {
 }
 
 .btn-primary {
-  @apply bg-red-700 text-white hover:bg-red-800;
+  @apply bg-[var(--accent)] text-white hover:bg-primary-700;
 }
 
 .btn-secondary {
@@ -87,7 +87,7 @@ body {
 }
 
 .btn-danger {
-  @apply bg-red-600 text-white hover:bg-red-700;
+  @apply bg-error-600 text-white hover:bg-error-700;
 }
 
 
@@ -96,7 +96,7 @@ body {
 }
 
 .input-base {
-  @apply w-full px-4 py-3 rounded-lg border border-neutral-300 bg-neutral-50 text-sm text-neutral-900 focus:outline-none focus:ring-2 focus:ring-red-600 transition;
+  @apply w-full px-4 py-3 rounded-lg border border-neutral-300 bg-neutral-50 text-sm text-neutral-900 focus:outline-none focus:ring-2 focus:ring-error-600 transition;
 }
 
 .table-base {


### PR DESCRIPTION
## Summary
- substitui texto cinza em `BlogHeroCarousel` por `text-neutral-800`
- troca `dark:bg-[#0c0d0a]` por `dark:bg-neutral-950` em clientes e usuários
- usa cores da paleta nos gráficos de `DashboardResumo`
- converte botões e inputs globais para tokens de cor

## Testing
- `npm run lint`
- `npx vitest --run`


------
https://chatgpt.com/codex/tasks/task_e_6844525531e8832c8bd562459879a314