### PR TITLE
Add image & link support to post editor

### DIFF
--- a/app/admin/posts/components/EditorToolbar.tsx
+++ b/app/admin/posts/components/EditorToolbar.tsx
@@ -1,7 +1,14 @@
 "use client";
 
 import type { Editor } from "@tiptap/react";
-import { Bold, Italic, Heading1 } from "lucide-react";
+import {
+  Bold,
+  Italic,
+  Heading2,
+  Heading3,
+  Pilcrow,
+  Image as ImageIcon,
+} from "lucide-react";
 
 type Props = {
   editor: Editor | null;
@@ -38,9 +45,38 @@ export default function EditorToolbar({ editor }: Props) {
         type="button"
         onClick={() => editor.chain().focus().toggleHeading({ level: 2 }).run()}
         className={`${btnBase} ${editor.isActive("heading", { level: 2 }) ? activeBg : ""}`}
-        aria-label="T\u00edtulo"
+        aria-label="H2"
       >
-        <Heading1 size={16} />
+        <Heading2 size={16} />
+      </button>
+      <button
+        type="button"
+        onClick={() => editor.chain().focus().toggleHeading({ level: 3 }).run()}
+        className={`${btnBase} ${editor.isActive("heading", { level: 3 }) ? activeBg : ""}`}
+        aria-label="H3"
+      >
+        <Heading3 size={16} />
+      </button>
+      <button
+        type="button"
+        onClick={() => editor.chain().focus().setParagraph().run()}
+        className={`${btnBase} ${editor.isActive("paragraph") ? activeBg : ""}`}
+        aria-label="Par\u00e1grafo"
+      >
+        <Pilcrow size={16} />
+      </button>
+      <button
+        type="button"
+        onClick={() => {
+          const url = window.prompt("URL da imagem");
+          if (url) {
+            editor.chain().focus().setImage({ src: url }).run();
+          }
+        }}
+        className={btnBase}
+        aria-label="Inserir imagem"
+      >
+        <ImageIcon size={16} />
       </button>
     </div>
   );

--- a/app/admin/posts/components/PostContentEditor.tsx
+++ b/app/admin/posts/components/PostContentEditor.tsx
@@ -1,6 +1,8 @@
 "use client";
 import { useEditor, EditorContent } from "@tiptap/react";
 import StarterKit from "@tiptap/starter-kit";
+import Image from "@tiptap/extension-image";
+import Link from "@tiptap/extension-link";
 import EditorToolbar from "./EditorToolbar";
 import { useEffect } from "react";
 // @ts-expect-error: turndown não possui tipos TypeScript oficiais
@@ -22,7 +24,7 @@ type Props = {
 
 export default function PostMarkdownEditor({ value, onChange }: Props) {
   const editor = useEditor({
-    extensions: [StarterKit],
+    extensions: [StarterKit, Image, Link],
     content: markdownToHtml(value),
     editorProps: {
       attributes: {


### PR DESCRIPTION
## Summary
- support links and images in `PostContentEditor`
- extend the editor toolbar with buttons for headings, paragraphs and image insertion

## Testing
- `npm run lint` *(fails: handleExcluir, iniciarEdicao, err unused)*

------
https://chatgpt.com/codex/tasks/task_e_68447e4ec6b8832c814a06ad11d5f9f0