### PR TITLE
Improve ModalProduto generics

### DIFF
--- a/app/admin/produtos/novo/ModalProduto.tsx
+++ b/app/admin/produtos/novo/ModalProduto.tsx
@@ -1,10 +1,10 @@
 import { useEffect, useRef } from "react";
 import { useState } from "react";
 
-export interface ModalProdutoProps {
+export interface ModalProdutoProps<T extends Record<string, unknown>> {
   open: boolean;
   onClose: () => void;
-  onSubmit: (form: Record<string, unknown>) => void;
+  onSubmit: (form: T) => void;
   initial?: {
     nome?: string;
     preco?: string;
@@ -19,12 +19,12 @@ export interface ModalProdutoProps {
   };
 }
 
-export function ModalProduto({
+export function ModalProduto<T extends Record<string, unknown>>({
   open,
   onClose,
   onSubmit,
   initial = {},
-}: ModalProdutoProps) {
+}: ModalProdutoProps<T>) {
   const ref = useRef<HTMLDialogElement>(null);
   const [categorias, setCategorias] = useState<{ id: string; nome: string }[]>([]);
 
@@ -59,7 +59,7 @@ export function ModalProduto({
     form.imagens = imagensInput && imagensInput.files && imagensInput.files.length > 0
       ? imagensInput.files
       : null;
-    onSubmit(form);
+    onSubmit(form as T);
     onClose();
   }
 

--- a/app/admin/produtos/page.tsx
+++ b/app/admin/produtos/page.tsx
@@ -45,7 +45,7 @@ export default function AdminProdutosPage() {
   );
 
   // Função para adicionar produto na lista após cadastro via modal
-  const handleNovoProduto = (form: Record<string, unknown>) => {
+  const handleNovoProduto = (form: Produto) => {
     // Aqui você pode adaptar para criar um Produto a partir do form retornado pelo modal
     // Exemplo básico (ajuste conforme necessário para seu backend/estrutura):
     const produto: Produto = {
@@ -106,7 +106,7 @@ export default function AdminProdutosPage() {
 
       {/* O modal fica aqui, fora do cabeçalho. Só é aberto se modalOpen=true */}
       {modalOpen && (
-        <ModalProduto
+        <ModalProduto<Produto>
           open={modalOpen}
           onClose={() => setModalOpen(false)}
           onSubmit={handleNovoProduto}


### PR DESCRIPTION
## Summary
- add generic type to `ModalProdutoProps`
- use `<Produto>` when using `ModalProduto` in the admin page

## Testing
- `npx tsc` *(fails: Property 'slug' does not exist on type '{ id: string; nome: string; }' ...)*
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_684657861968832c9f65db28050bd5e2