### PR TITLE
Add role-based login redirects

### DIFF
--- a/app/components/Header.tsx
+++ b/app/components/Header.tsx
@@ -91,6 +91,15 @@ export default function Header() {
             </Link>
           ))}
 
+          {!isLoggedIn && (
+            <Link
+              href="/admin/login"
+              className="btn btn-primary text-sm whitespace-nowrap"
+            >
+              Acessar sua conta
+            </Link>
+          )}
+
           {(role === "lider" || role === "coordenador") && (
             <div className="relative">
               <button
@@ -158,6 +167,16 @@ export default function Header() {
                 </Link>
               ))}
             </>
+          )}
+
+          {!isLoggedIn && (
+            <Link
+              href="/admin/login"
+              onClick={() => setOpen(false)}
+              className="btn btn-primary text-sm text-center mt-2"
+            >
+              Acessar sua conta
+            </Link>
           )}
 
           {isLoggedIn && (

--- a/app/components/LoginForm.tsx
+++ b/app/components/LoginForm.tsx
@@ -25,7 +25,7 @@ export default function LoginForm() {
       } else if (user.role === "lider") {
         router.replace("/admin/lider-painel");
       } else {
-        setErro("Perfil de acesso não permitido.");
+        router.replace("/loja/cliente");
       }
     }
   }, [isLoading, isLoggedIn, user, router]);

--- a/app/loja/login/page.tsx
+++ b/app/loja/login/page.tsx
@@ -1,8 +1,5 @@
+import LoginForm from "../../components/LoginForm";
+
 export default function LojaLoginPage() {
-  return (
-    <main className="p-8 text-platinum font-sans">
-      <h1 className="text-3xl font-bold mb-6">Login do Cliente</h1>
-      <p>Funcionalidade em desenvolvimento.</p>
-    </main>
-  );
+  return <LoginForm />;
 }

--- a/lib/context/AuthContext.tsx
+++ b/lib/context/AuthContext.tsx
@@ -10,7 +10,7 @@ import type { RecordModel } from "pocketbase";
 type UserModel = {
   id: string;
   nome: string;
-  role: "coordenador" | "lider";
+  role: "coordenador" | "lider" | "cliente";
   [key: string]: unknown;
 };
 


### PR DESCRIPTION
## Summary
- update user type to accept `cliente` role
- redirect based on role after login
- reuse `LoginForm` on the store login page

## Testing
- `npm run lint` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_68464bea5fec832cb40630981f4c37f1