### PR TITLE
Implement primary color shades utility

### DIFF
--- a/__tests__/appConfigSSR.test.ts
+++ b/__tests__/appConfigSSR.test.ts
@@ -1,3 +1,4 @@
+import * as React from 'react'
 import { describe, it, expect } from 'vitest'
 import { renderToString } from 'react-dom/server'
 import { AppConfigProvider } from '../lib/context/AppConfigContext'
@@ -6,10 +7,10 @@ describe('AppConfigProvider SSR', () => {
   it('renders without crashing in a server environment', () => {
     const render = () =>
       renderToString(
-        require('react').createElement(
+        React.createElement(
           AppConfigProvider,
           null,
-          require('react').createElement('div', null, 'SSR')
+          React.createElement('div', null, 'SSR')
         )
       )
     expect(render).not.toThrow()

--- a/lib/context/AppConfigContext.tsx
+++ b/lib/context/AppConfigContext.tsx
@@ -1,6 +1,7 @@
 "use client";
+import * as React from "react";
 import { createContext, useContext, useEffect, useState } from "react";
-import { generateHslShades } from "@/utils/colorShades";
+import { generatePrimaryShades } from "@/utils/primaryShades";
 
 export type AppConfig = {
   font: string;
@@ -39,7 +40,7 @@ export function AppConfigProvider({ children }: { children: React.ReactNode }) {
     document.documentElement.style.setProperty("--font-body", config.font);
     document.documentElement.style.setProperty("--font-heading", config.font);
     document.documentElement.style.setProperty("--accent", config.primaryColor);
-    const shades = generateHslShades(config.primaryColor);
+    const shades = generatePrimaryShades(config.primaryColor);
     Object.entries(shades).forEach(([key, value]) => {
       document.documentElement.style.setProperty(`--primary-${key}`, value);
     });

--- a/logs/DOC_LOG.md
+++ b/logs/DOC_LOG.md
@@ -35,3 +35,4 @@
 
 ## [2025-06-07] Documentada protecao de SSR no AppConfigProvider.
 ## [2025-06-07] Geradas variáveis CSS dinâmicas de cor e mapeamento via Tailwind. Documentação atualizada.
+## [2025-06-08] Gerado utilitário primaryShades e atualizado AppConfigProvider para definir variáveis CSS. Tailwind e testes ajustados.

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -1,4 +1,6 @@
 /** @type {import('tailwindcss').Config} */
+// Helper to read HSL values from CSS variables so Tailwind classes
+// like bg-primary-600 respect the current theme color.
 const withOpacityValue = (variable) => {
   return ({ opacityValue }) => {
     if (opacityValue !== undefined) {

--- a/utils/primaryShades.ts
+++ b/utils/primaryShades.ts
@@ -1,0 +1,59 @@
+export function hexToHsl(hex: string): [number, number, number] {
+  hex = hex.replace('#', '')
+  if (hex.length === 3) {
+    hex = hex.split('').map((c) => c + c).join('')
+  }
+  const r = parseInt(hex.substring(0, 2), 16) / 255
+  const g = parseInt(hex.substring(2, 4), 16) / 255
+  const b = parseInt(hex.substring(4, 6), 16) / 255
+
+  const max = Math.max(r, g, b)
+  const min = Math.min(r, g, b)
+  let h = 0
+  let s = 0
+  const l = (max + min) / 2
+
+  if (max !== min) {
+    const d = max - min
+    s = l > 0.5 ? d / (2 - max - min) : d / (max + min)
+    switch (max) {
+      case r:
+        h = (g - b) / d + (g < b ? 6 : 0)
+        break
+      case g:
+        h = (b - r) / d + 2
+        break
+      case b:
+        h = (r - g) / d + 4
+        break
+    }
+    h /= 6
+  }
+
+  return [Math.round(h * 360), Math.round(s * 100), Math.round(l * 100)]
+}
+
+export function generatePrimaryShades(hex: string): Record<string, string> {
+  const [h, s, l] = hexToHsl(hex)
+  const steps: Record<string, number> = {
+    50: 42,
+    100: 32,
+    200: 24,
+    300: 16,
+    400: 8,
+    500: 4,
+    600: 0,
+    700: -8,
+    800: -16,
+    900: -24,
+  }
+
+  const shades: Record<string, string> = {}
+  Object.keys(steps).forEach((key) => {
+    const delta = steps[key]
+    const newL = Math.max(0, Math.min(100, l + delta))
+    shades[key] = `${h} ${s}% ${newL}%`
+  })
+
+  return shades
+}

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,9 +1,16 @@
 import { defineConfig } from 'vitest/config'
+import { fileURLToPath } from 'url'
+import path from 'path'
 
 export default defineConfig({
+  resolve: {
+    alias: {
+      '@': path.dirname(fileURLToPath(import.meta.url)),
+    },
+  },
   test: {
     environment: 'node',
     globals: true,
-    include: ['__tests__/**/*.test.ts']
-  }
+    include: ['__tests__/**/*.test.ts'],
+  },
 })


### PR DESCRIPTION
## Summary
- add `primaryShades` helper to generate light and dark variations
- expose new shades in `AppConfigProvider`
- comment Tailwind helper
- fix Vitest config alias and SSR tests
- log documentation update

## Testing
- `npm run lint`
- `npm run test`


------
https://chatgpt.com/codex/tasks/task_e_6844ac6b5c50832cb5206c0079b4140d