### PR TITLE
Implement dynamic primary color shades

### DIFF
--- a/app/admin/posts/editar/[slug]/page.tsx
+++ b/app/admin/posts/editar/[slug]/page.tsx
@@ -94,7 +94,7 @@ export default function EditarPostPage() {
           )}
 
           {category && (
-            <span className="text-xs uppercase text-primary-600 font-semibold">
+            <span className="text-xs uppercase text-[var(--primary-600)] font-semibold">
               {category}
             </span>
           )}

--- a/app/blog/post/[slug]/page.tsx
+++ b/app/blog/post/[slug]/page.tsx
@@ -134,7 +134,7 @@ export default async function BlogPostPage({
         )}
 
         {data.category && (
-          <span className="text-xs uppercase text-primary-600 font-semibold">
+          <span className="text-xs uppercase text-[var(--primary-600)] font-semibold">
             {data.category}
           </span>
         )}
@@ -166,7 +166,7 @@ export default async function BlogPostPage({
             )}`}
             target="_blank"
             rel="noopener noreferrer"
-            className="flex items-center gap-1 text-primary-600 hover:underline"
+            className="flex items-center gap-1 text-[var(--primary-600)] hover:underline"
           >
             <Share2 className="w-4 h-4" />
             Compartilhar

--- a/app/components/Header.tsx
+++ b/app/components/Header.tsx
@@ -85,7 +85,7 @@ export default function Header() {
             <Link
               key={link.href}
               href={link.href}
-              className="hover:text-primary-400 transition px-2 py-1 rounded-md"
+              className="hover:text-[var(--primary-400)] transition px-2 py-1 rounded-md"
             >
               {link.label}
             </Link>
@@ -95,7 +95,7 @@ export default function Header() {
             <div className="relative">
               <button
                 onClick={() => setAdminOpen((prev) => !prev)}
-                className="flex items-center gap-1 hover:text-primary-400 transition px-2 py-1 rounded-md"
+                className="flex items-center gap-1 hover:text-[var(--primary-400)] transition px-2 py-1 rounded-md"
               >
                 {isLoggedIn && (
                   <span className="ml-4 text-sm">Olá, {firstName}</span>
@@ -137,7 +137,7 @@ export default function Header() {
             <Link
               key={link.href}
               href={link.href}
-              className="text-platinum hover:text-primary-400 transition py-2 text-base font-medium"
+              className="text-platinum hover:text-[var(--primary-400)] transition py-2 text-base font-medium"
               onClick={() => setOpen(false)}
             >
               {link.label}
@@ -151,7 +151,7 @@ export default function Header() {
                 <Link
                   key={link.href}
                   href={link.href}
-                  className="text-platinum hover:text-primary-400 transition py-2 text-base font-medium"
+                  className="text-platinum hover:text-[var(--primary-400)] transition py-2 text-base font-medium"
                   onClick={() => setOpen(false)}
                 >
                   {link.label}

--- a/app/globals.css
+++ b/app/globals.css
@@ -133,7 +133,7 @@ p {
 }
 
 .btn-primary {
-  @apply bg-[var(--accent)] text-white hover:bg-primary-700;
+  @apply bg-[var(--accent)] text-white hover:bg-[var(--primary-700)];
 }
 
 .btn-secondary {

--- a/app/loja/inscricoes/page.tsx
+++ b/app/loja/inscricoes/page.tsx
@@ -249,7 +249,7 @@ export default function InscricaoPage() {
 
         <button
           type="submit"
-          className="w-full bg-primary-600 hover:bg-primary-700 text-white font-semibold py-3 px-6 rounded-lg uppercase transition"
+          className="w-full bg-[var(--primary-600)] hover:bg-[var(--primary-700)] text-white font-semibold py-3 px-6 rounded-lg uppercase transition"
           disabled={status === "sending"}
         >
           {status === "sending" ? "Enviando..." : "Enviar inscrição"}

--- a/app/loja/page.tsx
+++ b/app/loja/page.tsx
@@ -90,7 +90,7 @@ export default function Home() {
                 onClick={() => setSection(s)}
                 className={`px-4 py-1 rounded-full transition font-bold ${
                   section === s
-                    ? "bg-primary-600 text-white"
+                    ? "bg-[var(--primary-600)] text-white"
                     : "bg-transparent text-platinum"
                 }`}
               >
@@ -136,7 +136,7 @@ export default function Home() {
 
               <Link
                 href="/loja/inscricoes"
-                className="inline-block bg-primary-600 hover:bg-primary-700 text-white px-8 py-3 rounded-full font-semibold transition"
+                className="inline-block bg-[var(--primary-600)] hover:bg-[var(--primary-700)] text-white px-8 py-3 rounded-full font-semibold transition"
               >
                 Inscreva-se agora
               </Link>
@@ -208,7 +208,7 @@ export default function Home() {
 
             <Link
               href="/loja/produtos"
-              className="inline-block mt-2 px-8 py-3 rounded-full font-semibold transition transform hover:scale-105 shadow-lg text-lg bg-primary-600 text-white hover:bg-primary-700"
+              className="inline-block mt-2 px-8 py-3 rounded-full font-semibold transition transform hover:scale-105 shadow-lg text-lg bg-[var(--primary-600)] text-white hover:bg-[var(--primary-700)]"
             >
               {content.bannerButton}
             </Link>

--- a/app/loja/produtos/page.tsx
+++ b/app/loja/produtos/page.tsx
@@ -61,7 +61,7 @@ export default function ProdutoPage() {
     <main className="font-sans px-4 md:px-16 py-10">
       <a
         href="/loja"
-        className="text-sm text-platinum hover:text-primary-600 mb-6 inline-block transition"
+        className="text-sm text-platinum hover:text-[var(--primary-600)] mb-6 inline-block transition"
       >
         &lt; voltar
       </a>
@@ -87,7 +87,7 @@ export default function ProdutoPage() {
                 onClick={() => handleMiniaturaClick(i)}
                 className={`w-16 h-16 object-cover rounded-lg border-2 cursor-pointer transition ${
                   indexImg === i
-                    ? "border-primary-600 ring-2 ring-primary-600"
+                    ? "border-[var(--primary-600)] ring-2 ring-[var(--primary-600)]"
                     : "border-black_bean hover:brightness-110"
                 }`}
               />
@@ -97,7 +97,7 @@ export default function ProdutoPage() {
 
         {/* Detalhes do produto */}
         <div className="space-y-6">
-          <h1 className="font-bebas text-primary-600 text-3xl md:text-4xl font-bold leading-tight">
+          <h1 className="font-bebas text-[var(--primary-600)] text-3xl md:text-4xl font-bold leading-tight">
             Camiseta Stanton — Edição Congresso UMADEUS
           </h1>
           <p className="text-xl font-semibold text-platinum">R$ 129,90</p>
@@ -116,7 +116,7 @@ export default function ProdutoPage() {
                   }}
                   className={`px-4 py-1 rounded-full border font-medium transition ${
                     generoSelecionado === g
-                      ? "bg-primary-600 text-white"
+                      ? "bg-[var(--primary-600)] text-white"
                       : "border-platinum/30 text-platinum hover:bg-black_bean"
                   }`}
                 >
@@ -138,7 +138,7 @@ export default function ProdutoPage() {
                   onClick={() => setTamanhoSelecionado(t)}
                   className={`px-3 py-1 border rounded-full text-sm transition ${
                     tamanhoSelecionado === t
-                      ? "bg-primary-600 text-white font-bold"
+                      ? "bg-[var(--primary-600)] text-white font-bold"
                       : "border-platinum/30 text-platinum hover:bg-black_bean"
                   }`}
                 >
@@ -148,7 +148,7 @@ export default function ProdutoPage() {
             </div>
             <a
               href="#"
-              className="text-xs underline mt-2 inline-block text-platinum/60 hover:text-primary-600 transition"
+              className="text-xs underline mt-2 inline-block text-platinum/60 hover:text-[var(--primary-600)] transition"
             >
               Ver guia de tamanhos
             </a>
@@ -159,7 +159,7 @@ export default function ProdutoPage() {
             href={checkoutLink}
             target="_blank"
             rel="noopener noreferrer"
-            className="block w-full bg-primary-600 hover:bg-primary-700 text-white text-center py-3 rounded-full font-semibold transition text-lg"
+            className="block w-full bg-[var(--primary-600)] hover:bg-[var(--primary-700)] text-white text-center py-3 rounded-full font-semibold transition text-lg"
           >
             Quero essa pra brilhar no Congresso!
           </a>

--- a/docs/design-system.md
+++ b/docs/design-system.md
@@ -145,5 +145,8 @@ Qualquer novo token ou componente deve ter uma história correspondente.
 
 O portal permite ajustar fonte, cor primária e logotipo dinamicamente. As
 configurações são gerenciadas pelo `AppConfigProvider` (`lib/context/AppConfigContext.tsx`),
-que salva as preferências no `localStorage` e aplica os valores às variáveis CSS
-`--font-body`, `--font-heading` e `--accent`.
+que salva as preferências no `localStorage`.
+Além de definir `--accent`, o provedor gera uma paleta HSL e expõe as variáveis
+`--primary-50` … `--primary-900`. As classes Tailwind utilizam essas variáveis
+(`bg-[var(--primary-600)]`, `text-[var(--primary-500)]`, etc.), permitindo que
+a interface se adapte à cor escolhida.

--- a/lib/context/AppConfigContext.tsx
+++ b/lib/context/AppConfigContext.tsx
@@ -1,5 +1,6 @@
 "use client";
 import { createContext, useContext, useEffect, useState } from "react";
+import { generateHslShades } from "@/utils/colorShades";
 
 export type AppConfig = {
   font: string;
@@ -36,6 +37,10 @@ export function AppConfigProvider({ children }: { children: React.ReactNode }) {
     document.documentElement.style.setProperty("--font-body", config.font);
     document.documentElement.style.setProperty("--font-heading", config.font);
     document.documentElement.style.setProperty("--accent", config.primaryColor);
+    const shades = generateHslShades(config.primaryColor);
+    Object.entries(shades).forEach(([key, value]) => {
+      document.documentElement.style.setProperty(`--primary-${key}`, value);
+    });
   }, [config]);
 
   const updateConfig = (cfg: Partial<AppConfig>) =>

--- a/logs/DOC_LOG.md
+++ b/logs/DOC_LOG.md
@@ -31,3 +31,4 @@
 ## [2025-06-07] Documentada correção do carregamento de inscrições ao subscrever mudanças de autenticação.
 ## [2025-06-07] Documentada correção do loop infinito em admin/perfil no ERR_LOG
 ## [2025-06-07] Documentada personalização via AppConfigProvider em docs/design-system.md.
+## [2025-06-07] Geradas variáveis CSS dinâmicas de cor e mapeamento via Tailwind. Documentação atualizada.

--- a/stories/Header.tsx
+++ b/stories/Header.tsx
@@ -24,11 +24,11 @@ export const Header = ({ user, onLogin, onLogout, onCreateAccount }: HeaderProps
             />
             <path
               d="M5.3 10.6l10.4 6v11.1l-10.4-6v-11zm11.4-6.2l9.7 5.5-9.7 5.6V4.4z"
-              className="fill-primary-600"
+              className="fill-[var(--primary-600)]"
             />
             <path
               d="M27.2 10.6v11.2l-10.5 6V16.5l10.5-6zM15.7 4.4v11L6 10l9.7-5.5z"
-              className="fill-primary-300"
+              className="fill-[var(--primary-300)]"
             />
           </g>
         </svg>

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -1,4 +1,13 @@
 /** @type {import('tailwindcss').Config} */
+const withOpacityValue = (variable) => {
+  return ({ opacityValue }) => {
+    if (opacityValue !== undefined) {
+      return `hsl(var(${variable}) / ${opacityValue})`;
+    }
+    return `hsl(var(${variable}))`;
+  };
+};
+
 module.exports = {
   darkMode: 'class',
   content: [
@@ -10,16 +19,16 @@ module.exports = {
     extend: {
       colors: {
         primary: {
-          50: "#f5f3ff",
-          100: "#ede9fe",
-          200: "#ddd6fe",
-          300: "#c4b5fd",
-          400: "#a78bfa",
-          500: "#8b5cf6", // roxo vibrante
-          600: "#7c3aed", // principal
-          700: "#6d28d9",
-          800: "#5b21b6",
-          900: "#4c1d95",
+          50: withOpacityValue('--primary-50'),
+          100: withOpacityValue('--primary-100'),
+          200: withOpacityValue('--primary-200'),
+          300: withOpacityValue('--primary-300'),
+          400: withOpacityValue('--primary-400'),
+          500: withOpacityValue('--primary-500'),
+          600: withOpacityValue('--primary-600'),
+          700: withOpacityValue('--primary-700'),
+          800: withOpacityValue('--primary-800'),
+          900: withOpacityValue('--primary-900'),
         },
         error: {
           DEFAULT: "#dc2626",

--- a/utils/colorShades.ts
+++ b/utils/colorShades.ts
@@ -1,0 +1,59 @@
+export function hexToHsl(hex: string): [number, number, number] {
+  hex = hex.replace('#', '');
+  if (hex.length === 3) {
+    hex = hex.split('').map((c) => c + c).join('');
+  }
+  const r = parseInt(hex.substring(0, 2), 16) / 255;
+  const g = parseInt(hex.substring(2, 4), 16) / 255;
+  const b = parseInt(hex.substring(4, 6), 16) / 255;
+
+  const max = Math.max(r, g, b);
+  const min = Math.min(r, g, b);
+  let h = 0;
+  let s = 0;
+  const l = (max + min) / 2;
+
+  if (max !== min) {
+    const d = max - min;
+    s = l > 0.5 ? d / (2 - max - min) : d / (max + min);
+    switch (max) {
+      case r:
+        h = (g - b) / d + (g < b ? 6 : 0);
+        break;
+      case g:
+        h = (b - r) / d + 2;
+        break;
+      case b:
+        h = (r - g) / d + 4;
+        break;
+    }
+    h /= 6;
+  }
+
+  return [Math.round(h * 360), Math.round(s * 100), Math.round(l * 100)];
+}
+
+export function generateHslShades(hex: string): Record<string, string> {
+  const [h, s, l] = hexToHsl(hex);
+  const steps: Record<string, number> = {
+    50: 42,
+    100: 32,
+    200: 24,
+    300: 16,
+    400: 8,
+    500: 4,
+    600: 0,
+    700: -8,
+    800: -16,
+    900: -24,
+  };
+
+  const shades: Record<string, string> = {};
+  Object.keys(steps).forEach((key) => {
+    const delta = steps[key];
+    const newL = Math.max(0, Math.min(100, l + delta));
+    shades[key] = `${h} ${s}% ${newL}%`;
+  });
+
+  return shades;
+}


### PR DESCRIPTION
## Summary
- generate HSL color shades from a base HEX color
- expose shades in `AppConfigProvider`
- reference shades with CSS variables in pages and components
- map `primary-*` colors in Tailwind to CSS variables
- document dynamic theming behaviour
- log documentation update

## Testing
- `npm run lint` *(fails: next not found)*
- `npm run test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6844a256e7f4832c896b016d4f0ea2ef