### PR TITLE
Implement post fetch endpoint and auto-fill editor

### DIFF
--- a/app/admin/api/posts/[slug]/route.ts
+++ b/app/admin/api/posts/[slug]/route.ts
@@ -1,0 +1,48 @@
+import { NextRequest, NextResponse } from "next/server";
+import fs from "fs";
+import path from "path";
+import matter from "gray-matter";
+
+export async function GET(req: NextRequest) {
+  const { pathname } = req.nextUrl;
+  const slug = pathname.split("/").pop() ?? "";
+
+  if (!slug) {
+    return NextResponse.json(
+      { error: "Slug ausente ou inválido." },
+      { status: 400 }
+    );
+  }
+
+  const filePath = path.join(process.cwd(), "posts", `${slug}.mdx`);
+
+  if (!fs.existsSync(filePath)) {
+    return NextResponse.json({ error: "Post não encontrado." }, { status: 404 });
+  }
+
+  try {
+    const raw = fs.readFileSync(filePath, "utf8");
+    const { data, content } = matter(raw);
+
+    const keywords = Array.isArray(data.keywords)
+      ? data.keywords.join(", ")
+      : data.keywords ?? "";
+
+    return NextResponse.json({
+      title: data.title ?? "",
+      summary: data.summary ?? "",
+      category: data.category ?? "",
+      date: data.date ?? "",
+      thumbnail: data.thumbnail ?? data.headerImage ?? "",
+      keywords,
+      content,
+    });
+  } catch (err) {
+    console.error("Erro ao carregar post:", err);
+    return NextResponse.json(
+      { error: "Erro ao carregar post." },
+      { status: 500 }
+    );
+  }
+}
+

--- a/app/admin/posts/editar/[slug]/page.tsx
+++ b/app/admin/posts/editar/[slug]/page.tsx
@@ -11,6 +11,8 @@ export default function EditarPostPage() {
 
   const [conteudo, setConteudo] = useState("");
   const [preview, setPreview] = useState(false);
+  const [title, setTitle] = useState("");
+  const [category, setCategory] = useState("");
   const [date, setDate] = useState("");
   const [thumbnail, setThumbnail] = useState("");
   const [keywords, setKeywords] = useState("");
@@ -23,6 +25,27 @@ export default function EditarPostPage() {
       router.replace("/admin/login");
     }
   }, [isLoggedIn, user, router]);
+
+  useEffect(() => {
+    fetch(`/admin/api/posts/${slug}`)
+      .then((res) => res.json())
+      .then((data: {
+        title: string;
+        category: string;
+        content: string;
+        date: string;
+        thumbnail: string;
+        keywords: string;
+      }) => {
+        setTitle(data.title);
+        setCategory(data.category);
+        setConteudo(data.content);
+        setDate(data.date);
+        setThumbnail(data.thumbnail);
+        setKeywords(data.keywords);
+      })
+      .catch((err) => console.error("Erro ao carregar post:", err));
+  }, [slug]);
 
   if (preview) {
     return (
@@ -66,6 +89,8 @@ export default function EditarPostPage() {
             type="text"
             placeholder="Título"
             name="title"
+            value={title}
+            onChange={(e) => setTitle(e.target.value)}
             className="w-full border p-2 rounded"
           />
           <input
@@ -79,6 +104,8 @@ export default function EditarPostPage() {
             type="text"
             placeholder="Categoria"
             name="category"
+            value={category}
+            onChange={(e) => setCategory(e.target.value)}
             className="w-full border p-2 rounded"
           />
           <input


### PR DESCRIPTION
## Summary
- add GET handler for `/admin/api/posts/[slug]` to read MDX files
- auto-fill edit form using fetched post data

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6844844eb4f8832cad0f258d501ab9a3