### PR TITLE
Centralize PocketBase url via env

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,16 @@ bun dev
 
 Open [http://localhost:3000](http://localhost:3000) with your browser to see the result.
 
+## Variáveis de Ambiente
+
+Crie um arquivo `.env.local` definindo a URL do servidor PocketBase:
+
+```bash
+PB_URL=https://seu-servidor-pocketbase.com
+```
+
+Essa variável será utilizada por `lib/pocketbase.ts` para conectar ao backend.
+
 You can start editing the page by modifying `app/page.tsx`. The page auto-updates as you edit the file.
 
 This project uses [`next/font`](https://nextjs.org/docs/app/building-your-application/optimizing/fonts) to automatically optimize and load [Geist](https://vercel.com/font), a new font family for Vercel.

--- a/app/api/checkout/route.ts
+++ b/app/api/checkout/route.ts
@@ -1,9 +1,7 @@
 import { NextRequest, NextResponse } from "next/server";
 import mercadopago from "mercadopago";
-import PocketBase from "pocketbase";
+import pb from "@/lib/pocketbase";
 
-const pb = new PocketBase("https://umadeus-production.up.railway.app");
-pb.autoCancellation(false);
 
 export async function POST(req: NextRequest) {
   const accessToken = process.env.MERCADO_PAGO_ACCESS_TOKEN;

--- a/app/api/checkout/webhook/route.ts
+++ b/app/api/checkout/webhook/route.ts
@@ -1,9 +1,7 @@
 import { NextRequest, NextResponse } from "next/server";
-import PocketBase from "pocketbase";
+import pb from "@/lib/pocketbase";
 import mercadopago from "mercadopago";
 
-const pb = new PocketBase("https://umadeus-production.up.railway.app");
-pb.autoCancellation(false);
 
 mercadopago.configure({
   access_token: process.env.MERCADO_PAGO_ACCESS_TOKEN!,

--- a/app/api/inscricoes/route.ts
+++ b/app/api/inscricoes/route.ts
@@ -1,5 +1,5 @@
 import { NextRequest, NextResponse } from "next/server";
-import PocketBase from "pocketbase";
+import pb from "@/lib/pocketbase";
 
 interface DadosInscricao {
   nome: string;
@@ -16,8 +16,6 @@ interface DadosInscricao {
   tamanho?: string;
 }
 
-const pb = new PocketBase("https://umadeus-production.up.railway.app");
-pb.autoCancellation(false);
 
 export async function POST(req: NextRequest) {
   try {

--- a/app/api/lider/[id]/route.ts
+++ b/app/api/lider/[id]/route.ts
@@ -1,5 +1,5 @@
 import { NextRequest, NextResponse } from "next/server";
-import PocketBase from "pocketbase";
+import pb from "@/lib/pocketbase";
 
 export async function GET(req: NextRequest) {
   const url = new URL(req.nextUrl);
@@ -9,11 +9,8 @@ export async function GET(req: NextRequest) {
     return NextResponse.json({ erro: "ID ausente ou inválido." }, { status: 400 });
   }
 
-  const pbSafe = new PocketBase("https://umadeus-production.up.railway.app");
-  pbSafe.autoCancellation(false);
-
   try {
-    const lider = await pbSafe.collection("usuarios").getOne(id, {
+    const lider = await pb.collection("usuarios").getOne(id, {
       expand: "campo",
     });
 

--- a/app/api/pedidos/routes.tsx
+++ b/app/api/pedidos/routes.tsx
@@ -1,8 +1,6 @@
 import { NextRequest, NextResponse } from "next/server";
-import PocketBase from "pocketbase";
+import pb from "@/lib/pocketbase";
 
-const pb = new PocketBase("https://umadeus-production.up.railway.app");
-pb.autoCancellation(false);
 
 export async function POST(req: NextRequest) {
   try {

--- a/app/api/recuperar-link/route.ts
+++ b/app/api/recuperar-link/route.ts
@@ -1,10 +1,5 @@
 import { NextRequest, NextResponse } from "next/server";
-import PocketBase from "pocketbase";
-
-const pb = new PocketBase(
-  process.env.PB_URL || "https://umadeus-production.up.railway.app"
-);
-pb.autoCancellation(false);
+import pb from "@/lib/pocketbase";
 
 export async function POST(req: NextRequest) {
   try {

--- a/lib/pocketbase.ts
+++ b/lib/pocketbase.ts
@@ -1,5 +1,8 @@
 import PocketBase from "pocketbase";
 
-const pb = new PocketBase("https://umadeus-production.up.railway.app");
+const pb = new PocketBase(
+  process.env.PB_URL || "https://umadeus-production.up.railway.app"
+);
+pb.autoCancellation(false);
 
 export default pb;


### PR DESCRIPTION
## Summary
- read PB_URL from environment in `lib/pocketbase.ts`
- use centralized PocketBase instance in API routes
- document the PB_URL variable in the README

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6844ac2ebbc0832ca7da59627a16ba0e