### PR TITLE
Add toolbar to post editor

### DIFF
--- a/app/admin/posts/components/EditorToolbar.tsx
+++ b/app/admin/posts/components/EditorToolbar.tsx
@@ -1,0 +1,47 @@
+"use client";
+
+import type { Editor } from "@tiptap/react";
+import { Bold, Italic, Heading1 } from "lucide-react";
+
+type Props = {
+  editor: Editor | null;
+};
+
+export default function EditorToolbar({ editor }: Props) {
+  if (!editor) {
+    return null;
+  }
+
+  const btnBase =
+    "btn px-2 py-1 hover:bg-neutral-200 dark:hover:bg-neutral-700";
+  const activeBg = "bg-neutral-200 dark:bg-neutral-700";
+
+  return (
+    <div className="flex gap-2 border-b border-neutral-200 dark:border-neutral-700 rounded-t-lg p-2 bg-neutral-50 dark:bg-neutral-800">
+      <button
+        type="button"
+        onClick={() => editor.chain().focus().toggleBold().run()}
+        className={`${btnBase} ${editor.isActive("bold") ? activeBg : ""}`}
+        aria-label="Negrito"
+      >
+        <Bold size={16} />
+      </button>
+      <button
+        type="button"
+        onClick={() => editor.chain().focus().toggleItalic().run()}
+        className={`${btnBase} ${editor.isActive("italic") ? activeBg : ""}`}
+        aria-label="It\u00e1lico"
+      >
+        <Italic size={16} />
+      </button>
+      <button
+        type="button"
+        onClick={() => editor.chain().focus().toggleHeading({ level: 2 }).run()}
+        className={`${btnBase} ${editor.isActive("heading", { level: 2 }) ? activeBg : ""}`}
+        aria-label="T\u00edtulo"
+      >
+        <Heading1 size={16} />
+      </button>
+    </div>
+  );
+}

--- a/app/admin/posts/components/PostContentEditor.tsx
+++ b/app/admin/posts/components/PostContentEditor.tsx
@@ -1,6 +1,7 @@
 "use client";
 import { useEditor, EditorContent } from "@tiptap/react";
 import StarterKit from "@tiptap/starter-kit";
+import EditorToolbar from "./EditorToolbar";
 import { useEffect } from "react";
 // @ts-expect-error: turndown não possui tipos TypeScript oficiais
 import TurndownService from "turndown";
@@ -50,6 +51,7 @@ export default function PostMarkdownEditor({ value, onChange }: Props) {
 
   return (
     <div className="bg-white rounded-xl shadow">
+      <EditorToolbar editor={editor} />
       <EditorContent editor={editor} />
     </div>
   );

--- a/logs/DOC_LOG.md
+++ b/logs/DOC_LOG.md
@@ -18,3 +18,4 @@
 ## [2025-06-07] Adicionada seção "Blog e CMS" ao README e script generate-posts no package.json.
 ## [2025-06-07] Atualizadas cores para tokens e padronizado exemplos de botoes
 ## [2025-06-07] Unificação de estilos globais e documentação do design system. Atualizados tokens de cores, utilitários e exemplos.
+## [2025-06-07] Criado componente EditorToolbar no admin e integrado ao editor de posts.


### PR DESCRIPTION
## Summary
- add `EditorToolbar` component with basic formatting controls
- include toolbar above the markdown editor
- document the addition in `DOC_LOG`

## Testing
- `npm run lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_6844717be978832c9c363aef451186dd