### PR TITLE
Refactor color tokens and docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,6 +65,8 @@ documentação.
 Leia as diretrizes completas em [docs/design-system.md](docs/design-system.md)
 e consulte a tabela de tokens em
 [docs/design-tokens.md](docs/design-tokens.md).
+Esses documentos também trazem exemplos das classes globais `btn` e
+`input-base` utilizadas em formulários.
 
 ## Variáveis de Ambiente
 

--- a/app/admin/components/DashboardAnalytics.tsx
+++ b/app/admin/components/DashboardAnalytics.tsx
@@ -6,6 +6,7 @@ import dynamic from "next/dynamic";
 import { saveAs } from "file-saver";
 import * as XLSX from "xlsx";
 import type { Inscricao, Pedido } from "@/types";
+import colors from "@/utils/twColors";
 
 const LineChart = dynamic(() => import("react-chartjs-2").then((m) => m.Line), {
   ssr: false,
@@ -58,7 +59,7 @@ export default function DashboardAnalytics({ inscricoes, pedidos }: DashboardAna
         label: "Inscrições",
         data: inscricoesData.data,
         fill: true,
-        borderColor: "#7c3aed",
+        borderColor: colors.primary600,
         backgroundColor: "rgba(124,58,237,0.2)",
       },
     ],
@@ -71,7 +72,7 @@ export default function DashboardAnalytics({ inscricoes, pedidos }: DashboardAna
         label: "Pedidos",
         data: pedidosData.data,
         fill: true,
-        borderColor: "#0ea5e9",
+        borderColor: colors.blue500,
         backgroundColor: "rgba(14,165,233,0.2)",
       },
     ],
@@ -104,7 +105,7 @@ export default function DashboardAnalytics({ inscricoes, pedidos }: DashboardAna
       {
         label: "Arrecadação (R$)",
         data: arrecadacaoLabels.map((l) => arrecadacaoCampo[l]),
-        backgroundColor: "#8b5cf6",
+        backgroundColor: colors.primary600,
       },
     ],
   };

--- a/app/admin/dashboard/components/DashboardResumo.tsx
+++ b/app/admin/dashboard/components/DashboardResumo.tsx
@@ -3,6 +3,7 @@
 import dynamic from "next/dynamic";
 import { useEffect } from "react";
 import { setupCharts } from "@/lib/chartSetup";
+import colors from "@/utils/twColors";
 import { Info } from "lucide-react";
 import Tippy from "@tippyjs/react";
 import "tippy.js/dist/tippy.css";
@@ -67,7 +68,7 @@ export default function DashboardResumo({
       {
         label: "Inscrições",
         data: inscricoes.map(() => 1),
-        backgroundColor: "#7c3aed",
+        backgroundColor: colors.primary600,
       },
     ],
   };
@@ -85,7 +86,11 @@ export default function DashboardResumo({
         {
           label: `Pedidos (${filtroStatus})`,
           data: Object.values(contagem),
-          backgroundColor: ["#7c3aed", "#dc2626", "#3b82f6"],
+          backgroundColor: [
+            colors.primary600,
+            colors.error600,
+            colors.blue500,
+          ],
         },
       ],
     };

--- a/app/globals.css
+++ b/app/globals.css
@@ -12,7 +12,7 @@
   --text-secondary: #4b4b4b;
   --text-header-primary: #dcdcdc;
   --text-header-secondary: #4b4b4b;
-  --accent: #7c3aed; /* roxo primário */
+  --accent: theme(colors.primary.600); /* roxo primário */
   --color-secondary: #2a1a1c; /* tonalidade complementar */
   --font-body: var(--font-geist);
   --font-heading: var(--font-geist);

--- a/docs/design-system.md
+++ b/docs/design-system.md
@@ -37,6 +37,17 @@ Os principais componentes têm exemplos interativos no Storybook. Alguns dos mai
 
 Execute `npm run storybook` para iniciar a interface e explorar os exemplos.
 
+## Botões e Inputs
+
+Utilizamos classes utilitárias para manter a consistência visual de elementos
+interativos. Os estilos base encontram-se em `app/globals.css` e devem ser
+reaproveitados nos componentes.
+
+```html
+<button class="btn btn-primary">Salvar</button>
+<input class="input-base" />
+```
+
 ## Adicionando Novos Tokens
 
 1. Inclua a variável desejada em `app/globals.css` ou expanda a paleta de cores em `tailwind.config.js`.

--- a/docs/design-tokens.md
+++ b/docs/design-tokens.md
@@ -44,3 +44,16 @@ Exemplo de uso em um componente:
   Conteúdo
 </div>
 ```
+
+### Padrão de Botões e Inputs
+
+Todos os componentes interativos utilizam classes globais para manter a
+uniformidade. As principais são:
+
+```html
+<button class="btn btn-primary">Ação</button>
+<input class="input-base" />
+```
+
+Essas classes aplicam cores `primary-600` e foco `error-600` definidos em
+`tailwind.config.js`.

--- a/logs/DOC_LOG.md
+++ b/logs/DOC_LOG.md
@@ -16,3 +16,4 @@
 ## [2025-06-07] Documentados tokens neutros e atualizados estilos globais.
 ## [2025-06-07] Documentada paleta 'error' no design-tokens.
 ## [2025-06-07] Adicionada seção "Blog e CMS" ao README e script generate-posts no package.json.
+## [2025-06-07] Atualizadas cores para tokens e padronizado exemplos de botoes

--- a/utils/twColors.ts
+++ b/utils/twColors.ts
@@ -1,0 +1,11 @@
+const resolveConfig = require('tailwindcss/resolveConfig');
+const tailwindConfig = require('../tailwind.config.js');
+const colors = require('tailwindcss/colors');
+
+const fullConfig = resolveConfig(tailwindConfig);
+
+module.exports = {
+  primary600: fullConfig.theme.extend.colors.primary[600],
+  error600: fullConfig.theme.extend.colors.error[600],
+  blue500: colors.blue[500],
+};


### PR DESCRIPTION
## Summary
- replace hex colors with centralized Tailwind tokens in dashboard charts
- expose Tailwind color helpers via `twColors.ts`
- point accent variable to primary color token
- document button/input utility classes
- reference docs in README
- log documentation changes

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68445a70c3e0832ca5efcf1313c9bdc3