### PR TITLE
Implement product filtering

### DIFF
--- a/__tests__/products.test.ts
+++ b/__tests__/products.test.ts
@@ -1,0 +1,22 @@
+import { describe, it, expect } from 'vitest'
+import { filtrarProdutos, ProdutoRecord } from '../lib/products'
+
+const produtos: ProdutoRecord[] = [
+  { id: '1', nome: 'A', preco: 10, ativo: true, categoria: 'roupas' },
+  { id: '2', nome: 'B', preco: 20, ativo: false, categoria: 'roupas' },
+  { id: '3', nome: 'C', preco: 30, ativo: true, categoria: 'acessorios' },
+]
+
+describe('filtrarProdutos', () => {
+  it('remove produtos inativos', () => {
+    const filtrados = filtrarProdutos(produtos)
+    expect(filtrados).toHaveLength(2)
+    expect(filtrados.find(p => p.id === '2')).toBeUndefined()
+  })
+
+  it('filtra por categoria quando informada', () => {
+    const filtrados = filtrarProdutos(produtos, 'roupas')
+    expect(filtrados).toHaveLength(1)
+    expect(filtrados[0].id).toBe('1')
+  })
+})

--- a/app/api/produtos/route.ts
+++ b/app/api/produtos/route.ts
@@ -1,11 +1,25 @@
-import { NextResponse } from "next/server";
+import { NextRequest, NextResponse } from "next/server";
 import createPocketBase from "@/lib/pocketbase";
+import { filtrarProdutos, ProdutoRecord } from "@/lib/products";
 
-export async function GET() {
+export async function GET(req: NextRequest) {
   const pb = createPocketBase();
+  const categoria = req.nextUrl.searchParams.get("categoria") || undefined;
+
   try {
-    const produtos = await pb.collection("produtos").getFullList({ sort: "-created" });
-    return NextResponse.json(produtos);
+    const produtos = await pb.collection("produtos").getFullList<ProdutoRecord>({
+      filter: categoria ? `ativo = true && categoria = '${categoria}'` : "ativo = true",
+      sort: "-created",
+    });
+
+    const ativos = filtrarProdutos(produtos, categoria);
+
+    const comUrls = ativos.map((p) => ({
+      ...p,
+      imagens: (p.imagens || []).map((img) => pb.files.getUrl(p, img)),
+    }));
+
+    return NextResponse.json(comUrls);
   } catch (err) {
     console.error("Erro ao listar produtos:", err);
     return NextResponse.json([], { status: 500 });

--- a/lib/products.ts
+++ b/lib/products.ts
@@ -1,0 +1,19 @@
+export interface ProdutoRecord {
+  id: string;
+  nome: string;
+  preco: number;
+  imagens?: string[];
+  checkout_url?: string;
+  categoria?: string;
+  ativo?: boolean;
+  [key: string]: unknown;
+}
+
+export function filtrarProdutos(
+  produtos: ProdutoRecord[],
+  categoria?: string
+): ProdutoRecord[] {
+  return produtos.filter(
+    (p) => p.ativo === true && (!categoria || p.categoria === categoria)
+  );
+}


### PR DESCRIPTION
## Summary
- filter products by active status and optional category in public API
- include product images via PocketBase URLs
- add utility to filter active products
- test product filtering logic

## Testing
- `npm run lint`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68463247cfc8832c9c043b1701551c6c