### PR TITLE
Fix inscriptions hook

### DIFF
--- a/app/admin/inscricoes/page.tsx
+++ b/app/admin/inscricoes/page.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useEffect, useState, useMemo } from "react";
+import { useEffect, useState, useMemo, useCallback } from "react";
 import createPocketBase from "@/lib/pocketbase";
 import { Copy } from "lucide-react";
 import { saveAs } from "file-saver";
@@ -55,7 +55,7 @@ export default function ListaInscricoesPage() {
       ? "Buscar por nome, telefone, CPF ou campo"
       : "Buscar por nome, telefone ou CPF";
 
-  useEffect(() => {
+  const carregarInscricoes = useCallback(() => {
     const user = pb.authStore.model;
 
     if (!user?.id || !user?.role) {
@@ -101,7 +101,14 @@ export default function ListaInscricoesPage() {
       // TODO: caso seja preciso listar campos disponíveis futuramente,
       // recuperar dados aqui e popular o estado correspondente.
     }
-  }, [pb, pb.authStore.model, showError]);
+  }, [pb, showError]);
+
+  useEffect(() => {
+    carregarInscricoes();
+
+    const unsubscribe = pb.authStore.onChange(carregarInscricoes);
+    return () => unsubscribe();
+  }, [pb, carregarInscricoes]);
 
   const copiarLink = async () => {
     try {

--- a/logs/DOC_LOG.md
+++ b/logs/DOC_LOG.md
@@ -28,3 +28,4 @@
 ## [2025-06-07] Documentada classe `.heading` e exemplo de uso em docs/design-system.md.
 ## [2025-06-07] Atualizado arquitetura.md incluindo se\xC3\xA7\xC3\xA3o do Blog e nova estrutura de pastas.
 ## [2025-06-07] Ajustado processo de tipagem na rota loja/categorias/[slug].
+## [2025-06-07] Documentada correção do carregamento de inscrições ao subscrever mudanças de autenticação.

--- a/logs/ERR_LOG.md
+++ b/logs/ERR_LOG.md
@@ -1,3 +1,4 @@
 ## [2025-06-07] Corrigido erro de importacao no blog - dev - 1f6facf
 ## [2025-06-07] Removidos tipos do React 19 e downgrade para React 18.2 para resolver erros em tempo de execução - dev - 469ca13
 ## [2025-06-07] Corrigida tipagem da página de categoria que quebrava build - dev - 450cce4
+## [2025-06-07] Corrigido efeito em ListaInscricoes que não respondia a mudanças de autenticação - dev -


### PR DESCRIPTION
## Summary
- reload admin inscription list when auth changes
- log fix in ERR_LOG and DOC_LOG

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68449d9cb270832c80dba457c4bdf997