### PR TITLE
Implement post fetch endpoint and improve preview

### DIFF
--- a/app/admin/api/posts/[slug]/route.ts
+++ b/app/admin/api/posts/[slug]/route.ts
@@ -1,0 +1,48 @@
+import { NextRequest, NextResponse } from "next/server";
+import fs from "fs";
+import path from "path";
+import matter from "gray-matter";
+
+export async function GET(req: NextRequest) {
+  const { pathname } = req.nextUrl;
+  const slug = pathname.split("/").pop() ?? "";
+
+  if (!slug) {
+    return NextResponse.json(
+      { error: "Slug ausente ou inválido." },
+      { status: 400 }
+    );
+  }
+
+  const filePath = path.join(process.cwd(), "posts", `${slug}.mdx`);
+
+  if (!fs.existsSync(filePath)) {
+    return NextResponse.json({ error: "Post não encontrado." }, { status: 404 });
+  }
+
+  try {
+    const raw = fs.readFileSync(filePath, "utf8");
+    const { data, content } = matter(raw);
+
+    const keywords = Array.isArray(data.keywords)
+      ? data.keywords.join(", ")
+      : data.keywords ?? "";
+
+    return NextResponse.json({
+      title: data.title ?? "",
+      summary: data.summary ?? "",
+      category: data.category ?? "",
+      date: data.date ?? "",
+      thumbnail: data.thumbnail ?? data.headerImage ?? "",
+      keywords,
+      content,
+    });
+  } catch (err) {
+    console.error("Erro ao carregar post:", err);
+    return NextResponse.json(
+      { error: "Erro ao carregar post." },
+      { status: 500 }
+    );
+  }
+}
+

--- a/app/admin/posts/editar/[slug]/page.tsx
+++ b/app/admin/posts/editar/[slug]/page.tsx
@@ -5,12 +5,20 @@ import { useRouter, useParams } from "next/navigation";
 import { useAuthContext } from "@/lib/context/AuthContext";
 import { marked } from "marked";
 import PostContentEditor from "../../components/PostContentEditor";
+import Header from "@/app/components/Header";
+import Footer from "@/app/components/Footer";
+import Image from "next/image";
+import { Clock } from "lucide-react";
+import { isExternalUrl } from "@/utils/isExternalUrl";
 
 export default function EditarPostPage() {
   const { slug } = useParams<{ slug: string }>();
 
   const [conteudo, setConteudo] = useState("");
   const [preview, setPreview] = useState(false);
+  const [title, setTitle] = useState("");
+  const [summary, setSummary] = useState("");
+  const [category, setCategory] = useState("");
   const [date, setDate] = useState("");
   const [thumbnail, setThumbnail] = useState("");
   const [keywords, setKeywords] = useState("");
@@ -24,20 +32,112 @@ export default function EditarPostPage() {
     }
   }, [isLoggedIn, user, router]);
 
+  useEffect(() => {
+    fetch(`/admin/api/posts/${slug}`)
+      .then((res) => res.json())
+      .then((data: {
+        title: string;
+        summary: string;
+        category: string;
+        content: string;
+        date: string;
+        thumbnail: string;
+        keywords: string;
+      }) => {
+        setTitle(data.title);
+        setSummary(data.summary);
+        setCategory(data.category);
+        setConteudo(data.content);
+        setDate(data.date);
+        setThumbnail(data.thumbnail);
+        setKeywords(data.keywords);
+      })
+      .catch((err) => console.error("Erro ao carregar post:", err));
+  }, [slug]);
+
   if (preview) {
+    const words = conteudo.split(/\s+/).length;
+    const readingTime = Math.ceil(words / 200);
+
     return (
-      <main className="max-w-[680px] mx-auto px-4 py-8 bg-white">
-        <button
-          onClick={() => setPreview(false)}
-          className="mb-4 rounded bg-neutral-200 px-3 py-2"
-        >
-          Editar
-        </button>
-        <article
-          className="prose prose-neutral max-w-none"
-          dangerouslySetInnerHTML={{ __html: marked.parse(conteudo) }}
-        />
-      </main>
+      <>
+        <Header />
+        <main className="mx-auto mt-8 max-w-[680px] px-5 py-20 text-[1.125rem] leading-[1.8] text-[var(--text-primary)] bg-white">
+          <button
+            onClick={() => setPreview(false)}
+            className="mb-6 rounded bg-neutral-200 px-3 py-2"
+          >
+            Editar
+          </button>
+
+          {thumbnail && (
+            <figure>
+              {isExternalUrl(thumbnail) ? (
+                // eslint-disable-next-line @next/next/no-img-element
+                <img
+                  src={thumbnail}
+                  alt={`Imagem de capa: ${title}`}
+                  className="w-full max-w-[640px] max-h-[360px] object-cover rounded-xl mx-auto mb-6"
+                />
+              ) : (
+                <Image
+                  src={thumbnail}
+                  alt={`Imagem de capa: ${title}`}
+                  width={1200}
+                  height={600}
+                  className="w-full max-w-[640px] max-h-[360px] object-cover rounded-xl mx-auto mb-6"
+                />
+              )}
+            </figure>
+          )}
+
+          {category && (
+            <span className="text-xs uppercase text-primary-600 font-semibold">
+              {category}
+            </span>
+          )}
+
+          <h1 className="text-2xl md:text-3xl font-bold leading-snug mt-2 mb-6">
+            {title}
+          </h1>
+
+          <div className="flex flex-wrap items-center gap-4 text-[0.9375rem] mb-6">
+            <div className="flex items-center gap-2 min-w-0">
+              <Image
+                src="/img/avatar_m24.webp"
+                alt="Autor"
+                width={40}
+                height={40}
+                className="flex-shrink-0 w-9 h-9 rounded-full object-cover"
+              />
+              <span>Redação M24</span>
+            </div>
+
+            <div className="flex items-center gap-1">
+              <Clock className="w-4 h-4" />
+              <span>{readingTime} min de leitura</span>
+            </div>
+          </div>
+
+          {keywords && (
+            <p className="mb-2 text-sm text-neutral-500">Palavras-chave: {keywords}</p>
+          )}
+
+          {date && (
+            <p className="text-sm text-neutral-500 mb-6">{date}</p>
+          )}
+
+          {summary && (
+            <p className="mb-8 text-[1.125rem] text-neutral-700">{summary}</p>
+          )}
+
+          <article
+            className="prose prose-neutral max-w-none"
+            dangerouslySetInnerHTML={{ __html: marked.parse(conteudo) }}
+          />
+        </main>
+        <Footer />
+      </>
     );
   }
 
@@ -66,6 +166,8 @@ export default function EditarPostPage() {
             type="text"
             placeholder="Título"
             name="title"
+            value={title}
+            onChange={(e) => setTitle(e.target.value)}
             className="w-full border p-2 rounded"
           />
           <input
@@ -79,6 +181,8 @@ export default function EditarPostPage() {
             type="text"
             placeholder="Categoria"
             name="category"
+            value={category}
+            onChange={(e) => setCategory(e.target.value)}
             className="w-full border p-2 rounded"
           />
           <input

--- a/app/blog/BlogClient.tsx
+++ b/app/blog/BlogClient.tsx
@@ -98,17 +98,22 @@ export default function BlogClient() {
                       className="bg-white rounded-xl shadow-md hover:shadow-lg transition overflow-hidden flex flex-col"
                     >
                       {post.thumbnail && (
-                        <Image
-                          src={
-                            isExternalUrl(post.thumbnail)
-                              ? post.thumbnail
-                              : `${post.thumbnail}`
-                          }
-                          alt={`Imagem de capa do post: ${post.title}`}
-                          width={640}
-                          height={320}
-                          className="w-full h-56 object-cover"
-                        />
+                        isExternalUrl(post.thumbnail) ? (
+                          // eslint-disable-next-line @next/next/no-img-element
+                          <img
+                            src={post.thumbnail}
+                            alt={`Imagem de capa do post: ${post.title}`}
+                            className="w-full h-56 object-cover"
+                          />
+                        ) : (
+                          <Image
+                            src={post.thumbnail}
+                            alt={`Imagem de capa do post: ${post.title}`}
+                            width={640}
+                            height={320}
+                            className="w-full h-56 object-cover"
+                          />
+                        )
                       )}
                       <div className="p-6 flex-1 flex flex-col justify-between">
                         {post.category && (

--- a/app/blog/components/BlogSidebar.tsx
+++ b/app/blog/components/BlogSidebar.tsx
@@ -2,6 +2,7 @@
 
 import Link from "next/link";
 import Image from "next/image";
+import { isExternalUrl } from "@/utils/isExternalUrl";
 import { useEffect, useState } from "react";
 import { useSearchParams } from "next/navigation";
 
@@ -80,13 +81,22 @@ export default function BlogSidebar() {
           {popular.map((post) => (
             <li key={post.slug} className="flex items-center gap-3">
               {post.thumbnail && (
-                <Image
-                  src={post.thumbnail}
-                  alt={post.title}
-                  width={48}
-                  height={48}
-                  className="w-12 h-12 object-cover rounded-md"
-                />
+                isExternalUrl(post.thumbnail) ? (
+                  // eslint-disable-next-line @next/next/no-img-element
+                  <img
+                    src={post.thumbnail}
+                    alt={post.title}
+                    className="w-12 h-12 object-cover rounded-md"
+                  />
+                ) : (
+                  <Image
+                    src={post.thumbnail}
+                    alt={post.title}
+                    width={48}
+                    height={48}
+                    className="w-12 h-12 object-cover rounded-md"
+                  />
+                )
               )}
               <Link
                 href={`/blog/post/${post.slug}`}

--- a/app/blog/components/PostSuggestions.tsx
+++ b/app/blog/components/PostSuggestions.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import Image from "next/image";
+import { isExternalUrl } from "@/utils/isExternalUrl";
 
 interface Post {
   slug: string;
@@ -31,13 +32,22 @@ export default function PostSuggestions({ posts }: PostSuggestionsProps) {
               href={`/blog/post/${post.slug}`}
               className="block bg-white border border-gray-200 rounded-2xl shadow-sm hover:shadow-md transition overflow-hidden"
             >
-              <Image
-                src={post.thumbnail}
-                alt={`Thumbnail de ${post.title}`}
-                width={640}
-                height={320}
-                className="w-full h-48 object-cover"
-              />
+              {isExternalUrl(post.thumbnail) ? (
+                // eslint-disable-next-line @next/next/no-img-element
+                <img
+                  src={post.thumbnail}
+                  alt={`Thumbnail de ${post.title}`}
+                  className="w-full h-48 object-cover"
+                />
+              ) : (
+                <Image
+                  src={post.thumbnail}
+                  alt={`Thumbnail de ${post.title}`}
+                  width={640}
+                  height={320}
+                  className="w-full h-48 object-cover"
+                />
+              )}
               <div className="p-4 flex flex-col h-full">
                 <span className="text-xs text-blue-600 uppercase mb-2">
                   {post.category}

--- a/app/blog/post/[slug]/page.tsx
+++ b/app/blog/post/[slug]/page.tsx
@@ -109,15 +109,22 @@ export default async function BlogPostPage({
       >
         {data.thumbnail && (
           <figure>
-            <Image
-              src={
-                isExternalUrl(data.thumbnail) ? data.thumbnail : data.thumbnail
-              }
-              alt={`Imagem de capa: ${data.title}`}
-              width={1200}
-              height={600}
-              className="w-full max-w-[640px] max-h-[360px] object-cover rounded-xl mx-auto mb-6"
-            />
+            {isExternalUrl(data.thumbnail) ? (
+              // eslint-disable-next-line @next/next/no-img-element
+              <img
+                src={data.thumbnail}
+                alt={`Imagem de capa: ${data.title}`}
+                className="w-full max-w-[640px] max-h-[360px] object-cover rounded-xl mx-auto mb-6"
+              />
+            ) : (
+              <Image
+                src={data.thumbnail}
+                alt={`Imagem de capa: ${data.title}`}
+                width={1200}
+                height={600}
+                className="w-full max-w-[640px] max-h-[360px] object-cover rounded-xl mx-auto mb-6"
+              />
+            )}
             {data.credit && (
               <figcaption className="text-sm text-neutral-500 text-center mt-2 italic">
                 {data.credit}


### PR DESCRIPTION
## Summary
- add GET handler for `/admin/api/posts/[slug]` to read MDX files with frontmatter
- auto-fill edit form using fetched post data
- show full blog post preview with header and footer
- display external post images without requiring domains in Next.js config

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6844844eb4f8832cad0f258d501ab9a3