### PR TITLE
Adicionar guia de testes e coberturas iniciais

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,11 +112,8 @@ npm run generate-posts
 
 ## Testes
 
-Para rodar a suíte de testes utilize:
-
-```bash
-npm run test
-```
+Execute `npm run lint` e `npm run test` para validar o projeto.
+Consulte [docs/testes.md](docs/testes.md) para instruções completas.
 
 ## Build
 

--- a/__tests__/colorShades.test.ts
+++ b/__tests__/colorShades.test.ts
@@ -1,0 +1,15 @@
+import { describe, it, expect } from 'vitest'
+import { hexToHsl, generateHslShades } from '../utils/colorShades'
+
+describe('colorShades utilities', () => {
+  it('converts hex to hsl correctly', () => {
+    expect(hexToHsl('#ff0000')).toEqual([0, 100, 50])
+    expect(hexToHsl('#fff')).toEqual([0, 0, 100])
+  })
+
+  it('generates hsl shades based on color', () => {
+    const shades = generateHslShades('#ffffff')
+    expect(shades["600"]).toBe('0 0% 100%')
+    expect(Object.keys(shades)).toContain('900')
+  })
+})

--- a/__tests__/isExternalUrl.test.ts
+++ b/__tests__/isExternalUrl.test.ts
@@ -1,0 +1,14 @@
+import { describe, it, expect } from 'vitest'
+import { isExternalUrl } from '../utils/isExternalUrl'
+
+describe('isExternalUrl', () => {
+  it('detects http and https urls', () => {
+    expect(isExternalUrl('https://example.com')).toBe(true)
+    expect(isExternalUrl('http://example.com')).toBe(true)
+  })
+
+  it('returns false for relative urls', () => {
+    expect(isExternalUrl('/about')).toBe(false)
+    expect(isExternalUrl('mailto:test@example.com')).toBe(false)
+  })
+})

--- a/__tests__/twColors.test.ts
+++ b/__tests__/twColors.test.ts
@@ -1,0 +1,13 @@
+import { describe, it, expect } from 'vitest'
+import twColors from '../utils/twColors'
+
+describe('twColors utility', () => {
+  it('reads colors from tailwind config', () => {
+    expect(twColors.primary600({})).toBe('hsl(var(--primary-600))')
+    expect(twColors.error600).toBe('#dc2626')
+  })
+
+  it('exposes tailwindcss blue color', () => {
+    expect(twColors.blue500).toBe('#3b82f6')
+  })
+})

--- a/docs/testes.md
+++ b/docs/testes.md
@@ -1,0 +1,26 @@
+# Guia de Testes
+
+Este projeto utiliza [Vitest](https://vitest.dev/) para testes unitários e [React Testing Library](https://testing-library.com/docs/react-testing-library/intro/) para componentes React.
+
+## Dependências
+
+Instale as dependências de desenvolvimento com:
+
+```bash
+npm install
+```
+
+## Estrutura
+
+Os arquivos de teste ficam no diretório `__tests__/` na raiz do projeto. Cada módulo possui um arquivo `*.test.ts` correspondente.
+
+## Execução
+
+Para rodar a linter e a bateria de testes utilize:
+
+```bash
+npm run lint
+npm run test
+```
+
+Recomenda-se executar estes comandos antes de abrir um pull request.

--- a/logs/DOC_LOG.md
+++ b/logs/DOC_LOG.md
@@ -35,3 +35,4 @@
 
 ## [2025-06-07] Documentada protecao de SSR no AppConfigProvider.
 ## [2025-06-07] Geradas variáveis CSS dinâmicas de cor e mapeamento via Tailwind. Documentação atualizada.
+## [2025-06-07] Adicionado docs/testes.md e atualizada secao de testes no README.

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,6 +1,12 @@
 import { defineConfig } from 'vitest/config'
+import path from 'path'
 
 export default defineConfig({
+  resolve: {
+    alias: {
+      '@': path.resolve(__dirname, '.')
+    }
+  },
   test: {
     environment: 'node',
     globals: true,


### PR DESCRIPTION
## Resumo
- adicionar alias no vitest.config para suportar `@/`
- criar testes para utilitários `colorShades`, `isExternalUrl` e `twColors`
- documentar processo de testes em `docs/testes.md`
- atualizar seção de testes no README
- registrar alteração em `DOC_LOG.md`

## Testes
- `npm run lint`
- `npm run test` *(falha: React is not defined em appConfigSSR.test.ts)*

------
https://chatgpt.com/codex/tasks/task_e_6844ac221584832caf92e9c7ca85dad2