### PR TITLE
Fix twColors test value

### DIFF
--- a/__tests__/twColors.test.ts
+++ b/__tests__/twColors.test.ts
@@ -3,7 +3,7 @@ import twColors from '../utils/twColors'
 
 describe('twColors utility', () => {
   it('reads colors from tailwind config', () => {
-    expect(twColors.primary600({})).toBe('hsl(var(--primary-600))')
+    expect(twColors.primary600).toBe('hsl(var(--primary-600))')
     expect(twColors.error600).toBe('#dc2626')
   })
 

--- a/utils/twColors.ts
+++ b/utils/twColors.ts
@@ -5,9 +5,13 @@ import colors from "tailwindcss/colors";
 // @ts-expect-error: tailwindConfig may not match the expected type, but works at runtime
 const fullConfig = resolveConfig(tailwindConfig);
 
+function resolveColor(value: any) {
+  return typeof value === 'function' ? value({}) : value;
+}
+
 export const twColors = {
-  primary600: ((fullConfig.theme.colors as unknown) as { [key: string]: any }).primary?.[600],
-  error600: ((fullConfig.theme.colors as unknown) as { [key: string]: any }).error?.[600],
+  primary600: resolveColor(((fullConfig.theme.colors as unknown) as { [key: string]: any }).primary?.[600]),
+  error600: resolveColor(((fullConfig.theme.colors as unknown) as { [key: string]: any }).error?.[600]),
   blue500: colors.blue[500],
 };
 


### PR DESCRIPTION
## Summary
- treat `twColors.primary600` as a value
- adjust twColors util to resolve function values

## Testing
- `npm run lint`
- `npm run test -- --run`


------
https://chatgpt.com/codex/tasks/task_e_6846577003fc832ca589616676a38c4e