### PR TITLE
Fix unauthorized admin product requests

### DIFF
--- a/app/admin/api/produtos/route.ts
+++ b/app/admin/api/produtos/route.ts
@@ -7,6 +7,7 @@ export async function GET(req: NextRequest) {
     return NextResponse.json({ error: auth.error }, { status: auth.status });
   }
   const { pb, user } = auth;
+  console.log("PocketBase host:", (pb as any).baseUrl || (pb as any).client?.baseUrl);
   try {
     const produtos = await pb.collection("produtos").getFullList({
       sort: "-created",
@@ -25,6 +26,7 @@ export async function POST(req: NextRequest) {
     return NextResponse.json({ error: auth.error }, { status: auth.status });
   }
   const { pb, user } = auth;
+  console.log("PocketBase host:", (pb as any).baseUrl || (pb as any).client?.baseUrl);
   try {
     const formData = await req.formData();
     formData.set("user_org", user.id);

--- a/app/admin/produtos/categorias/page.tsx
+++ b/app/admin/produtos/categorias/page.tsx
@@ -26,9 +26,18 @@ export default function CategoriasAdminPage() {
 
   useEffect(() => {
     if (!isLoggedIn || !user || user.role !== "coordenador") return;
-    fetch("/admin/api/categorias")
+    const token = localStorage.getItem("pb_token");
+    const rawUser = localStorage.getItem("pb_user");
+    fetch("/admin/api/categorias", {
+      headers: {
+        Authorization: `Bearer ${token}`,
+        "X-PB-User": rawUser ?? "",
+      },
+    })
       .then((res) => res.json())
-      .then(setCategorias)
+      .then((data) => {
+        setCategorias(Array.isArray(data) ? data : []);
+      })
       .catch(() => {});
   }, [isLoggedIn, user]);
 
@@ -39,18 +48,31 @@ export default function CategoriasAdminPage() {
     const metodo = editId ? "PUT" : "POST";
     const url = editId ? `/admin/api/categorias/${editId}` : "/admin/api/categorias";
     try {
+      const token = localStorage.getItem("pb_token");
+      const rawUser = localStorage.getItem("pb_user");
       const res = await fetch(url, {
         method: metodo,
-        headers: { "Content-Type": "application/json" },
+        headers: {
+          "Content-Type": "application/json",
+          Authorization: `Bearer ${token}`,
+          "X-PB-User": rawUser ?? "",
+        },
         body: JSON.stringify({ nome }),
       });
       const data = await res.json();
       if (res.ok) {
         setNome("");
         setEditId(null);
-        fetch("/admin/api/categorias")
+        fetch("/admin/api/categorias", {
+          headers: {
+            Authorization: `Bearer ${token}`,
+            "X-PB-User": rawUser ?? "",
+          },
+        })
           .then((r) => r.json())
-          .then(setCategorias);
+          .then((cats) => {
+            setCategorias(Array.isArray(cats) ? cats : []);
+          });
       } else {
         console.error(data.error);
       }
@@ -61,7 +83,15 @@ export default function CategoriasAdminPage() {
 
   async function handleDelete(id: string) {
     if (!confirm("Confirma excluir?")) return;
-    await fetch(`/admin/api/categorias/${id}`, { method: "DELETE" });
+    const token = localStorage.getItem("pb_token");
+    const rawUser = localStorage.getItem("pb_user");
+    await fetch(`/admin/api/categorias/${id}`, {
+      method: "DELETE",
+      headers: {
+        Authorization: `Bearer ${token}`,
+        "X-PB-User": rawUser ?? "",
+      },
+    });
     setCategorias((prev) => prev.filter((c) => c.id !== id));
   }
 

--- a/app/admin/produtos/novo/ModalProduto.tsx
+++ b/app/admin/produtos/novo/ModalProduto.tsx
@@ -1,10 +1,11 @@
 import { useEffect, useRef } from "react";
 import { useState } from "react";
+import { useAuthContext } from "@/lib/context/AuthContext";
 
-export interface ModalProdutoProps {
+export interface ModalProdutoProps<T extends Record<string, unknown>> {
   open: boolean;
   onClose: () => void;
-  onSubmit: (form: Record<string, unknown>) => void;
+  onSubmit: (form: T) => void;
   initial?: {
     nome?: string;
     preco?: string;
@@ -19,14 +20,21 @@ export interface ModalProdutoProps {
   };
 }
 
-export function ModalProduto({
+interface Categoria {
+  id: string;
+  nome: string;
+  slug: string;
+}
+
+export function ModalProduto<T extends Record<string, unknown>>({
   open,
   onClose,
   onSubmit,
   initial = {},
-}: ModalProdutoProps) {
+}: ModalProdutoProps<T>) {
   const ref = useRef<HTMLDialogElement>(null);
-  const [categorias, setCategorias] = useState<{ id: string; nome: string }[]>([]);
+  const [categorias, setCategorias] = useState<Categoria[]>([]);
+  const { isLoggedIn, user } = useAuthContext();
 
   useEffect(() => {
     if (open) ref.current?.showModal();
@@ -34,11 +42,21 @@ export function ModalProduto({
   }, [open]);
 
   useEffect(() => {
-    fetch("/admin/api/categorias")
+    if (!isLoggedIn || !user || user.role !== "coordenador") return;
+    const token = localStorage.getItem("pb_token");
+    const rawUser = localStorage.getItem("pb_user");
+    fetch("/admin/api/categorias", {
+      headers: {
+        Authorization: `Bearer ${token}`,
+        "X-PB-User": rawUser ?? "",
+      },
+    })
       .then((r) => r.json())
-      .then(setCategorias)
+      .then((data) => {
+        setCategorias(Array.isArray(data) ? data : []);
+      })
       .catch(() => {});
-  }, []);
+  }, [isLoggedIn, user]);
 
   function handleSubmit(e: React.FormEvent) {
     e.preventDefault();
@@ -59,7 +77,7 @@ export function ModalProduto({
     form.imagens = imagensInput && imagensInput.files && imagensInput.files.length > 0
       ? imagensInput.files
       : null;
-    onSubmit(form);
+    onSubmit(form as T);
     onClose();
   }
 

--- a/app/admin/produtos/page.tsx
+++ b/app/admin/produtos/page.tsx
@@ -28,7 +28,14 @@ export default function AdminProdutosPage() {
 
     async function fetchProdutos() {
       try {
-        const res = await fetch("/admin/api/produtos");
+        const token = localStorage.getItem("pb_token");
+        const rawUser = localStorage.getItem("pb_user");
+        const res = await fetch("/admin/api/produtos", {
+          headers: {
+            Authorization: `Bearer ${token}`,
+            "X-PB-User": rawUser ?? "",
+          },
+        });
         const data = await res.json();
         setProdutos(Array.isArray(data) ? data : data.items ?? []);
       } catch (err) {
@@ -45,24 +52,48 @@ export default function AdminProdutosPage() {
   );
 
   // Função para adicionar produto na lista após cadastro via modal
-  const handleNovoProduto = (form: Record<string, unknown>) => {
-    // Aqui você pode adaptar para criar um Produto a partir do form retornado pelo modal
-    // Exemplo básico (ajuste conforme necessário para seu backend/estrutura):
-    const produto: Produto = {
-      id: crypto.randomUUID(), // ou gere conforme necessário
-      nome: String(form.nome ?? ""),
-      preco: Number(form.preco ?? 0),
-      imagens: [], // ajuste se necessário
-      checkout_url: String(form.checkoutUrl ?? ""),
-      categoria: "", // ajuste se necessário
-      tamanhos: Array.isArray(form.tamanhos) ? form.tamanhos as string[] : [],
-      generos: Array.isArray(form.generos) ? form.generos as string[] : [],
-      descricao: String(form.descricao ?? ""),
-      detalhes: String(form.detalhes ?? ""),
-      ativo: !!form.ativo,
-      // ...adicione outros campos se necessário
-    };
-    setProdutos((prev) => [produto, ...prev]);
+  const handleNovoProduto = async (form: Produto) => {
+    const formData = new FormData();
+    formData.set("nome", String(form.nome ?? ""));
+    formData.set("preco", String(form.preco ?? 0));
+    if (form.checkoutUrl) formData.set("checkoutUrl", String(form.checkoutUrl));
+    if (form.categoria) formData.set("categoria", String(form.categoria));
+    if (Array.isArray(form.tamanhos))
+      form.tamanhos.forEach((t) => formData.append("tamanhos", t));
+    if (Array.isArray(form.generos))
+      form.generos.forEach((g) => formData.append("generos", g));
+    if (form.descricao) formData.set("descricao", String(form.descricao));
+    if (form.detalhes) formData.set("detalhes", String(form.detalhes));
+    formData.set("ativo", String(form.ativo ? "true" : "false"));
+    if (form.imagens && form.imagens instanceof FileList) {
+      Array.from(form.imagens).forEach((file) =>
+        formData.append("imagens", file)
+      );
+    }
+
+    try {
+      const token = localStorage.getItem("pb_token");
+      const rawUser = localStorage.getItem("pb_user");
+      const res = await fetch("/admin/api/produtos", {
+        method: "POST",
+        headers: {
+          Authorization: `Bearer ${token}`,
+          "X-PB-User": rawUser ?? "",
+        },
+        body: formData,
+      });
+      if (!res.ok) {
+        const data = await res.json().catch(() => ({}));
+        console.error("Falha ao criar produto", res.status, data);
+        return;
+      }
+      const data = await res.json();
+      console.log("Produto criado:", data);
+      setProdutos((prev) => [data, ...prev]);
+    } catch (err) {
+      console.error("Erro ao criar produto:", err);
+    }
+
     setModalOpen(false);
     setPage(1);
   };
@@ -106,7 +137,7 @@ export default function AdminProdutosPage() {
 
       {/* O modal fica aqui, fora do cabeçalho. Só é aberto se modalOpen=true */}
       {modalOpen && (
-        <ModalProduto
+        <ModalProduto<Produto>
           open={modalOpen}
           onClose={() => setModalOpen(false)}
           onSubmit={handleNovoProduto}

--- a/logs/ERR_LOG.md
+++ b/logs/ERR_LOG.md
@@ -8,3 +8,8 @@
 ## [2025-06-07] Erro 'Property "posts" does not exist on type "{}"' em stories do blog, causando falha no build - dev - 441b5f1
 
 ## [2025-06-07] Corrigido mock de fetch nas stories do blog para retornar Response - dev - 4ab1693
+## [2025-06-09] Tratamento de dados de categoria para evitar erro "categorias.map is not a function" no modal de produto - dev - 20a0ca8
+## [2025-06-09] Corrigido retorno 401 ao acessar rotas de produtos e categorias no admin - dev - 655ebf9
+## [2025-06-09] Recuperação do token no momento da requisição para evitar 401 nas páginas de produtos - dev - 0a36fd1
+## [2025-06-09] Cadastro de produtos não enviava dados à API; adicionada chamada POST com logs - dev - 91694f6
+## [2025-06-09] Adicionado log de host do PocketBase nas rotas de produtos para verificar inconsistências de banco


### PR DESCRIPTION
## Summary
- fetch token and user from localStorage during requests
- document 401 fix in ERR_LOG
- send product creation to API with proper auth headers
- log product API errors for debugging
- log PocketBase host used by admin API to detect environment mismatch

## Testing
- `npm run lint` *(failed: next not found)*
- `npx tsc --noEmit` *(failed: module resolution errors)*

------
https://chatgpt.com/codex/tasks/task_e_684657861968832c9f65db28050bd5e2