### PR TITLE
Update heading docs

### DIFF
--- a/docs/design-system.md
+++ b/docs/design-system.md
@@ -59,6 +59,17 @@ reaproveitados nos componentes.
 <input class="input-base" />
 ```
 
+## Cabeçalhos
+
+Use os elementos `h1`, `h2` e `h3` para títulos. A classe `.heading` compartilha
+os mesmos estilos do `h1` e pode ser adicionada a qualquer tag:
+
+```html
+<h1 class="heading">Título Principal</h1>
+<h2 class="heading">Subtítulo</h2>
+<h3 class="heading">Seção Interna</h3>
+```
+
 ## Cartões e Tabelas
 
 Utilize as classes `.card` e `.table-base` para aplicar bordas,

--- a/logs/DOC_LOG.md
+++ b/logs/DOC_LOG.md
@@ -23,3 +23,4 @@
 ## [2025-06-07] Corrigidos nomes de ícones e atualizado manifest.json para remover referência ausente.
 ## [2025-06-08] Adicionados story do PostContentEditor
 ## [2025-06-07] Criado componente EditorToolbar no admin e integrado ao editor de posts.
+## [2025-06-07] Documentada classe `.heading` e exemplo de uso em docs/design-system.md.


### PR DESCRIPTION
## Summary
- document usage of `.heading` class in the design system
- log the documentation update

## Testing
- `npm run lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_68447e02bfe0832ca01f8ef68144cfbf