### PR TITLE
Add configuration page

### DIFF
--- a/app/admin/components/Header.tsx
+++ b/app/admin/components/Header.tsx
@@ -18,6 +18,7 @@ import {
 } from "lucide-react";
 import { useState } from "react";
 import { useTheme } from "@/lib/context/ThemeContext";
+import { useAppConfig } from "@/lib/context/AppConfigContext";
 import RedefinirSenhaModal from "./RedefinirSenhaModal";
 
 const getNavLinks = (role?: string) => {
@@ -48,6 +49,7 @@ export default function Header() {
   const [perfilAberto, setPerfilAberto] = useState(false);
   const [mostrarModalSenha, setMostrarModalSenha] = useState(false);
   const { theme, toggleTheme } = useTheme();
+  const { config } = useAppConfig();
 
   const navLinks = getNavLinks(user?.role);
 
@@ -63,7 +65,7 @@ export default function Header() {
       <div className="flex justify-between items-center px-6 py-4 max-w-7xl mx-auto">
         <Link href="/" className="flex items-center">
           <Image
-            src="/img/logo_umadeus_branco.png"
+            src={config.logoUrl || "/img/logo_umadeus_branco.png"}
             alt="Logotipo UMADEUS"
             width={160}
             height={40}
@@ -125,6 +127,14 @@ export default function Header() {
                       className="flex items-center gap-2 px-4 py-2 hover:bg-zinc-100 dark:hover:bg-zinc-800 cursor-pointer"
                     >
                       <User size={16} /> Visualizar perfil
+                    </Link>
+                  </li>
+                  <li>
+                    <Link
+                      href="/admin/configuracoes"
+                      className="flex items-center gap-2 px-4 py-2 hover:bg-zinc-100 dark:hover:bg-zinc-800 cursor-pointer"
+                    >
+                      Configurações
                     </Link>
                   </li>
                   <li>
@@ -197,6 +207,13 @@ export default function Header() {
                   className="px-4 py-2 text-sm hover:bg-[var(--background)] hover:text-[var(--foreground)]"
                 >
                   Perfil
+                </Link>
+                <Link
+                  href="/admin/configuracoes"
+                  onClick={() => setMenuAberto(false)}
+                  className="px-4 py-2 text-sm hover:bg-[var(--background)] hover:text-[var(--foreground)]"
+                >
+                  Configurações
                 </Link>
                 <button
                   onClick={() => {

--- a/app/admin/configuracoes/page.tsx
+++ b/app/admin/configuracoes/page.tsx
@@ -1,0 +1,72 @@
+"use client";
+import { useState, useRef, ChangeEvent } from "react";
+import { useAppConfig } from "@/lib/context/AppConfigContext";
+import Image from "next/image";
+
+export default function ConfiguracoesPage() {
+  const { config, updateConfig } = useAppConfig();
+  const [font, setFont] = useState(config.font);
+  const [primaryColor, setPrimaryColor] = useState(config.primaryColor);
+  const [logoUrl, setLogoUrl] = useState(config.logoUrl);
+  const fileRef = useRef<HTMLInputElement>(null);
+
+  const handleLogoChange = (e: ChangeEvent<HTMLInputElement>) => {
+    const file = e.target.files?.[0];
+    if (!file) return;
+    const reader = new FileReader();
+    reader.onload = () => {
+      const url = reader.result as string;
+      setLogoUrl(url);
+      updateConfig({ logoUrl: url });
+    };
+    reader.readAsDataURL(file);
+  };
+
+  const handleSave = () => {
+    updateConfig({ font, primaryColor, logoUrl });
+  };
+
+  return (
+    <div className="max-w-xl mx-auto p-6 space-y-6">
+      <h1 className="text-2xl font-bold">Configurações do App</h1>
+      <div className="space-y-4">
+        <label className="block">
+          <span className="block mb-1">Fonte</span>
+          <select
+            value={font}
+            onChange={(e) => setFont(e.target.value)}
+            className="input-base"
+          >
+            <option value="var(--font-geist)">Geist</option>
+            <option value="var(--font-bebas)">Bebas Neue</option>
+            <option value="Arial, sans-serif">Arial</option>
+          </select>
+        </label>
+        <label className="block">
+          <span className="block mb-1">Cor Primária</span>
+          <input
+            type="color"
+            value={primaryColor}
+            onChange={(e) => setPrimaryColor(e.target.value)}
+            className="w-16 h-8 p-0 border-none"
+          />
+        </label>
+        <label className="block">
+          <span className="block mb-1">Logo</span>
+          <input
+            ref={fileRef}
+            type="file"
+            accept="image/*"
+            onChange={handleLogoChange}
+          />
+        </label>
+        {logoUrl && (
+          <Image src={logoUrl} alt="Logo" width={64} height={64} className="h-16 w-auto" />
+        )}
+      </div>
+      <button onClick={handleSave} className="btn btn-primary">
+        Salvar
+      </button>
+    </div>
+  );
+}

--- a/app/components/Header.tsx
+++ b/app/components/Header.tsx
@@ -5,6 +5,7 @@ import { Menu, X, ChevronDown } from "lucide-react";
 import Link from "next/link";
 import Image from "next/image"; // se quiser exibir logo
 import { useAuthContext } from "@/lib/context/AuthContext";
+import { useAppConfig } from "@/lib/context/AppConfigContext";
 
 type UserRole = "visitante" | "usuario" | "lider" | "coordenador";
 
@@ -21,6 +22,7 @@ export default function Header() {
   const [open, setOpen] = useState(false);
   const [adminOpen, setAdminOpen] = useState(false);
   const { user, isLoggedIn } = useAuthContext();
+  const { config } = useAppConfig();
 
   const role: UserRole = useMemo(() => {
     if (!isLoggedIn) return "visitante";
@@ -69,7 +71,7 @@ export default function Header() {
           aria-label="Página inicial"
         >
           <Image
-            src="/img/logo_umadeus_branco.png"
+            src={config.logoUrl || "/img/logo_umadeus_branco.png"}
             alt="UMADEUS"
             width={36}
             height={36}

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -3,6 +3,7 @@ import "./globals.css";
 import { AuthProvider } from "@/lib/context/AuthContext";
 import { ThemeProvider } from "@/lib/context/ThemeContext";
 import { ToastProvider } from "@/lib/context/ToastContext";
+import { AppConfigProvider } from "@/lib/context/AppConfigContext";
 import { Geist, Geist_Mono, Bebas_Neue } from "next/font/google";
 
 // Inicialize as fontes
@@ -32,13 +33,15 @@ export default function RootLayout({
   return (
     <html lang="pt-BR">
       <body className={`font-sans antialiased ${geistSans.variable} ${geistMono.variable} ${bebas.variable}`}>
-        <ThemeProvider>
-          <AuthProvider>
-            <ToastProvider>
-              {children}
-            </ToastProvider>
-          </AuthProvider>
-        </ThemeProvider>
+        <AppConfigProvider>
+          <ThemeProvider>
+            <AuthProvider>
+              <ToastProvider>
+                {children}
+              </ToastProvider>
+            </AuthProvider>
+          </ThemeProvider>
+        </AppConfigProvider>
       </body>
     </html>
   );

--- a/docs/design-system.md
+++ b/docs/design-system.md
@@ -140,3 +140,10 @@ export const Padrão = () => <MeuBotao />;
 
 Execute `npm run storybook` para iniciar a interface e validar os componentes.
 Qualquer novo token ou componente deve ter uma história correspondente.
+
+## Personalização
+
+O portal permite ajustar fonte, cor primária e logotipo dinamicamente. As
+configurações são gerenciadas pelo `AppConfigProvider` (`lib/context/AppConfigContext.tsx`),
+que salva as preferências no `localStorage` e aplica os valores às variáveis CSS
+`--font-body`, `--font-heading` e `--accent`.

--- a/lib/context/AppConfigContext.tsx
+++ b/lib/context/AppConfigContext.tsx
@@ -1,0 +1,53 @@
+"use client";
+import { createContext, useContext, useEffect, useState } from "react";
+
+export type AppConfig = {
+  font: string;
+  primaryColor: string;
+  logoUrl: string;
+};
+
+const defaultConfig: AppConfig = {
+  font: "var(--font-geist)",
+  primaryColor: "#7c3aed",
+  logoUrl: "/img/logo_umadeus_branco.png",
+};
+
+type AppConfigContextType = {
+  config: AppConfig;
+  updateConfig: (cfg: Partial<AppConfig>) => void;
+};
+
+const AppConfigContext = createContext<AppConfigContextType>({
+  config: defaultConfig,
+  updateConfig: () => {},
+});
+
+export function AppConfigProvider({ children }: { children: React.ReactNode }) {
+  const [config, setConfig] = useState<AppConfig>(defaultConfig);
+
+  useEffect(() => {
+    const stored = localStorage.getItem("app_config");
+    if (stored) setConfig(JSON.parse(stored));
+  }, []);
+
+  useEffect(() => {
+    localStorage.setItem("app_config", JSON.stringify(config));
+    document.documentElement.style.setProperty("--font-body", config.font);
+    document.documentElement.style.setProperty("--font-heading", config.font);
+    document.documentElement.style.setProperty("--accent", config.primaryColor);
+  }, [config]);
+
+  const updateConfig = (cfg: Partial<AppConfig>) =>
+    setConfig((prev) => ({ ...prev, ...cfg }));
+
+  return (
+    <AppConfigContext.Provider value={{ config, updateConfig }}>
+      {children}
+    </AppConfigContext.Provider>
+  );
+}
+
+export function useAppConfig() {
+  return useContext(AppConfigContext);
+}

--- a/logs/DOC_LOG.md
+++ b/logs/DOC_LOG.md
@@ -28,3 +28,4 @@
 ## [2025-06-07] Documentada classe `.heading` e exemplo de uso em docs/design-system.md.
 ## [2025-06-07] Atualizado arquitetura.md incluindo se\xC3\xA7\xC3\xA3o do Blog e nova estrutura de pastas.
 ## [2025-06-07] Ajustado processo de tipagem na rota loja/categorias/[slug].
+## [2025-06-07] Documentada personalização via AppConfigProvider em docs/design-system.md.


### PR DESCRIPTION
## Summary
- add app config context
- allow custom font, color and logo
- show custom logo in headers
- link config page in admin menu
- wrap layout with config provider
- document customization via AppConfigProvider
- apply heading font variable

## Testing
- `npm run lint`
- `npm run test` *(fails: waiting for file changes, aborted)*

------
https://chatgpt.com/codex/tasks/task_e_684498d5b634832ca6b97cfb2622145b