### PR TITLE
Fix external image support

### DIFF
--- a/logs/ERR_LOG.md
+++ b/logs/ERR_LOG.md
@@ -1,2 +1,3 @@
 ## [2025-06-07] Corrigido erro de importacao no blog - dev - 1f6facf
 ## [2025-06-07] Removidos tipos do React 19 e downgrade para React 18.2 para resolver erros em tempo de execução - dev - 469ca13
+## [2025-06-07] Configurado domínio Unsplash para imagens externas - dev - b7c6c62

--- a/next.config.ts
+++ b/next.config.ts
@@ -3,7 +3,7 @@ import type { NextConfig } from "next";
 const nextConfig: NextConfig = {
   reactStrictMode: true,
   images: {
-    domains: ["asaas.com"],
+    domains: ["asaas.com", "images.unsplash.com"],
   },
   redirects: async () => [
     {


### PR DESCRIPTION
## Summary
- allow Unsplash domain for Next.js images
- log the fix in ERR_LOG

## Testing
- `npm run lint` *(fails: next not found)*
- `npm run test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68444aea24d8832c8d2fd8f7cebe54c8