### PR TITLE
Remove console logs and add environment-aware logger

### DIFF
--- a/app/api/campos/route.ts
+++ b/app/api/campos/route.ts
@@ -1,5 +1,6 @@
 import { NextRequest, NextResponse } from "next/server";
 import { getUserFromHeaders } from "@/lib/getUserFromHeaders";
+import { logInfo } from "@/lib/logger";
 
 export async function GET(req: NextRequest) {
   const auth = await getUserFromHeaders(req);
@@ -49,7 +50,7 @@ export async function POST(req: NextRequest) {
 
   try {
     const { nome } = await req.json();
-    console.log("📥 Nome recebido:", nome);
+    logInfo("📥 Requisição para criar campo recebida");
 
     if (!nome || nome.length < 2) {
       return NextResponse.json({ error: "Nome inválido" }, { status: 400 });
@@ -57,7 +58,7 @@ export async function POST(req: NextRequest) {
 
     const campo = await pbSafe.collection("campos").create({ nome });
 
-    console.log("✅ Campo criado:", campo);
+    logInfo("✅ Campo criado com sucesso");
 
     return NextResponse.json(campo, { status: 201 });
   } catch (err: unknown) {

--- a/app/api/usuarios/route.ts
+++ b/app/api/usuarios/route.ts
@@ -1,5 +1,6 @@
 import { NextRequest, NextResponse } from "next/server";
 import { getUserFromHeaders } from "@/lib/getUserFromHeaders";
+import { logInfo } from "@/lib/logger";
 
 export async function GET(req: NextRequest) {
   const result = await getUserFromHeaders(req);
@@ -20,7 +21,7 @@ export async function GET(req: NextRequest) {
       expand: "campo",
     });
 
-    console.log(`📦 ${usuarios.length} usuários encontrados.`);
+    logInfo(`📦 ${usuarios.length} usuários encontrados.`);
     return NextResponse.json(usuarios);
   } catch (err: unknown) {
     if (err instanceof Error) {
@@ -73,7 +74,7 @@ export async function POST(req: NextRequest) {
       campo,
     });
 
-    console.log("✅ Usuário criado:", novoUsuario);
+    logInfo("✅ Usuário criado com sucesso");
     return NextResponse.json(novoUsuario, { status: 201 });
   } catch (err: unknown) {
     if (err instanceof Error) {

--- a/app/campos/page.tsx
+++ b/app/campos/page.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useEffect, useState } from "react";
+import { logInfo } from "@/lib/logger";
 
 interface Campo {
   id: string;
@@ -22,9 +23,9 @@ export default function GerenciarCamposPage() {
 
   useEffect(() => {
     async function carregarCampos() {
-      console.log("🔐 Iniciando carregamento de campos...");
+      logInfo("🔐 Iniciando carregamento de campos...");
       if (!token || !user) {
-        console.warn("⚠️ Usuário ou token ausente.");
+        logInfo("⚠️ Usuário ou token ausente.");
         setMensagem("Usuário não autenticado.");
         return;
       }
@@ -47,7 +48,7 @@ export default function GerenciarCamposPage() {
         }
 
         if (!Array.isArray(data)) {
-          console.warn("⚠️ Resposta inesperada:", data);
+          logInfo("⚠️ Resposta inesperada", data);
           setMensagem("Dados inválidos recebidos.");
           return;
         }

--- a/app/inscricoes/[id]/page.tsx
+++ b/app/inscricoes/[id]/page.tsx
@@ -3,6 +3,7 @@
 import { useEffect, useState } from "react";
 import { useParams } from "next/navigation";
 import Link from "next/link";
+import { logInfo } from "@/lib/logger";
 
 const PRODUTOS = [
   { nome: "Kit Camisa + Pulseira", valor: 50.0 },
@@ -119,8 +120,8 @@ export default function InscricaoPage() {
           }),
         });
       } catch (erro) {
-        console.warn(
-          "⚠️ Falha ao notificar o n8n (sem impacto no usuário):",
+        logInfo(
+          "⚠️ Falha ao notificar o n8n (sem impacto no usuário)",
           erro
         );
       }

--- a/app/inscricoes/page.tsx
+++ b/app/inscricoes/page.tsx
@@ -2,6 +2,7 @@
 
 import { useEffect, useState } from "react";
 import pb from "@/lib/pocketbase";
+import { logInfo } from "@/lib/logger";
 import { Copy } from "lucide-react";
 import { saveAs } from "file-saver";
 import ModalEditarInscricao from "./componentes/ModalEdit";
@@ -106,7 +107,7 @@ export default function ListaInscricoesPage() {
           );
           // Se ainda for usar camposDisponiveis no futuro:
           // setCamposDisponiveis(nomes);
-          console.log("Campos disponíveis:", nomes);
+          logInfo("Campos disponíveis", nomes);
         })
         .catch(() => {});
     }

--- a/lib/logger.ts
+++ b/lib/logger.ts
@@ -1,0 +1,5 @@
+export function logInfo(...args: unknown[]) {
+  if (process.env.NODE_ENV !== 'production') {
+    console.info(...args);
+  }
+}


### PR DESCRIPTION
## Summary
- add a small helper `logInfo` to avoid debug logging in production
- replace `console.log`/`console.warn` with `logInfo` in API routes and pages
- prevent sensitive data from being logged

## Testing
- `npm run lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_6844ac307d14832cb7025f8c7135cd5a