### PR TITLE
Implementacao do role usuario

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,6 +96,14 @@ Esta integração realiza chamadas HTTP diretamente na API do Asaas, sem utiliza
 
 2. Utilize as variáveis `PB_ADMIN_EMAIL` e `PB_ADMIN_PASSWORD` para autenticar a aplicação.
 
+## Perfis de Acesso
+
+O sistema possui três níveis de usuário:
+
+- **Coordenador** – acesso total ao painel administrativo.
+- **Lider** – acesso restrito às inscrições e pedidos do seu campo.
+- **Usuário** – cliente final que realiza compras e visualiza a área do cliente em `/loja/cliente`.
+
 ## Blog e CMS
 
 Os arquivos de conteúdo ficam dentro da pasta `posts/` na raiz do projeto. Cada

--- a/app/admin/usuarios/novo/page.tsx
+++ b/app/admin/usuarios/novo/page.tsx
@@ -30,7 +30,7 @@ export default function NovoUsuarioPage() {
   const [telefone, setTelefone] = useState("");
   const [cpf, setCpf] = useState("");
   const [dataNascimento, setDataNascimento] = useState("");
-  const [role, setRole] = useState("lider");
+  const [role, setRole] = useState("usuario");
   const [campoId, setCampoId] = useState("");
   const [campos, setCampos] = useState<Campo[]>([]);
   const [mensagem, setMensagem] = useState("");
@@ -86,7 +86,7 @@ export default function NovoUsuarioPage() {
       setTelefone("");
       setCpf("");
       setDataNascimento("");
-      setRole("lider");
+      setRole("usuario");
       setCampoId("");
     } else {
       setMensagem("❌ Erro: " + (data?.error || "Erro desconhecido"));
@@ -168,6 +168,7 @@ export default function NovoUsuarioPage() {
           onChange={(e) => setRole(e.target.value)}
           className="w-full border rounded p-2"
         >
+          <option value="usuario">Usuário</option>
           <option value="lider">Liderança</option>
           <option value="coordenador">Coordenador</option>
         </select>

--- a/app/loja/cliente/page.tsx
+++ b/app/loja/cliente/page.tsx
@@ -1,9 +1,11 @@
 "use client";
 
-import { useAuthContext } from "@/lib/context/AuthContext";
+import { useAuthGuard } from "@/lib/hooks/useAuthGuard";
 
 export default function AreaCliente() {
-  const { user } = useAuthContext();
+  const { user, authChecked } = useAuthGuard(["usuario"]);
+
+  if (!authChecked) return null;
 
   const pedidos = [
     {

--- a/lib/context/AuthContext.tsx
+++ b/lib/context/AuthContext.tsx
@@ -10,7 +10,7 @@ import type { RecordModel } from "pocketbase";
 type UserModel = {
   id: string;
   nome: string;
-  role: "coordenador" | "lider" | "cliente";
+  role: "coordenador" | "lider" | "usuario";
   [key: string]: unknown;
 };
 

--- a/logs/DOC_LOG.md
+++ b/logs/DOC_LOG.md
@@ -40,3 +40,4 @@
 ## [2025-06-08] Documentado uso de dominio proprio com Vercel no README
 ## [2025-06-08] Atualizadas regras de acesso: produtos agora vinculados ao campo `user_org` e consultas filtradas por usuário.
 ## [2025-06-09] Movido rota de inscricoes do admin para raiz e atualizados caminhos.
+## [2025-06-09] Adicionado role 'usuario' e documentada seção de perfis de acesso no README.

--- a/types/UserModel.ts
+++ b/types/UserModel.ts
@@ -2,6 +2,6 @@ export type UserModel = {
   id: string;
   nome: string;
   email: string;
-  role: "coordenador" | "lider";
+  role: "coordenador" | "lider" | "usuario";
   [key: string]: unknown;
 };


### PR DESCRIPTION
## Summary
- adicionar role `usuario` nas tipagens e contexto de autenticação
- incluir opção de usuário comum na tela de cadastro
- proteger rota `/loja/cliente` e exigir role `usuario`
- documentar os perfis de acesso no README
- registrar atualização em `DOC_LOG.md`

## Testing
- `npm run lint` *(falhou: `next: not found`)*
- `npm run test` *(falhou: `vitest: not found`)*

------
https://chatgpt.com/codex/tasks/task_e_68466069ccec832c8e3a82409d7e620f