### PR TITLE
Fix fetch mock Response types

### DIFF
--- a/stories/BlogHeroCarousel.stories.tsx
+++ b/stories/BlogHeroCarousel.stories.tsx
@@ -53,7 +53,13 @@ type Story = StoryObj<typeof meta>;
 const FetchWrapper = ({ posts, children }: { posts: Post[]; children: React.ReactNode }) => {
   useEffect(() => {
     const original = global.fetch;
-    global.fetch = () => Promise.resolve({ json: async () => posts });
+    global.fetch = () =>
+      Promise.resolve(
+        new Response(JSON.stringify(posts), {
+          status: 200,
+          headers: { "Content-Type": "application/json" },
+        })
+      );
     return () => {
       global.fetch = original;
     };

--- a/stories/BlogSidebar.stories.tsx
+++ b/stories/BlogSidebar.stories.tsx
@@ -46,7 +46,12 @@ const FetchWrapper = ({ posts, children }: { posts: Post[]; children: React.Reac
   useEffect(() => {
     const original = global.fetch;
     global.fetch = () =>
-      Promise.resolve({ json: async () => posts });
+      Promise.resolve(
+        new Response(JSON.stringify(posts), {
+          status: 200,
+          headers: { "Content-Type": "application/json" },
+        })
+      );
     return () => {
       global.fetch = original;
     };


### PR DESCRIPTION
## Summary
- adjust fetch mocks to return `Response` in blog stories

## Testing
- `npm run lint`
- `npm run test`

------
https://chatgpt.com/codex/tasks/task_e_6844a3e62964832ca9263a38b78aa64e