### PR TITLE
feat(admin): adiciona gestao de eventos

### DIFF
--- a/app/admin/api/eventos/[id]/route.ts
+++ b/app/admin/api/eventos/[id]/route.ts
@@ -1,0 +1,57 @@
+import { NextRequest, NextResponse } from "next/server";
+import { requireRole } from "@/lib/apiAuth";
+
+export async function GET(req: NextRequest) {
+  const { pathname } = req.nextUrl;
+  const id = pathname.split("/").pop() ?? "";
+  if (!id) return NextResponse.json({ error: "ID ausente" }, { status: 400 });
+  const auth = requireRole(req, "coordenador");
+  if ("error" in auth) {
+    return NextResponse.json({ error: auth.error }, { status: auth.status });
+  }
+  const { pb } = auth;
+  try {
+    const evento = await pb.collection("eventos").getOne(id);
+    return NextResponse.json(evento, { status: 200 });
+  } catch (err) {
+    console.error("Erro ao obter evento:", err);
+    return NextResponse.json({ error: "Erro ao obter" }, { status: 500 });
+  }
+}
+
+export async function PUT(req: NextRequest) {
+  const { pathname } = req.nextUrl;
+  const id = pathname.split("/").pop() ?? "";
+  if (!id) return NextResponse.json({ error: "ID ausente" }, { status: 400 });
+  const auth = requireRole(req, "coordenador");
+  if ("error" in auth) {
+    return NextResponse.json({ error: auth.error }, { status: auth.status });
+  }
+  const { pb } = auth;
+  try {
+    const formData = await req.formData();
+    const evento = await pb.collection("eventos").update(id, formData);
+    return NextResponse.json(evento, { status: 200 });
+  } catch (err) {
+    console.error("Erro ao atualizar evento:", err);
+    return NextResponse.json({ error: "Erro ao atualizar" }, { status: 500 });
+  }
+}
+
+export async function DELETE(req: NextRequest) {
+  const { pathname } = req.nextUrl;
+  const id = pathname.split("/").pop() ?? "";
+  if (!id) return NextResponse.json({ error: "ID ausente" }, { status: 400 });
+  const auth = requireRole(req, "coordenador");
+  if ("error" in auth) {
+    return NextResponse.json({ error: auth.error }, { status: auth.status });
+  }
+  const { pb } = auth;
+  try {
+    await pb.collection("eventos").delete(id);
+    return NextResponse.json({ sucesso: true }, { status: 200 });
+  } catch (err) {
+    console.error("Erro ao excluir evento:", err);
+    return NextResponse.json({ error: "Erro ao excluir" }, { status: 500 });
+  }
+}

--- a/app/admin/api/eventos/route.ts
+++ b/app/admin/api/eventos/route.ts
@@ -1,0 +1,33 @@
+import { NextRequest, NextResponse } from "next/server";
+import { requireRole } from "@/lib/apiAuth";
+
+export async function GET(req: NextRequest) {
+  const auth = requireRole(req, "coordenador");
+  if ("error" in auth) {
+    return NextResponse.json({ error: auth.error }, { status: auth.status });
+  }
+  const { pb } = auth;
+  try {
+    const eventos = await pb.collection("eventos").getFullList({ sort: "-data" });
+    return NextResponse.json(eventos, { status: 200 });
+  } catch (err) {
+    console.error("Erro ao listar eventos:", err);
+    return NextResponse.json({ error: "Erro ao listar" }, { status: 500 });
+  }
+}
+
+export async function POST(req: NextRequest) {
+  const auth = requireRole(req, "coordenador");
+  if ("error" in auth) {
+    return NextResponse.json({ error: auth.error }, { status: auth.status });
+  }
+  const { pb } = auth;
+  try {
+    const formData = await req.formData();
+    const evento = await pb.collection("eventos").create(formData);
+    return NextResponse.json(evento, { status: 201 });
+  } catch (err) {
+    console.error("Erro ao criar evento:", err);
+    return NextResponse.json({ error: "Erro ao criar" }, { status: 500 });
+  }
+}

--- a/app/admin/components/Header.tsx
+++ b/app/admin/components/Header.tsx
@@ -37,6 +37,7 @@ const getNavLinks = (role?: string) => {
     { href: "/admin/usuarios", label: "Usuários" },
     { href: "/admin/campos", label: "Campos" },
     { href: "/admin/produtos", label: "Produtos" },
+    { href: "/admin/eventos", label: "Eventos" },
     { href: "/admin/posts", label: "Posts" },
 
   ];

--- a/app/admin/eventos/editar/[id]/page.tsx
+++ b/app/admin/eventos/editar/[id]/page.tsx
@@ -1,0 +1,74 @@
+"use client";
+import { useEffect, useState } from "react";
+import { useParams, useRouter } from "next/navigation";
+import { useAuthContext } from "@/lib/context/AuthContext";
+
+export default function EditarEventoPage() {
+  const { id } = useParams<{ id: string }>();
+  const { user, isLoggedIn } = useAuthContext();
+  const router = useRouter();
+  const [initial, setInitial] = useState<Record<string, unknown> | null>(null);
+  const [loading, setLoading] = useState(true);
+
+  useEffect(() => {
+    if (!isLoggedIn || !user || user.role !== "coordenador") {
+      router.replace("/admin/login");
+    }
+  }, [isLoggedIn, user, router]);
+
+  useEffect(() => {
+    fetch(`/admin/api/eventos/${id}`)
+      .then((r) => r.json())
+      .then((data) => {
+        setInitial({
+          titulo: data.titulo,
+          descricao: data.descricao,
+          data: data.data,
+          cidade: data.cidade,
+          status: data.status,
+        });
+      })
+      .finally(() => setLoading(false));
+  }, [id]);
+
+  if (loading || !initial) {
+    return <p className="p-4">Carregando...</p>;
+  }
+
+  async function handleSubmit(e: React.FormEvent) {
+    e.preventDefault();
+    const formElement = e.currentTarget as HTMLFormElement;
+    const formData = new FormData(formElement);
+    const res = await fetch(`/admin/api/eventos/${id}`, { method: "PUT", body: formData });
+    if (res.ok) {
+      router.push("/admin/eventos");
+    }
+  }
+
+  return (
+    <main className="max-w-xl mx-auto px-4 py-8">
+      <h1 className="text-2xl font-bold mb-4" style={{ fontFamily: "var(--font-heading)" }}>
+        Editar Evento
+      </h1>
+      <form onSubmit={handleSubmit} className="space-y-4">
+        <input className="input-base" name="titulo" defaultValue={String(initial.titulo)} required />
+        <textarea className="input-base" name="descricao" rows={2} defaultValue={String(initial.descricao)} required />
+        <input className="input-base" name="data" type="date" defaultValue={String(initial.data)} required />
+        <input className="input-base" name="cidade" defaultValue={String(initial.cidade)} required />
+        <input type="file" name="imagem" accept="image/*" className="input-base" />
+        <select name="status" defaultValue={String(initial.status)} className="input-base" required>
+          <option value="em breve">Em breve</option>
+          <option value="realizado">Realizado</option>
+        </select>
+        <div className="flex gap-2">
+          <button type="submit" className="btn btn-primary flex-1">
+            Salvar
+          </button>
+          <button type="button" onClick={() => router.push("/admin/eventos")} className="btn flex-1">
+            Cancelar
+          </button>
+        </div>
+      </form>
+    </main>
+  );
+}

--- a/app/admin/eventos/novo/ModalEvento.tsx
+++ b/app/admin/eventos/novo/ModalEvento.tsx
@@ -1,0 +1,76 @@
+import { useEffect, useRef } from "react";
+
+export interface ModalEventoProps<T extends Record<string, unknown>> {
+  open: boolean;
+  onClose: () => void;
+  onSubmit: (form: T) => void;
+  initial?: {
+    titulo?: string;
+    descricao?: string;
+    data?: string;
+    cidade?: string;
+    imagem?: FileList | null;
+    status?: "realizado" | "em breve";
+  };
+}
+
+export function ModalEvento<T extends Record<string, unknown>>({
+  open,
+  onClose,
+  onSubmit,
+  initial = {},
+}: ModalEventoProps<T>) {
+  const ref = useRef<HTMLDialogElement>(null);
+
+  useEffect(() => {
+    if (open) ref.current?.showModal();
+    else ref.current?.close();
+  }, [open]);
+
+  function handleSubmit(e: React.FormEvent) {
+    e.preventDefault();
+    const formElement = e.currentTarget as HTMLFormElement;
+    const form = new FormData(formElement);
+    onSubmit(Object.fromEntries(form) as T);
+    onClose();
+  }
+
+  return (
+    <dialog ref={ref} className="rounded-xl card max-w-lg w-full border-0 p-0 fade-in-up z-[9999]">
+      <form onSubmit={handleSubmit} className="p-6 space-y-5" method="dialog" autoComplete="off">
+        <div className="flex justify-between items-center mb-3">
+          <h2 className="text-xl font-bold" style={{ fontFamily: "var(--font-heading)" }}>
+            {initial?.titulo ? "Editar Evento" : "Novo Evento"}
+          </h2>
+          <button
+            type="button"
+            className="text-lg px-3 py-1 rounded hover:bg-neutral-100 dark:hover:bg-neutral-800"
+            onClick={onClose}
+            aria-label="Fechar"
+            tabIndex={0}
+          >
+            ×
+          </button>
+        </div>
+
+        <input className="input-base" name="titulo" placeholder="Título" defaultValue={initial.titulo || ""} required />
+        <textarea className="input-base" name="descricao" rows={2} defaultValue={initial.descricao || ""} required />
+        <input className="input-base" name="data" type="date" defaultValue={initial.data || ""} required />
+        <input className="input-base" name="cidade" defaultValue={initial.cidade || ""} required />
+        <input type="file" name="imagem" accept="image/*" className="input-base" />
+        <select name="status" defaultValue={initial.status || "em breve"} className="input-base" required>
+          <option value="em breve">Em breve</option>
+          <option value="realizado">Realizado</option>
+        </select>
+        <div className="flex justify-end gap-3 mt-4">
+          <button type="button" className="btn btn-secondary" onClick={onClose}>
+            Cancelar
+          </button>
+          <button type="submit" className="btn btn-primary">
+            Salvar
+          </button>
+        </div>
+      </form>
+    </dialog>
+  );
+}

--- a/app/admin/eventos/page.tsx
+++ b/app/admin/eventos/page.tsx
@@ -1,0 +1,141 @@
+"use client";
+import { useEffect, useState } from "react";
+import { useRouter, usePathname } from "next/navigation";
+import { useAuthContext } from "@/lib/context/AuthContext";
+import Link from "next/link";
+import type { Evento } from "@/types";
+import { ModalEvento } from "./novo/ModalEvento";
+
+const EVENTOS_POR_PAGINA = 10;
+
+export default function AdminEventosPage() {
+  const { user, isLoggedIn } = useAuthContext();
+  const router = useRouter();
+  const [eventos, setEventos] = useState<Evento[]>([]);
+  const [page, setPage] = useState(1);
+  const [modalOpen, setModalOpen] = useState(false);
+  const pathname = usePathname();
+
+  useEffect(() => {
+    if (!isLoggedIn || !user || user.role !== "coordenador") {
+      router.replace("/admin/login");
+    }
+  }, [isLoggedIn, user, router]);
+
+  useEffect(() => {
+    if (!isLoggedIn || !user || user.role !== "coordenador") return;
+
+    async function fetchEventos() {
+      try {
+        const res = await fetch("/admin/api/eventos");
+        const data = await res.json();
+        setEventos(Array.isArray(data) ? data : []);
+      } catch (err) {
+        console.error("Erro ao carregar eventos:", err);
+      }
+    }
+    fetchEventos();
+  }, [isLoggedIn, user]);
+
+  const totalPages = Math.ceil(eventos.length / EVENTOS_POR_PAGINA);
+  const paginated = eventos.slice((page - 1) * EVENTOS_POR_PAGINA, page * EVENTOS_POR_PAGINA);
+
+  const handleNovoEvento = (form: Evento) => {
+    const evento: Evento = {
+      id: crypto.randomUUID(),
+      titulo: String(form.titulo ?? ""),
+      descricao: String(form.descricao ?? ""),
+      data: String(form.data ?? ""),
+      cidade: String(form.cidade ?? ""),
+      status: (form.status as Evento["status"]) ?? "em breve",
+    };
+    setEventos((prev) => [evento, ...prev]);
+    setModalOpen(false);
+    setPage(1);
+  };
+
+  return (
+    <main className="max-w-4xl mx-auto px-4 py-8">
+      <div className="flex justify-between items-center mb-[var(--space-lg)]">
+        <h2 className="text-2xl font-bold" style={{ fontFamily: "var(--font-heading)" }}>
+          Eventos
+        </h2>
+        <button className="btn btn-primary" onClick={() => setModalOpen(true)}>
+          + Novo Evento
+        </button>
+      </div>
+
+      <nav className="mb-6 border-b border-neutral-200 dark:border-neutral-700 flex gap-4">
+        <Link
+          href="/admin/eventos"
+          className={`pb-2 ${pathname === "/admin/eventos" ? "border-b-2 border-[var(--accent)]" : "hover:text-[var(--accent)]"}`}
+        >
+          Eventos
+        </Link>
+      </nav>
+
+      {modalOpen && (
+        <ModalEvento<Evento>
+          open={modalOpen}
+          onClose={() => setModalOpen(false)}
+          onSubmit={handleNovoEvento}
+        />
+      )}
+
+      <div className="overflow-x-auto rounded border shadow-sm bg-neutral-50 dark:bg-neutral-900 border-neutral-200 dark:border-neutral-700">
+        <table className="table-base">
+          <thead>
+            <tr>
+              <th>Título</th>
+              <th>Data</th>
+              <th>Status</th>
+              <th>Ações</th>
+            </tr>
+          </thead>
+          <tbody>
+            {paginated.length === 0 ? (
+              <tr>
+                <td colSpan={4} className="text-center py-6 text-neutral-400">
+                  Nenhum evento cadastrado.
+                </td>
+              </tr>
+            ) : (
+              paginated.map((evento) => (
+                <tr key={evento.id}>
+                  <td className="font-medium">{evento.titulo}</td>
+                  <td>{new Date(evento.data).toLocaleDateString("pt-BR")}</td>
+                  <td>{evento.status === "realizado" ? <span className="text-green-600 font-semibold">Realizado</span> : <span className="text-yellow-600 font-semibold">Em breve</span>}</td>
+                  <td>
+                    <Link href={`/admin/eventos/editar/${evento.id}`} className="text-[var(--accent)] hover:underline">
+                      Editar
+                    </Link>
+                  </td>
+                </tr>
+              ))
+            )}
+          </tbody>
+        </table>
+      </div>
+
+      {totalPages > 1 && (
+        <div className="flex justify-center items-center gap-[var(--space-md)] mt-[var(--space-lg)]">
+          <button
+            className="btn btn-secondary"
+            disabled={page === 1}
+            onClick={() => setPage((p) => Math.max(1, p - 1))}
+          >
+            Anterior
+          </button>
+          <span className="text-sm">Página {page} de {totalPages}</span>
+          <button
+            className="btn btn-secondary"
+            disabled={page === totalPages}
+            onClick={() => setPage((p) => Math.min(totalPages, p + 1))}
+          >
+            Próxima
+          </button>
+        </div>
+      )}
+    </main>
+  );
+}

--- a/app/admin/produtos/page.tsx
+++ b/app/admin/produtos/page.tsx
@@ -51,13 +51,13 @@ export default function AdminProdutosPage() {
       nome: String(form.nome ?? ""),
       preco: Number(form.preco ?? 0),
       imagens: [], // ajuste se necessário
-      checkout_url: String((form as any).checkout_url ?? ""), // corrigido para checkout_url
+      checkout_url: String(form.checkout_url ?? ""),
       categoria: "", // ajuste se necessário
-      tamanhos: Array.isArray((form as any).tamanhos) ? (form as any).tamanhos as string[] : [],
-      generos: Array.isArray((form as any).generos) ? (form as any).generos as string[] : [],
-      descricao: String((form as any).descricao ?? ""),
-      detalhes: String((form as any).detalhes ?? ""),
-      ativo: !!(form as any).ativo,
+      tamanhos: Array.isArray(form.tamanhos) ? form.tamanhos : [],
+      generos: Array.isArray(form.generos) ? form.generos : [],
+      descricao: String(form.descricao ?? ""),
+      detalhes: String(form.detalhes ?? ""),
+      ativo: !!form.ativo,
       // ...adicione outros campos se necessário
     };
     setProdutos((prev) => [produto, ...prev]);

--- a/app/api/eventos/route.ts
+++ b/app/api/eventos/route.ts
@@ -1,0 +1,19 @@
+import { NextResponse } from "next/server";
+import createPocketBase from "@/lib/pocketbase";
+import { EventoRecord, atualizarStatus } from "@/lib/events";
+
+export async function GET() {
+  const pb = createPocketBase();
+  try {
+    const eventos = await pb.collection("eventos").getFullList<EventoRecord>({ sort: "-data" });
+    await atualizarStatus(eventos, pb);
+    const comUrls = eventos.map((e) => ({
+      ...e,
+      imagem: e.imagem ? pb.files.getUrl(e, e.imagem) : undefined,
+    }));
+    return NextResponse.json(comUrls);
+  } catch (err) {
+    console.error("Erro ao listar eventos:", err);
+    return NextResponse.json([], { status: 500 });
+  }
+}

--- a/lib/events.ts
+++ b/lib/events.ts
@@ -1,0 +1,27 @@
+export interface EventoRecord {
+  id: string;
+  titulo: string;
+  descricao: string;
+  data: string;
+  cidade: string;
+  imagem?: string;
+  status: "realizado" | "em breve";
+  [key: string]: unknown;
+}
+
+import type PocketBase from "pocketbase";
+
+export function atualizarStatus(eventos: EventoRecord[], pb: PocketBase): Promise<void[]> {
+  const agora = new Date();
+  const atualizacoes: Promise<void>[] = [];
+
+  eventos.forEach((e) => {
+    const dataEvento = new Date(e.data);
+    if (e.status !== "realizado" && !isNaN(dataEvento.getTime()) && dataEvento < agora) {
+      e.status = "realizado";
+      atualizacoes.push(pb.collection("eventos").update(e.id, { status: "realizado" }).then(() => {}));
+    }
+  });
+
+  return Promise.all(atualizacoes);
+}

--- a/types/index.ts
+++ b/types/index.ts
@@ -99,3 +99,14 @@ export type Categoria = {
   nome: string;
   slug: string;
 };
+
+export type Evento = {
+  id: string;
+  titulo: string;
+  descricao: string;
+  data: string;
+  cidade: string;
+  imagem?: string;
+  status: "realizado" | "em breve";
+  created?: string;
+};


### PR DESCRIPTION
## Summary
- criar tipo `Evento`
- adicionar util `atualizarStatus` para eventos
- incluir API de eventos (publica e admin)
- listar e editar eventos no admin
- adicionar link de Eventos no menu do admin

## Testing
- `npm run lint`
- `npm run test`

------
https://chatgpt.com/codex/tasks/task_e_68465cc6bc50832c8132a93bb6625122