### PR TITLE
Add PostContentEditor story

### DIFF
--- a/logs/DOC_LOG.md
+++ b/logs/DOC_LOG.md
@@ -18,3 +18,4 @@
 ## [2025-06-07] Adicionada seção "Blog e CMS" ao README e script generate-posts no package.json.
 ## [2025-06-07] Atualizadas cores para tokens e padronizado exemplos de botoes
 ## [2025-06-07] Unificação de estilos globais e documentação do design system. Atualizados tokens de cores, utilitários e exemplos.
+## [2025-06-08] Adicionados story do PostContentEditor

--- a/stories/PostContentEditor.stories.tsx
+++ b/stories/PostContentEditor.stories.tsx
@@ -1,0 +1,37 @@
+import type { Meta, StoryObj } from '@storybook/nextjs';
+import React, { useState } from 'react';
+import { fn } from 'storybook/test';
+import PostContentEditor from '../app/admin/posts/components/PostContentEditor';
+
+const meta = {
+  title: 'Admin/PostContentEditor',
+  component: PostContentEditor,
+  argTypes: {
+    value: { control: 'text' },
+    onChange: { action: 'changed' },
+  },
+  args: {
+    value: '# Post de Exemplo\n\nEdite o conte\u00fado...',
+    onChange: fn(),
+  },
+} satisfies Meta<typeof PostContentEditor>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+const Template = ({ value, onChange }: { value: string; onChange: (val: string) => void }) => {
+  const [content, setContent] = useState(value);
+  return (
+    <PostContentEditor
+      value={content}
+      onChange={(val) => {
+        setContent(val);
+        onChange(val);
+      }}
+    />
+  );
+};
+
+export const Default: Story = {
+  render: (args) => <Template {...(args as any)} />,
+};


### PR DESCRIPTION
## Summary
- add story for PostContentEditor to interactively edit markdown
- log new documentation entry

## Testing
- `npm run lint`
- `npm run storybook` *(fails to fully run in this environment but starts build)*

------
https://chatgpt.com/codex/tasks/task_e_6844719a2890832c814530c2f98e72dc