### PR TITLE
docs: include portal area in architecture

### DIFF
--- a/arquitetura.md
+++ b/arquitetura.md
@@ -6,10 +6,11 @@ Este documento descreve a **arquitetura de pastas e responsabilidades** do proje
 
 ## 🧭 Visão Geral
 
-O projeto é dividido logicamente em duas áreas:
+O projeto é dividido logicamente em quatro áreas:
 
 | Área        | Função Principal                         | Acesso            | Público-alvo            |
 |-------------|-------------------------------------------|-------------------|-------------------------|
+| **Portal**  | Página institucional do cliente           | Público           | Membros, visitantes, geral |
 | **Loja**    | Página pública para venda e inscrições    | Público           | Visitantes e inscritos  |
 | **Admin**   | Painel de gestão e controle de dados      | Privado (auth)    | Coordenadores e líderes |
 | **Blog**    | Página pública para postagens de conteúdo | Público           | Visitantes e inscritos  |
@@ -49,6 +50,7 @@ Todas coexistem no mesmo projeto Next.js (App Router) hospedado na **Vercel**.
 │   ├── layout.tsx         # Layout público da loja
 │   └── page.tsx           # Home da loja
 ├── layout.tsx             # Layout raiz compartilhado
+├── page.tsx               # Portal do cliente (institucional)
 ├── globals.css            # CSS global compartilhado
 /posts/                    # Conteúdo do blog em arquivos .mdx
 /scripts/                  # Scripts auxiliares
@@ -56,6 +58,13 @@ Todas coexistem no mesmo projeto Next.js (App Router) hospedado na **Vercel**.
 ```
 
 ---
+
+## 🌐 Portal – Boas Práticas
+
+- Mantém a identidade visual do cliente de forma *white label*
+- Permite customização de logo e cores via painel admin (`/admin/configuracoes`)
+- Integra navegação para Loja, Admin e Blog
+- Detalhes em [docs/design-system.md](docs/design-system.md#personalizacao)
 
 ## 🛍️ Loja – Boas Práticas
 

--- a/logs/DOC_LOG.md
+++ b/logs/DOC_LOG.md
@@ -31,3 +31,4 @@
 ## [2025-06-07] Documentada correção do carregamento de inscrições ao subscrever mudanças de autenticação.
 ## [2025-06-07] Documentada correção do loop infinito em admin/perfil no ERR_LOG
 ## [2025-06-07] Documentada personalização via AppConfigProvider em docs/design-system.md.
+## [2025-06-07] Portal adicionado na arquitetura e boas práticas ajustadas.


### PR DESCRIPTION
## Summary
- add Portal to table of areas with access info
- document Portal best practices and customisation via admin
- log documentation update

## Testing
- `npm run lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_6844a3a829b4832c8a3ca1b2e64e7dc8