### PR TITLE
Enable custom domain support

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,13 @@ The easiest way to deploy your Next.js app is to use the [Vercel Platform](https
 
 Check out our [Next.js deployment documentation](https://nextjs.org/docs/app/building-your-application/deploying) for more details.
 
+### Domínio próprio na Vercel
+
+1. Instale a Vercel CLI com `npm i -g vercel` e execute `vercel` para vincular o projeto à sua conta.
+2. No painel da Vercel, adicione o domínio desejado em **Settings > Domains**.
+3. Defina a variável `NEXT_PUBLIC_SITE_URL` com o domínio configurado (ex.: `https://meuapp.com`).
+4. Rode `vercel --prod` para publicar e aplique as configurações de DNS indicadas pela própria Vercel.
+
 ## Lint e boas práticas
 
 Execute `npm run lint` para verificar problemas de código. Evite o uso de `any` especificando tipos adequados e sempre inclua todas as dependências utilizadas dentro dos hooks `useEffect`.

--- a/app/blog/post/[slug]/page.tsx
+++ b/app/blog/post/[slug]/page.tsx
@@ -74,6 +74,8 @@ export default async function BlogPostPage({
   const words = content.split(/\s+/).length;
   const readingTime = Math.ceil(words / 200);
 
+  const siteUrl = process.env.NEXT_PUBLIC_SITE_URL || "https://m24saude.com.br";
+
   const schema = {
     "@context": "https://schema.org",
     "@type": "BlogPosting",
@@ -81,7 +83,7 @@ export default async function BlogPostPage({
     description: data.summary || "",
     image: isExternalUrl(data.thumbnail)
       ? data.thumbnail
-      : `https://m24saude.com.br${data.thumbnail || "/img/og-default.jpg"}`,
+      : `${siteUrl}${data.thumbnail || "/img/og-default.jpg"}`,
     author: {
       "@type": "Person",
       name: "Redação M24",
@@ -91,13 +93,13 @@ export default async function BlogPostPage({
       name: "M24 Saúde",
       logo: {
         "@type": "ImageObject",
-        url: "https://m24saude.com.br/img/M24.webp",
+        url: `${siteUrl}/img/M24.webp`,
       },
     },
     datePublished: data.date || new Date().toISOString(),
     mainEntityOfPage: {
       "@type": "WebPage",
-      "@id": `https://m24saude.com.br/blog/post/${slug}`,
+      "@id": `${siteUrl}/blog/post/${slug}`,
     },
   };
 
@@ -161,7 +163,7 @@ export default async function BlogPostPage({
           </div>
 
           <a
-            href={`https://twitter.com/intent/tweet?url=https://m24saude.com.br/blog/post/${slug}&text=${encodeURIComponent(
+            href={`https://twitter.com/intent/tweet?url=${siteUrl}/blog/post/${slug}&text=${encodeURIComponent(
               data.title
             )}`}
             target="_blank"

--- a/logs/DOC_LOG.md
+++ b/logs/DOC_LOG.md
@@ -37,3 +37,4 @@
 ## [2025-06-07] Geradas variáveis CSS dinâmicas de cor e mapeamento via Tailwind. Documentação atualizada.
 ## [2025-06-08] Gerado utilitário primaryShades e atualizado AppConfigProvider para definir variáveis CSS. Tailwind e testes ajustados.
 ## [2025-06-07] Adicionado docs/testes.md e atualizada secao de testes no README.
+## [2025-06-08] Documentado uso de dominio proprio com Vercel no README

--- a/scripts/generate-sitemap.js
+++ b/scripts/generate-sitemap.js
@@ -2,7 +2,9 @@ const fs = require("fs");
 const path = require("path");
 const matter = require("gray-matter");
 
-const BASE_URL = "https://m24saude.com.br"; // sem barra no final
+// Usa a URL definida nas variáveis de ambiente ou mantém o domínio padrão
+const BASE_URL =
+  process.env.NEXT_PUBLIC_SITE_URL || "https://m24saude.com.br"; // sem barra no final
 
 function getStaticRoutes() {
   const appDir = path.join(process.cwd(), "app");


### PR DESCRIPTION
## Summary
- load site URL from env in sitemap generator
- make blog URLs use `NEXT_PUBLIC_SITE_URL`
- explain how to add custom domain on Vercel
- log documentation updates

## Testing
- `npm run lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_6844bbb2e0a0832cba9b39d47d007209