### PR TITLE
Implement customer profile with addresses

### DIFF
--- a/app/cliente/components/MudarSenha.tsx
+++ b/app/cliente/components/MudarSenha.tsx
@@ -1,0 +1,83 @@
+"use client";
+
+import { useState } from "react";
+import pb from "@/lib/pocketbase";
+import { useAuthContext } from "@/lib/context/AuthContext";
+
+export default function MudarSenha({ onClose }: { onClose: () => void }) {
+  const { user } = useAuthContext();
+  const [senhaAtual, setSenhaAtual] = useState("");
+  const [novaSenha, setNovaSenha] = useState("");
+  const [confirmacao, setConfirmacao] = useState("");
+  const [mensagem, setMensagem] = useState("");
+  const [erro, setErro] = useState("");
+
+  const handleSubmit = async () => {
+    setErro("");
+    setMensagem("");
+    if (!user?.id) {
+      setErro("Sessão inválida.");
+      return;
+    }
+    if (novaSenha !== confirmacao) {
+      setErro("As senhas não coincidem.");
+      return;
+    }
+    try {
+      await pb.collection("usuarios").update(user.id, {
+        password: novaSenha,
+        passwordConfirm: confirmacao,
+        oldPassword: senhaAtual,
+      });
+      setMensagem("Senha atualizada com sucesso.");
+    } catch (err) {
+      console.error(err);
+      setErro("Erro ao atualizar senha.");
+    }
+  };
+
+  const inputStyle =
+    "w-full border border-gray-300 dark:border-zinc-700 bg-white dark:bg-zinc-800 p-2 rounded";
+
+  return (
+    <div className="fixed inset-0 bg-black/60 dark:bg-black/80 backdrop-blur-sm flex items-center justify-center z-50">
+      <div className="bg-white dark:bg-zinc-900 text-black dark:text-white p-6 rounded-xl shadow-xl w-full max-w-md space-y-5">
+        <h2 className="text-xl font-semibold text-center">Alterar Senha</h2>
+        <input
+          type="password"
+          placeholder="Senha atual"
+          className={inputStyle}
+          value={senhaAtual}
+          onChange={(e) => setSenhaAtual(e.target.value)}
+        />
+        <input
+          type="password"
+          placeholder="Nova senha"
+          className={inputStyle}
+          value={novaSenha}
+          onChange={(e) => setNovaSenha(e.target.value)}
+        />
+        <input
+          type="password"
+          placeholder="Confirmar nova senha"
+          className={inputStyle}
+          value={confirmacao}
+          onChange={(e) => setConfirmacao(e.target.value)}
+        />
+        {mensagem && <p className="text-green-500 text-sm">{mensagem}</p>}
+        {erro && <p className="text-red-500 text-sm">{erro}</p>}
+        <div className="flex justify-end gap-2 pt-2">
+          <button className="text-sm text-gray-600 dark:text-gray-300" onClick={onClose}>
+            Cancelar
+          </button>
+          <button
+            className="bg-black dark:bg-white text-white dark:text-black text-sm px-4 py-2 rounded-lg"
+            onClick={handleSubmit}
+          >
+            Salvar
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/app/cliente/enderecos/novo/page.tsx
+++ b/app/cliente/enderecos/novo/page.tsx
@@ -1,0 +1,109 @@
+"use client";
+
+import { useState } from "react";
+import { useRouter } from "next/navigation";
+import pb from "@/lib/pocketbase";
+import { useAuthContext } from "@/lib/context/AuthContext";
+
+export default function NovoEnderecoPage() {
+  const { user } = useAuthContext();
+  const router = useRouter();
+
+  const [rua, setRua] = useState("");
+  const [numero, setNumero] = useState("");
+  const [bairro, setBairro] = useState("");
+  const [cidade, setCidade] = useState("");
+  const [estado, setEstado] = useState("");
+  const [cep, setCep] = useState("");
+  const [erro, setErro] = useState("");
+  const [mensagem, setMensagem] = useState("");
+
+  const handleSubmit = async () => {
+    setErro("");
+    setMensagem("");
+    if (!user?.id) {
+      setErro("Sessão inválida.");
+      return;
+    }
+    try {
+      await pb.collection("enderecos").create({
+        usuario: user.id,
+        rua,
+        numero,
+        bairro,
+        cidade,
+        estado,
+        cep,
+      });
+      setMensagem("Endereço cadastrado.");
+      setTimeout(() => router.push("/cliente/enderecos"), 1000);
+    } catch (err) {
+      console.error(err);
+      setErro("Erro ao cadastrar endereço.");
+    }
+  };
+
+  const inputStyle =
+    "w-full border border-gray-300 dark:border-zinc-700 bg-white dark:bg-zinc-800 p-2 rounded";
+
+  return (
+    <div className="max-w-md mx-auto mt-10 space-y-4 p-4 bg-white dark:bg-zinc-900 rounded-xl shadow">
+      <h1 className="text-xl font-bold">Novo Endereço</h1>
+      <input
+        type="text"
+        placeholder="Rua"
+        className={inputStyle}
+        value={rua}
+        onChange={(e) => setRua(e.target.value)}
+      />
+      <input
+        type="text"
+        placeholder="Número"
+        className={inputStyle}
+        value={numero}
+        onChange={(e) => setNumero(e.target.value)}
+      />
+      <input
+        type="text"
+        placeholder="Bairro"
+        className={inputStyle}
+        value={bairro}
+        onChange={(e) => setBairro(e.target.value)}
+      />
+      <input
+        type="text"
+        placeholder="Cidade"
+        className={inputStyle}
+        value={cidade}
+        onChange={(e) => setCidade(e.target.value)}
+      />
+      <input
+        type="text"
+        placeholder="Estado"
+        className={inputStyle}
+        value={estado}
+        onChange={(e) => setEstado(e.target.value)}
+      />
+      <input
+        type="text"
+        placeholder="CEP"
+        className={inputStyle}
+        value={cep}
+        onChange={(e) => setCep(e.target.value)}
+      />
+      {mensagem && <p className="text-green-500 text-sm">{mensagem}</p>}
+      {erro && <p className="text-red-500 text-sm">{erro}</p>}
+      <div className="flex justify-end gap-2 pt-2">
+        <button className="text-sm text-gray-600 dark:text-gray-300" onClick={() => router.back()}>
+          Cancelar
+        </button>
+        <button
+          onClick={handleSubmit}
+          className="bg-black dark:bg-white text-white dark:text-black px-4 py-2 rounded-lg text-sm"
+        >
+          Salvar
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/app/cliente/enderecos/page.tsx
+++ b/app/cliente/enderecos/page.tsx
@@ -1,0 +1,53 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { useRouter } from "next/navigation";
+import pb from "@/lib/pocketbase";
+import { Endereco } from "@/types";
+import Link from "next/link";
+import { useAuthContext } from "@/lib/context/AuthContext";
+
+export default function EnderecosPage() {
+  const router = useRouter();
+  const { user } = useAuthContext();
+  const [enderecos, setEnderecos] = useState<Endereco[]>([]);
+
+  useEffect(() => {
+    if (!pb.authStore.isValid) {
+      router.push("/login");
+      return;
+    }
+    if (!user?.id) return;
+    const fetchData = async () => {
+      const list = await pb.collection("enderecos").getFullList<Endereco>({
+        filter: `usuario="${user.id}"`,
+      });
+      setEnderecos(list);
+    };
+    fetchData();
+  }, [user, router]);
+
+  if (!pb.authStore.isValid) return null;
+
+  return (
+    <div className="max-w-2xl mx-auto mt-10 space-y-4 p-4">
+      <h1 className="text-2xl font-bold">Meus Endereços</h1>
+      <Link
+        href="/cliente/enderecos/novo"
+        className="inline-block bg-black dark:bg-white text-white dark:text-black px-4 py-2 rounded-lg"
+      >
+        Novo Endereço
+      </Link>
+      <ul className="space-y-2">
+        {enderecos.map((e) => (
+          <li key={e.id} className="border p-2 rounded">
+            {e.rua}, {e.numero} - {e.bairro} - {e.cidade}/{e.estado} - {e.cep}
+          </li>
+        ))}
+        {enderecos.length === 0 && (
+          <li className="text-sm text-zinc-600 dark:text-zinc-300">Nenhum endereço cadastrado.</li>
+        )}
+      </ul>
+    </div>
+  );
+}

--- a/app/cliente/page.tsx
+++ b/app/cliente/page.tsx
@@ -1,0 +1,94 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { useRouter } from "next/navigation";
+import pb from "@/lib/pocketbase";
+import ModalEditarPerfil from "../perfil/components/ModalEditarPerfil";
+import MudarSenha from "./components/MudarSenha";
+import Link from "next/link";
+
+interface UsuarioAuthModel {
+  id: string;
+  email: string;
+  nome: string;
+  telefone?: string;
+  cpf?: string;
+  data_nascimento?: string;
+  role: string;
+}
+
+export default function ClientePage() {
+  const router = useRouter();
+  const [usuario, setUsuario] = useState<UsuarioAuthModel | null>(null);
+  const [mostrarModalPerfil, setMostrarModalPerfil] = useState(false);
+  const [mostrarModalSenha, setMostrarModalSenha] = useState(false);
+
+  const atualizarUsuario = () => {
+    const model = pb.authStore.model as unknown as UsuarioAuthModel;
+    setUsuario(model);
+  };
+
+  useEffect(() => {
+    if (!pb.authStore.isValid) {
+      router.push("/login");
+      return;
+    }
+    const model = pb.authStore.model as unknown as UsuarioAuthModel;
+    setUsuario(model);
+  }, [router]);
+
+  if (!usuario) return null;
+
+  return (
+    <div className="max-w-2xl mx-auto mt-10 p-6 bg-white dark:bg-zinc-900 rounded-xl shadow space-y-6">
+      <h1 className="text-2xl font-bold text-zinc-800 dark:text-white">Área do Cliente</h1>
+
+      <div className="space-y-2 text-zinc-700 dark:text-zinc-200">
+        <p>
+          <span className="font-semibold">Nome:</span> {usuario.nome}
+        </p>
+        <p>
+          <span className="font-semibold">E-mail:</span> {usuario.email}
+        </p>
+      </div>
+
+      <div className="flex gap-2 flex-wrap">
+        <button
+          onClick={() => setMostrarModalPerfil(true)}
+          className="bg-black dark:bg-white text-white dark:text-black px-4 py-2 rounded-lg hover:opacity-90"
+        >
+          Editar Perfil
+        </button>
+        <button
+          onClick={() => setMostrarModalSenha(true)}
+          className="bg-black dark:bg-white text-white dark:text-black px-4 py-2 rounded-lg hover:opacity-90"
+        >
+          Alterar Senha
+        </button>
+        <Link
+          href="/cliente/enderecos"
+          className="bg-black dark:bg-white text-white dark:text-black px-4 py-2 rounded-lg hover:opacity-90"
+        >
+          Meus Endereços
+        </Link>
+      </div>
+
+      {mostrarModalPerfil && (
+        <ModalEditarPerfil
+          onClose={() => {
+            setMostrarModalPerfil(false);
+            atualizarUsuario();
+          }}
+        />
+      )}
+
+      {mostrarModalSenha && (
+        <MudarSenha
+          onClose={() => {
+            setMostrarModalSenha(false);
+          }}
+        />
+      )}
+    </div>
+  );
+}

--- a/types/Endereco.ts
+++ b/types/Endereco.ts
@@ -1,0 +1,12 @@
+export type Endereco = {
+  id: string;
+  usuario: string;
+  rua: string;
+  numero: string;
+  bairro: string;
+  cidade: string;
+  estado: string;
+  cep: string;
+  complemento?: string;
+  created?: string;
+};

--- a/types/index.ts
+++ b/types/index.ts
@@ -69,3 +69,4 @@ export type Pedido = {
     };
   };
 };
+export type { Endereco } from "./Endereco";


### PR DESCRIPTION
## Summary
- add `Endereco` type and export from `types`
- create customer area with profile details
- allow password update with `MudarSenha`
- implement address listing and creation for customers

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_684580f5faac832cb132c33662b147d2