### PR TITLE
Add tests for auth helpers

### DIFF
--- a/__tests__/apiAuth.test.ts
+++ b/__tests__/apiAuth.test.ts
@@ -1,0 +1,36 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { requireRole } from '../lib/apiAuth'
+import type { RecordModel } from 'pocketbase'
+
+let mockGetUserFromHeaders: ReturnType<typeof vi.fn>
+vi.mock('../lib/getUserFromHeaders', () => ({
+  getUserFromHeaders: (...args: unknown[]) => mockGetUserFromHeaders(...args)
+}))
+mockGetUserFromHeaders = vi.fn()
+
+beforeEach(() => {
+  vi.clearAllMocks()
+})
+
+describe('requireRole', () => {
+  it('propaga erro de autenticacao', () => {
+    mockGetUserFromHeaders.mockReturnValue({ error: 'fail' })
+    const result = requireRole({} as any, 'admin')
+    expect(result).toEqual({ error: 'fail', status: 401 })
+  })
+
+  it('nega acesso para role incorreta', () => {
+    const user = { role: 'user' } as RecordModel
+    mockGetUserFromHeaders.mockReturnValue({ user, pbSafe: {} })
+    const result = requireRole({} as any, 'admin')
+    expect(result).toEqual({ error: 'Acesso negado', status: 403 })
+  })
+
+  it('permite acesso quando role correta', () => {
+    const pb = {}
+    const user = { role: 'admin' } as RecordModel
+    mockGetUserFromHeaders.mockReturnValue({ user, pbSafe: pb })
+    const result = requireRole({} as any, 'admin')
+    expect(result).toEqual({ user, pb })
+  })
+})

--- a/__tests__/getUserFromHeaders.test.ts
+++ b/__tests__/getUserFromHeaders.test.ts
@@ -1,0 +1,48 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { getUserFromHeaders } from '../lib/getUserFromHeaders'
+
+const mockPb = {
+  authStore: { save: vi.fn() },
+  autoCancellation: vi.fn()
+}
+
+vi.mock('../lib/pocketbase', () => ({
+  __esModule: true,
+  default: vi.fn(() => mockPb)
+}))
+
+function makeRequest(token?: string, user?: string) {
+  const headers = new Headers()
+  if (token) headers.set('Authorization', `Bearer ${token}`)
+  if (user) headers.set('X-PB-User', user)
+  return { headers } as any
+}
+
+beforeEach(() => {
+  vi.clearAllMocks()
+})
+
+describe('getUserFromHeaders', () => {
+  it('retorna erro quando cabecalhos faltam', () => {
+    const req = makeRequest()
+    expect(getUserFromHeaders(req)).toEqual({ error: 'Token ou usuário ausente.' })
+  })
+
+  it('retorna erro para usuario invalido', () => {
+    const req = makeRequest('tok', 'invalid')
+    expect(getUserFromHeaders(req)).toEqual({ error: 'Usuário inválido.' })
+  })
+
+  it('retorna usuario e instancia do pocketbase quando cabecalhos validos', () => {
+    const user = { id: '1', nome: 'Test' }
+    const token = '123'
+    const req = makeRequest(token, JSON.stringify(user))
+    const result = getUserFromHeaders(req)
+    expect('error' in result).toBe(false)
+    if ('pbSafe' in result) {
+      expect(result.user).toEqual(user)
+      expect(mockPb.authStore.save).toHaveBeenCalledWith(token, user)
+      expect(mockPb.autoCancellation).toHaveBeenCalledWith(false)
+    }
+  })
+})

--- a/app/admin/produtos/novo/ModalProduto.tsx
+++ b/app/admin/produtos/novo/ModalProduto.tsx
@@ -3,7 +3,7 @@ import { useEffect, useRef } from "react";
 export interface ModalProdutoProps {
   open: boolean;
   onClose: () => void;
-  onSubmit: (form: any) => void;
+  onSubmit: (form: Record<string, unknown>) => void;
   initial?: {
     nome?: string;
     preco?: string;
@@ -37,10 +37,10 @@ export function ModalProduto({
     // Corrige checkboxes (arrays)
     form.tamanhos = Array.from(
       formElement.querySelectorAll("input[name='tamanhos']:checked")
-    ).map((el: any) => el.value);
+    ).map((el) => (el as HTMLInputElement).value);
     form.generos = Array.from(
       formElement.querySelectorAll("input[name='generos']:checked")
-    ).map((el: any) => el.value);
+    ).map((el) => (el as HTMLInputElement).value);
     form.ativo = !!form.ativo;
     // Corrige imagens para ser FileList ou File[]
     const imagensInput = formElement.querySelector("input[name='imagens']") as HTMLInputElement;


### PR DESCRIPTION
## Summary
- fix ESLint `any` in ModalProduto and map generics
- test getUserFromHeaders with mocked PocketBase
- test requireRole mocking header helper

## Testing
- `npm run lint`
- `npx vitest run`


------
https://chatgpt.com/codex/tasks/task_e_6846527abaa4832c84ea0619fa904c34