### PR TITLE
Fix eslint dependencies for post editing

### DIFF
--- a/app/admin/posts/components/PostContentEditor.tsx
+++ b/app/admin/posts/components/PostContentEditor.tsx
@@ -37,7 +37,7 @@ export default function PostMarkdownEditor({ value, onChange }: Props) {
     },
   });
 
-  // Atualiza quando value externo muda
+  // Atualiza quando o valor externo ou o editor mudam
   useEffect(() => {
     if (editor && value) {
       const html = markdownToHtml(value);
@@ -45,8 +45,7 @@ export default function PostMarkdownEditor({ value, onChange }: Props) {
         editor.commands.setContent(html, false);
       }
     }
-    // eslint-disable-next-line
-  }, [value]);
+  }, [value, editor]);
 
   return (
     <div className="bg-white rounded-xl shadow">

--- a/app/admin/posts/page.tsx
+++ b/app/admin/posts/page.tsx
@@ -34,7 +34,7 @@ export default function AdminPostsPage() {
       .catch((err) => {
         console.error("Erro ao carregar posts:", err);
       });
-  }, []);
+  }, [setPosts]);
 
   const totalPages = Math.ceil(posts.length / POSTS_PER_PAGE);
   const paginated = posts.slice(


### PR DESCRIPTION
## Summary
- add `editor` to `useEffect` dependencies in `PostContentEditor`
- include `setPosts` dependency in posts loader

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_684471834690832c88af8ca7c71abf47