### PR TITLE
Define card and table styles

### DIFF
--- a/app/admin/campos/page.tsx
+++ b/app/admin/campos/page.tsx
@@ -165,7 +165,18 @@ export default function GerenciarCamposPage() {
 
   return (
     <main className="max-w-xl mx-auto px-4 py-8">
-      <h1 className="text-2xl font-bold mb-4">Gerenciar Campos de Atuação</h1>
+      <div className="flex flex-col sm:flex-row sm:items-center justify-between gap-4 mb-6">
+        <h1 className="heading">Gerenciar Campos de Atuação</h1>
+        <button
+          onClick={() => {
+            setEditandoId(null);
+            setNome("");
+          }}
+          className="btn btn-primary"
+        >
+          + Novo Campo
+        </button>
+      </div>
 
       {mensagem && (
         <div className="mb-4 text-sm text-center text-gray-800">{mensagem}</div>
@@ -192,30 +203,37 @@ export default function GerenciarCamposPage() {
       </form>
 
       {/* Lista de campos */}
-      <ul className="space-y-2">
-        {campos.map((campo) => (
-          <li
-            key={campo.id}
-            className="flex justify-between items-center border p-2 rounded shadow-sm"
-          >
-            <span>{campo.nome}</span>
-            <div className="space-x-2">
-              <button
-                onClick={() => iniciarEdicao(campo)}
-                className="text-sm text-blue-600 hover:underline"
-              >
-                Editar
-              </button>
-              <button
-                onClick={() => handleExcluir(campo.id)}
-                className="text-sm text-red-600 hover:underline"
-              >
-                Excluir
-              </button>
-            </div>
-          </li>
-        ))}
-      </ul>
+      <div className="overflow-x-auto rounded-lg border bg-white border-gray-300 dark:bg-neutral-950 dark:border-gray-700 shadow-sm">
+        <table className="table-base">
+          <thead>
+            <tr>
+              <th>Nome</th>
+              <th>Ações</th>
+            </tr>
+          </thead>
+          <tbody>
+            {campos.map((campo) => (
+              <tr key={campo.id}>
+                <td>{campo.nome}</td>
+                <td className="space-x-2">
+                  <button
+                    onClick={() => iniciarEdicao(campo)}
+                    className="text-sm text-blue-600 hover:underline"
+                  >
+                    Editar
+                  </button>
+                  <button
+                    onClick={() => handleExcluir(campo.id)}
+                    className="text-sm text-red-600 hover:underline"
+                  >
+                    Excluir
+                  </button>
+                </td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      </div>
     </main>
   );
 }

--- a/app/globals.css
+++ b/app/globals.css
@@ -51,7 +51,13 @@ body {
 
 @media (prefers-color-scheme: dark) {
   html.dark body {
-    background: linear-gradient(270deg, #0c0d0a, #1e2019, #1e2019, #0c0d0a);
+    background: linear-gradient(
+      270deg,
+      theme(colors.neutral.950),
+      theme(colors.neutral.900),
+      theme(colors.neutral.900),
+      theme(colors.neutral.950)
+    );
     background-size: 500% 500%;
     background-repeat: no-repeat;
     animation: gradient-x 30s ease-in-out infinite;
@@ -60,7 +66,13 @@ body {
 
 @media (prefers-color-scheme: light) {
   html.light body {
-    background: linear-gradient(270deg, #dcdcdc, #d3d3d3, #dcdcdc, #d3d3d3);
+    background: linear-gradient(
+      270deg,
+      theme(colors.neutral.100),
+      theme(colors.neutral.200),
+      theme(colors.neutral.100),
+      theme(colors.neutral.200)
+    );
     background-size: 500% 500%;
     background-repeat: no-repeat;
     animation: gradient-x 30s ease-in-out infinite;
@@ -79,6 +91,28 @@ body {
 }
 .input-base {
   @apply w-full px-4 py-3 rounded-lg border border-neutral-300 bg-neutral-50 text-sm text-neutral-900 focus:outline-none focus:ring-2 focus:ring-error-600 transition;
+}
+
+/* Card e Tabela base */
+.card {
+  @apply flex flex-col gap-[var(--space-sm)] p-[var(--space-md)] bg-neutral-50 dark:bg-neutral-900 border border-neutral-200 dark:border-neutral-700 rounded-lg shadow-sm;
+}
+
+.table-base {
+  @apply w-full text-left text-sm divide-y divide-neutral-200 dark:divide-neutral-700;
+}
+
+.table-base thead {
+  @apply bg-neutral-100 dark:bg-neutral-800;
+}
+
+.table-base th,
+.table-base td {
+  @apply px-[var(--space-md)] py-[var(--space-sm)];
+}
+
+.table-base tbody tr:nth-child(even) {
+  @apply bg-neutral-50 dark:bg-neutral-950;
 }
 
 /* ==========================
@@ -108,7 +142,12 @@ body {
 }
 
 .bg-animated {
-  background: linear-gradient(270deg, #1f3162, #351669, #7a0926);
+  background: linear-gradient(
+    270deg,
+    theme(colors.primary.900),
+    theme(colors.primary.800),
+    theme(colors.error.800)
+  );
   background-size: 400% 400%;
   animation: gradient-x 15s ease infinite;
 }

--- a/docs/design-system.md
+++ b/docs/design-system.md
@@ -59,6 +59,19 @@ reaproveitados nos componentes.
 <input class="input-base" />
 ```
 
+## Cartões e Tabelas
+
+Utilize as classes `.card` e `.table-base` para aplicar bordas,
+espaçamentos e cores padronizados em cartões e listas.
+
+```html
+<div class="card">Conteúdo do cartão</div>
+
+<table class="table-base">
+  <!-- linhas -->
+</table>
+```
+
 ## Adicionando Novos Tokens
 
 1. Inclua a variável desejada em `app/globals.css` ou expanda a paleta de cores em `tailwind.config.js`.

--- a/logs/DOC_LOG.md
+++ b/logs/DOC_LOG.md
@@ -18,3 +18,4 @@
 ## [2025-06-07] Adicionada seção "Blog e CMS" ao README e script generate-posts no package.json.
 ## [2025-06-07] Atualizadas cores para tokens e padronizado exemplos de botoes
 ## [2025-06-07] Unificação de estilos globais e documentação do design system. Atualizados tokens de cores, utilitários e exemplos.
+## [2025-06-07] Incluídas classes `.card` e `.table-base` no design system.


### PR DESCRIPTION
## Summary
- add base styles for `.card` and `.table-base`
- document global card and table classes
- use theme tokens in animated gradient
- display fields list as table and add top-right action button

## Testing
- `npm run lint` *(fails: next not found)*
- `npm run test` *(fails: vitest not found)*
- `npm run build` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_684466dcd7f0832c9fc776345a299fae