### PR TITLE
Fix infinite loop in perfil page

### DIFF
--- a/app/admin/perfil/page.tsx
+++ b/app/admin/perfil/page.tsx
@@ -34,13 +34,22 @@ export default function PerfilPage() {
   };
 
   useEffect(() => {
-    if (!pb.authStore.isValid) {
-      router.push("/admin/login");
-      return;
-    }
-    const model = pb.authStore.model as unknown as UsuarioAuthModel;
-    setUsuario(model);
-  }, [pb.authStore.isValid, pb.authStore.model, router]);
+    const handleAuthChange = () => {
+      if (!pb.authStore.isValid) {
+        router.push("/admin/login");
+      } else {
+        const model = pb.authStore.model as unknown as UsuarioAuthModel;
+        setUsuario(model);
+      }
+    };
+
+    handleAuthChange();
+    const unsubscribe = pb.authStore.onChange(handleAuthChange);
+
+    return () => {
+      unsubscribe();
+    };
+  }, [pb, router]);
 
   if (!usuario) return null;
 

--- a/logs/DOC_LOG.md
+++ b/logs/DOC_LOG.md
@@ -28,3 +28,4 @@
 ## [2025-06-07] Documentada classe `.heading` e exemplo de uso em docs/design-system.md.
 ## [2025-06-07] Atualizado arquitetura.md incluindo se\xC3\xA7\xC3\xA3o do Blog e nova estrutura de pastas.
 ## [2025-06-07] Ajustado processo de tipagem na rota loja/categorias/[slug].
+## [2025-06-07] Documentada correção do loop infinito em admin/perfil no ERR_LOG

--- a/logs/ERR_LOG.md
+++ b/logs/ERR_LOG.md
@@ -1,3 +1,4 @@
 ## [2025-06-07] Corrigido erro de importacao no blog - dev - 1f6facf
 ## [2025-06-07] Removidos tipos do React 19 e downgrade para React 18.2 para resolver erros em tempo de execução - dev - 469ca13
 ## [2025-06-07] Corrigida tipagem da página de categoria que quebrava build - dev - 450cce4
+## [2025-06-07] Resolvido loop infinito em admin/perfil causado por dependências do useEffect - dev - 261ebe7


### PR DESCRIPTION
## Summary
- prevent update loop in `app/admin/perfil/page.tsx`
- log the fix in ERR_LOG
- record documentation note in DOC_LOG

## Testing
- `npm run lint` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_68449946c250832cae82bdb65cce9d56