### PR TITLE
fix(stories): type posts arg and log error

### DIFF
--- a/app/admin/components/DashboardAnalytics.tsx
+++ b/app/admin/components/DashboardAnalytics.tsx
@@ -6,7 +6,7 @@ import dynamic from "next/dynamic";
 import { saveAs } from "file-saver";
 import * as XLSX from "xlsx";
 import type { Inscricao, Pedido } from "@/types";
-import colors from "@/utils/twColors";
+import twColors from "@/utils/twColors";
 
 const LineChart = dynamic(() => import("react-chartjs-2").then((m) => m.Line), {
   ssr: false,
@@ -59,7 +59,7 @@ export default function DashboardAnalytics({ inscricoes, pedidos }: DashboardAna
         label: "Inscrições",
         data: inscricoesData.data,
         fill: true,
-        borderColor: colors.primary600,
+        borderColor: twColors.primary600,
         backgroundColor: "rgba(124,58,237,0.2)",
       },
     ],
@@ -72,7 +72,7 @@ export default function DashboardAnalytics({ inscricoes, pedidos }: DashboardAna
         label: "Pedidos",
         data: pedidosData.data,
         fill: true,
-        borderColor: colors.blue500,
+        borderColor: twColors.blue500,
         backgroundColor: "rgba(14,165,233,0.2)",
       },
     ],
@@ -105,7 +105,7 @@ export default function DashboardAnalytics({ inscricoes, pedidos }: DashboardAna
       {
         label: "Arrecadação (R$)",
         data: arrecadacaoLabels.map((l) => arrecadacaoCampo[l]),
-        backgroundColor: colors.primary600,
+        backgroundColor: twColors.primary600,
       },
     ],
   };

--- a/app/admin/dashboard/components/DashboardResumo.tsx
+++ b/app/admin/dashboard/components/DashboardResumo.tsx
@@ -3,7 +3,7 @@
 import dynamic from "next/dynamic";
 import { useEffect } from "react";
 import { setupCharts } from "@/lib/chartSetup";
-import colors from "@/utils/twColors";
+import twColors from "@/utils/twColors";
 import { Info } from "lucide-react";
 import Tippy from "@tippyjs/react";
 import "tippy.js/dist/tippy.css";
@@ -68,7 +68,7 @@ export default function DashboardResumo({
       {
         label: "Inscrições",
         data: inscricoes.map(() => 1),
-        backgroundColor: colors.primary600,
+        backgroundColor: twColors.primary600,
       },
     ],
   };
@@ -87,9 +87,9 @@ export default function DashboardResumo({
           label: `Pedidos (${filtroStatus})`,
           data: Object.values(contagem),
           backgroundColor: [
-            colors.primary600,
-            colors.error600,
-            colors.blue500,
+            twColors.primary600,
+            twColors.error600,
+            twColors.blue500,
           ],
         },
       ],

--- a/logs/ERR_LOG.md
+++ b/logs/ERR_LOG.md
@@ -1,3 +1,5 @@
 ## [2025-06-07] Corrigido erro de importacao no blog - dev - 1f6facf
 ## [2025-06-07] Removidos tipos do React 19 e downgrade para React 18.2 para resolver erros em tempo de execução - dev - 469ca13
 ## [2025-06-07] Corrigida tipagem da página de categoria que quebrava build - dev - 450cce4
+## [2025-06-07] Erro 'Property 'primary' does not exist on type 'DefaultColors' resolvido em twColors - dev - a63d0a1
+## [2025-06-07] Erro 'Property "posts" does not exist on type "{}"' em stories do blog, causando falha no build - dev - 441b5f1

--- a/stories/BlogHeroCarousel.stories.tsx
+++ b/stories/BlogHeroCarousel.stories.tsx
@@ -62,9 +62,12 @@ const FetchWrapper = ({ posts, children }: { posts: Post[]; children: React.Reac
 };
 
 export const Default: Story = {
-  render: ({ posts }) => (
-    <FetchWrapper posts={posts as Post[]}>
-      <BlogHeroCarousel />
-    </FetchWrapper>
-  ),
+  render: (args) => {
+    const { posts } = args as { posts: Post[] };
+    return (
+      <FetchWrapper posts={posts}>
+        <BlogHeroCarousel />
+      </FetchWrapper>
+    );
+  },
 };

--- a/stories/BlogSidebar.stories.tsx
+++ b/stories/BlogSidebar.stories.tsx
@@ -55,9 +55,12 @@ const FetchWrapper = ({ posts, children }: { posts: Post[]; children: React.Reac
 };
 
 export const Default: Story = {
-  render: ({ posts }) => (
-    <FetchWrapper posts={posts as Post[]}>
-      <BlogSidebar />
-    </FetchWrapper>
-  ),
+  render: (args) => {
+    const { posts } = args as { posts: Post[] };
+    return (
+      <FetchWrapper posts={posts}>
+        <BlogSidebar />
+      </FetchWrapper>
+    );
+  },
 };

--- a/utils/twColors.ts
+++ b/utils/twColors.ts
@@ -1,11 +1,13 @@
-const resolveConfig = require("tailwindcss/resolveConfig");
-const tailwindConfig = require("../tailwind.config.js");
-const colors = require("tailwindcss/colors");
+import resolveConfig from "tailwindcss/resolveConfig";
+import tailwindConfig from "../tailwind.config.js";
+import colors from "tailwindcss/colors";
 
 const fullConfig = resolveConfig(tailwindConfig);
 
-module.exports = {
-  primary600: fullConfig.theme.colors.primary[600],
-  error600: fullConfig.theme.colors.error[600],
+export const twColors = {
+  primary600: (fullConfig.theme.colors as any).primary[600],
+  error600: (fullConfig.theme.colors as any).error[600],
   blue500: colors.blue[500],
 };
+
+export default twColors;


### PR DESCRIPTION
## Summary
- fix blog stories to cast `posts` arg in `render`
- document build error due to missing `posts` type in ERR_LOG

## Testing
- `npm run lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_68449e6b8278832cbbce156d84f9da31