### PR TITLE
Add preview mode to post editor pages

### DIFF
--- a/app/admin/posts/editar/[slug]/page.tsx
+++ b/app/admin/posts/editar/[slug]/page.tsx
@@ -3,12 +3,14 @@
 import { useEffect, useState } from "react";
 import { useRouter, useParams } from "next/navigation";
 import { useAuthContext } from "@/lib/context/AuthContext";
+import { marked } from "marked";
 import PostContentEditor from "../../components/PostContentEditor";
 
 export default function EditarPostPage() {
   const { slug } = useParams<{ slug: string }>();
 
   const [conteudo, setConteudo] = useState("");
+  const [preview, setPreview] = useState(false);
 
   const { user, isLoggedIn } = useAuthContext();
   const router = useRouter();
@@ -18,6 +20,23 @@ export default function EditarPostPage() {
       router.replace("/admin/login");
     }
   }, [isLoggedIn, user, router]);
+
+  if (preview) {
+    return (
+      <main className="max-w-[680px] mx-auto px-4 py-8 bg-white">
+        <button
+          onClick={() => setPreview(false)}
+          className="mb-4 rounded bg-neutral-200 px-3 py-2"
+        >
+          Editar
+        </button>
+        <article
+          className="prose prose-neutral max-w-none"
+          dangerouslySetInnerHTML={{ __html: marked.parse(conteudo) }}
+        />
+      </main>
+    );
+  }
 
   return (
     <>
@@ -39,12 +58,21 @@ export default function EditarPostPage() {
           />
           <PostContentEditor value={conteudo} onChange={setConteudo} />
 
-          <button
-            type="submit"
-            className="w-full bg-red-600 text-white py-2 rounded"
-          >
-            Salvar
-          </button>
+          <div className="flex gap-2">
+            <button
+              type="button"
+              onClick={() => setPreview(true)}
+              className="flex-1 bg-neutral-200 py-2 rounded"
+            >
+              Pré-visualizar
+            </button>
+            <button
+              type="submit"
+              className="flex-1 bg-red-600 text-white py-2 rounded"
+            >
+              Salvar
+            </button>
+          </div>
         </form>
       </main>
     </>

--- a/app/admin/posts/novo/page.tsx
+++ b/app/admin/posts/novo/page.tsx
@@ -1,21 +1,39 @@
 "use client";
 
-import { useEffect } from "react";
+import { useEffect, useState } from "react";
 import { useRouter } from "next/navigation";
 import { useAuthContext } from "@/lib/context/AuthContext";
-import { useState } from "react";
+import { marked } from "marked";
 import PostContentEditor from "../components/PostContentEditor";
 
 export default function NovoPostPage() {
   const { user, isLoggedIn } = useAuthContext();
   const router = useRouter();
   const [conteudo, setConteudo] = useState("");
+  const [preview, setPreview] = useState(false);
 
   useEffect(() => {
     if (!isLoggedIn || !user) {
       router.replace("/admin/login");
     }
   }, [isLoggedIn, user, router]);
+
+  if (preview) {
+    return (
+      <main className="max-w-[680px] mx-auto px-4 py-8 bg-white">
+        <button
+          onClick={() => setPreview(false)}
+          className="mb-4 rounded bg-neutral-200 px-3 py-2"
+        >
+          Editar
+        </button>
+        <article
+          className="prose prose-neutral max-w-none"
+          dangerouslySetInnerHTML={{ __html: marked.parse(conteudo) }}
+        />
+      </main>
+    );
+  }
 
   return (
     <main className="max-w-xl mx-auto px-4 py-8">
@@ -34,12 +52,21 @@ export default function NovoPostPage() {
         />
         <PostContentEditor value={conteudo} onChange={setConteudo} />
 
-        <button
-          type="submit"
-          className="w-full bg-red-600 text-white py-2 rounded"
-        >
-          Salvar
-        </button>
+        <div className="flex gap-2">
+          <button
+            type="button"
+            onClick={() => setPreview(true)}
+            className="flex-1 bg-neutral-200 py-2 rounded"
+          >
+            Pré-visualizar
+          </button>
+          <button
+            type="submit"
+            className="flex-1 bg-red-600 text-white py-2 rounded"
+          >
+            Salvar
+          </button>
+        </div>
       </form>
     </main>
   );

--- a/stories/PostPreviewToggle.stories.tsx
+++ b/stories/PostPreviewToggle.stories.tsx
@@ -1,0 +1,48 @@
+import type { Meta, StoryObj } from '@storybook/nextjs';
+import { userEvent, within, expect } from 'storybook/test';
+import { useState } from 'react';
+import { marked } from 'marked';
+import PostContentEditor from '../app/admin/posts/components/PostContentEditor';
+
+function Demo() {
+  const [content, setContent] = useState('# Título');
+  const [preview, setPreview] = useState(false);
+
+  return preview ? (
+    <div>
+      <button onClick={() => setPreview(false)}>Editar</button>
+      <article
+        className="prose prose-neutral max-w-none"
+        dangerouslySetInnerHTML={{ __html: marked.parse(content) }}
+      />
+    </div>
+  ) : (
+    <div>
+      <PostContentEditor value={content} onChange={setContent} />
+      <button onClick={() => setPreview(true)}>Pré-visualizar</button>
+    </div>
+  );
+}
+
+const meta = {
+  title: 'Admin/PostPreviewToggle',
+  component: Demo,
+  tags: ['autodocs'],
+} satisfies Meta<typeof Demo>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    await userEvent.click(canvas.getByRole('button', { name: /pré-visualizar/i }));
+    await expect(
+      canvas.getByRole('button', { name: /editar/i })
+    ).toBeInTheDocument();
+    await userEvent.click(canvas.getByRole('button', { name: /editar/i }));
+    await expect(
+      canvas.getByRole('button', { name: /pré-visualizar/i })
+    ).toBeInTheDocument();
+  },
+};


### PR DESCRIPTION
## Summary
- add preview toggle to new and edit post pages in admin
- render markdown using blog layout when previewing
- include storybook example for preview toggle

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6844717ecbe8832cad221069d6aa6511