### PR TITLE
Replace hex colors with theme tokens

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -51,7 +51,13 @@ body {
 
 @media (prefers-color-scheme: dark) {
   html.dark body {
-    background: linear-gradient(270deg, #0c0d0a, #1e2019, #1e2019, #0c0d0a);
+    background: linear-gradient(
+      270deg,
+      theme(colors.neutral.950),
+      theme(colors.neutral.900),
+      theme(colors.neutral.900),
+      theme(colors.neutral.950)
+    );
     background-size: 500% 500%;
     background-repeat: no-repeat;
     animation: gradient-x 30s ease-in-out infinite;
@@ -60,7 +66,13 @@ body {
 
 @media (prefers-color-scheme: light) {
   html.light body {
-    background: linear-gradient(270deg, #dcdcdc, #d3d3d3, #dcdcdc, #d3d3d3);
+    background: linear-gradient(
+      270deg,
+      theme(colors.neutral.100),
+      theme(colors.neutral.200),
+      theme(colors.neutral.100),
+      theme(colors.neutral.200)
+    );
     background-size: 500% 500%;
     background-repeat: no-repeat;
     animation: gradient-x 30s ease-in-out infinite;

--- a/app/globals.css
+++ b/app/globals.css
@@ -93,6 +93,28 @@ body {
   @apply w-full px-4 py-3 rounded-lg border border-neutral-300 bg-neutral-50 text-sm text-neutral-900 focus:outline-none focus:ring-2 focus:ring-error-600 transition;
 }
 
+/* Card e Tabela base */
+.card {
+  @apply bg-neutral-50 dark:bg-neutral-900 border border-neutral-200 dark:border-neutral-700 rounded-lg shadow-sm;
+}
+
+.table-base {
+  @apply w-full text-left text-sm divide-y divide-neutral-200 dark:divide-neutral-700;
+}
+
+.table-base thead {
+  @apply bg-neutral-100 dark:bg-neutral-800;
+}
+
+.table-base th,
+.table-base td {
+  @apply px-4 py-2;
+}
+
+.table-base tbody tr:nth-child(even) {
+  @apply bg-neutral-50 dark:bg-neutral-950;
+}
+
 /* ==========================
    🎞️ Animações
    ========================== */


### PR DESCRIPTION
## Summary
- use neutral tokens in globals.css gradients

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_684466dcd7f0832c9fc776345a299fae