### PR TITLE
fix(config): guard css variable application for ssr

### DIFF
--- a/__tests__/appConfigSSR.test.ts
+++ b/__tests__/appConfigSSR.test.ts
@@ -1,0 +1,17 @@
+import { describe, it, expect } from 'vitest'
+import { renderToString } from 'react-dom/server'
+import { AppConfigProvider } from '../lib/context/AppConfigContext'
+
+describe('AppConfigProvider SSR', () => {
+  it('renders without crashing in a server environment', () => {
+    const render = () =>
+      renderToString(
+        require('react').createElement(
+          AppConfigProvider,
+          null,
+          require('react').createElement('div', null, 'SSR')
+        )
+      )
+    expect(render).not.toThrow()
+  })
+})

--- a/lib/context/AppConfigContext.tsx
+++ b/lib/context/AppConfigContext.tsx
@@ -1,5 +1,5 @@
 "use client";
-import { createContext, useContext, useEffect, useState } from "react";
+import React, { createContext, useContext, useEffect, useState } from "react";
 
 export type AppConfig = {
   font: string;
@@ -32,10 +32,13 @@ export function AppConfigProvider({ children }: { children: React.ReactNode }) {
   }, []);
 
   useEffect(() => {
+    if (typeof window === "undefined") return;
+
     localStorage.setItem("app_config", JSON.stringify(config));
-    document.documentElement.style.setProperty("--font-body", config.font);
-    document.documentElement.style.setProperty("--font-heading", config.font);
-    document.documentElement.style.setProperty("--accent", config.primaryColor);
+    const doc = document.documentElement;
+    doc.style.setProperty("--font-body", config.font);
+    doc.style.setProperty("--font-heading", config.font);
+    doc.style.setProperty("--accent", config.primaryColor);
   }, [config]);
 
   const updateConfig = (cfg: Partial<AppConfig>) =>

--- a/logs/DOC_LOG.md
+++ b/logs/DOC_LOG.md
@@ -31,3 +31,5 @@
 ## [2025-06-07] Documentada correção do carregamento de inscrições ao subscrever mudanças de autenticação.
 ## [2025-06-07] Documentada correção do loop infinito em admin/perfil no ERR_LOG
 ## [2025-06-07] Documentada personalização via AppConfigProvider em docs/design-system.md.
+
+## [2025-06-07] Documentada protecao de SSR no AppConfigProvider.


### PR DESCRIPTION
## Summary
- ensure CSS variable updates only run in browser
- add SSR rendering test for AppConfigProvider
- log documentation update

## Testing
- `npx vitest run`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6844a2583cb8832cb1e54c00ebf3287f