### PR TITLE
Add posts utilities tests

### DIFF
--- a/__tests__/posts.test.ts
+++ b/__tests__/posts.test.ts
@@ -1,0 +1,29 @@
+import { describe, it, expect, vi } from 'vitest'
+import { getPosts } from '../lib/posts/getPosts'
+import { getRelatedPosts } from '../lib/posts/getRelatedPosts'
+import { getRecentPostsClient } from '../lib/posts/getRecentPostsClient'
+
+describe('posts utilities', () => {
+  it('getPosts retorna lista ordenada', async () => {
+    const posts = await getPosts()
+    expect(posts[0].slug).toBe('segundo-post')
+    expect(posts.at(-1)?.slug).toBe('dicas-controlar-ansiedade')
+  })
+
+  it('getRelatedPosts fornece proximo post e sugestoes', () => {
+    const { nextPost, suggestions } = getRelatedPosts('primeiro-post', 'Geral')
+    expect(nextPost?.slug).toBe('segundo-post')
+    expect(suggestions.length).toBeGreaterThan(0)
+    expect(suggestions[0].slug).toBe('segundo-post')
+  })
+
+  it('getRecentPostsClient busca e limita a 3 posts', async () => {
+    const mockData = [{}, {}, {}, {}]
+    const fetchMock = vi.fn().mockResolvedValue({ ok: true, json: () => Promise.resolve(mockData) })
+    // @ts-ignore
+    global.fetch = fetchMock
+    const recent = await getRecentPostsClient()
+    expect(fetchMock).toHaveBeenCalledWith('/posts.json', { cache: 'no-store' })
+    expect(recent).toHaveLength(3)
+  })
+})

--- a/app/admin/produtos/novo/ModalProduto.tsx
+++ b/app/admin/produtos/novo/ModalProduto.tsx
@@ -3,7 +3,7 @@ import { useEffect, useRef } from "react";
 export interface ModalProdutoProps {
   open: boolean;
   onClose: () => void;
-  onSubmit: (form: any) => void;
+  onSubmit: (form: Record<string, unknown>) => void;
   initial?: {
     nome?: string;
     preco?: string;
@@ -37,10 +37,10 @@ export function ModalProduto({
     // Corrige checkboxes (arrays)
     form.tamanhos = Array.from(
       formElement.querySelectorAll("input[name='tamanhos']:checked")
-    ).map((el: any) => el.value);
+  ).map((el: HTMLInputElement) => el.value);
     form.generos = Array.from(
       formElement.querySelectorAll("input[name='generos']:checked")
-    ).map((el: any) => el.value);
+  ).map((el: HTMLInputElement) => el.value);
     form.ativo = !!form.ativo;
     // Corrige imagens para ser FileList ou File[]
     const imagensInput = formElement.querySelector("input[name='imagens']") as HTMLInputElement;


### PR DESCRIPTION
## Summary
- add unit tests for post utilities
- remove use of `any` in product modal props and handlers

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68464a95f700832c922f5dbc84cff3e7