### PR TITLE
Fix unauthorized admin product requests

### DIFF
--- a/app/admin/api/produtos/route.ts
+++ b/app/admin/api/produtos/route.ts
@@ -7,6 +7,7 @@ export async function GET(req: NextRequest) {
     return NextResponse.json({ error: auth.error }, { status: auth.status });
   }
   const { pb, user } = auth;
+  console.log("PocketBase host:", (pb as any).baseUrl || (pb as any).client?.baseUrl);
   try {
     const produtos = await pb.collection("produtos").getFullList({
       sort: "-created",
@@ -25,6 +26,7 @@ export async function POST(req: NextRequest) {
     return NextResponse.json({ error: auth.error }, { status: auth.status });
   }
   const { pb, user } = auth;
+  console.log("PocketBase host:", (pb as any).baseUrl || (pb as any).client?.baseUrl);
   try {
     const formData = await req.formData();
     formData.set("user_org", user.id);

--- a/app/admin/produtos/editar/[id]/page.tsx
+++ b/app/admin/produtos/editar/[id]/page.tsx
@@ -12,26 +12,52 @@ interface Categoria {
 
 export default function EditarProdutoPage() {
   const { id } = useParams<{ id: string }>();
-  const { user, isLoggedIn } = useAuthContext();
+  const { user: ctxUser, isLoggedIn } = useAuthContext();
   const router = useRouter();
+  const token =
+    typeof window !== "undefined" ? localStorage.getItem("pb_token") : null;
+  const rawUser =
+    typeof window !== "undefined" ? localStorage.getItem("pb_user") : null;
+  const user = rawUser ? JSON.parse(rawUser) : ctxUser;
   const [categorias, setCategorias] = useState<Categoria[]>([]);
   const [initial, setInitial] = useState<Record<string, unknown> | null>(null);
   const [loading, setLoading] = useState(true);
 
   useEffect(() => {
-    if (!isLoggedIn || !user || user.role !== "coordenador") {
+    if (!isLoggedIn || !token || !user || user.role !== "coordenador") {
       router.replace("/admin/login");
     }
-  }, [isLoggedIn, user, router]);
+  }, [isLoggedIn, token, user, router]);
 
   useEffect(() => {
-    fetch("/admin/api/categorias")
-      .then((r) => r.json())
-      .then(setCategorias)
-      .catch(() => {});
-    fetch(`/admin/api/produtos/${id}`)
+    if (!isLoggedIn || !token || !user || user.role !== "coordenador") return;
+    fetch("/admin/api/categorias", {
+      headers: {
+        Authorization: `Bearer ${token}`,
+        "X-PB-User": JSON.stringify(user),
+      },
+    })
       .then((r) => r.json())
       .then((data) => {
+        setCategorias(Array.isArray(data) ? data : []);
+      })
+      .catch(() => {});
+    fetch(`/admin/api/produtos/${id}`,
+      {
+        headers: {
+          Authorization: `Bearer ${token}`,
+          "X-PB-User": JSON.stringify(user),
+        },
+      })
+      .then(async (r) => {
+        if (r.status === 401) {
+          router.replace("/admin/login");
+          return null;
+        }
+        return r.json();
+      })
+      .then((data) => {
+        if (!data) return;
         setInitial({
           nome: data.nome,
           preco: data.preco,
@@ -45,7 +71,7 @@ export default function EditarProdutoPage() {
         });
       })
       .finally(() => setLoading(false));
-  }, [id]);
+  }, [id, isLoggedIn, user, router]);
 
   if (loading || !initial) {
     return <p className="p-4">Carregando...</p>;
@@ -55,7 +81,14 @@ export default function EditarProdutoPage() {
     e.preventDefault();
     const formElement = e.currentTarget as HTMLFormElement;
     const formData = new FormData(formElement);
-    const res = await fetch(`/admin/api/produtos/${id}`, { method: "PUT", body: formData });
+    const res = await fetch(`/admin/api/produtos/${id}`, {
+      method: "PUT",
+      body: formData,
+      headers: {
+        Authorization: `Bearer ${token}`,
+        "X-PB-User": JSON.stringify(user),
+      },
+    });
     if (res.ok) {
       router.push("/admin/produtos");
     }

--- a/app/admin/produtos/novo/ModalProduto.tsx
+++ b/app/admin/produtos/novo/ModalProduto.tsx
@@ -1,10 +1,11 @@
 import { useEffect, useRef } from "react";
 import { useState } from "react";
+import { useAuthContext } from "@/lib/context/AuthContext";
 
-export interface ModalProdutoProps {
+export interface ModalProdutoProps<T extends Record<string, unknown>> {
   open: boolean;
   onClose: () => void;
-  onSubmit: (form: Record<string, unknown>) => void;
+  onSubmit: (form: T) => void;
   initial?: {
     nome?: string;
     preco?: string;
@@ -19,14 +20,26 @@ export interface ModalProdutoProps {
   };
 }
 
-export function ModalProduto({
+interface Categoria {
+  id: string;
+  nome: string;
+  slug: string;
+}
+
+export function ModalProduto<T extends Record<string, unknown>>({
   open,
   onClose,
   onSubmit,
   initial = {},
-}: ModalProdutoProps) {
+}: ModalProdutoProps<T>) {
   const ref = useRef<HTMLDialogElement>(null);
-  const [categorias, setCategorias] = useState<{ id: string; nome: string }[]>([]);
+  const [categorias, setCategorias] = useState<Categoria[]>([]);
+  const { isLoggedIn, user: ctxUser } = useAuthContext();
+  const token =
+    typeof window !== "undefined" ? localStorage.getItem("pb_token") : null;
+  const rawUser =
+    typeof window !== "undefined" ? localStorage.getItem("pb_user") : null;
+  const user = rawUser ? JSON.parse(rawUser) : ctxUser;
 
   useEffect(() => {
     if (open) ref.current?.showModal();
@@ -34,11 +47,19 @@ export function ModalProduto({
   }, [open]);
 
   useEffect(() => {
-    fetch("/admin/api/categorias")
+    if (!isLoggedIn || !token || !user || user.role !== "coordenador") return;
+    fetch("/admin/api/categorias", {
+      headers: {
+        Authorization: `Bearer ${token}`,
+        "X-PB-User": JSON.stringify(user),
+      },
+    })
       .then((r) => r.json())
-      .then(setCategorias)
+      .then((data) => {
+        setCategorias(Array.isArray(data) ? data : []);
+      })
       .catch(() => {});
-  }, []);
+  }, [isLoggedIn, user]);
 
   function handleSubmit(e: React.FormEvent) {
     e.preventDefault();
@@ -59,7 +80,7 @@ export function ModalProduto({
     form.imagens = imagensInput && imagensInput.files && imagensInput.files.length > 0
       ? imagensInput.files
       : null;
-    onSubmit(form);
+    onSubmit(form as T);
     onClose();
   }
 

--- a/logs/ERR_LOG.md
+++ b/logs/ERR_LOG.md
@@ -8,3 +8,9 @@
 ## [2025-06-07] Erro 'Property "posts" does not exist on type "{}"' em stories do blog, causando falha no build - dev - 441b5f1
 
 ## [2025-06-07] Corrigido mock de fetch nas stories do blog para retornar Response - dev - 4ab1693
+## [2025-06-09] Tratamento de dados de categoria para evitar erro "categorias.map is not a function" no modal de produto - dev - 20a0ca8
+## [2025-06-09] Corrigido retorno 401 ao acessar rotas de produtos e categorias no admin - dev - 655ebf9
+## [2025-06-09] Recuperação do token no momento da requisição para evitar 401 nas páginas de produtos - dev - 0a36fd1
+## [2025-06-09] Cadastro de produtos não enviava dados à API; adicionada chamada POST com logs - dev - 91694f6
+## [2025-06-09] Adicionado log de host do PocketBase nas rotas de produtos para verificar inconsistências de banco
+## [2025-06-09] Ajustado envio de token e usuário nas páginas de produtos e categorias para evitar 401 - dev - TBD


### PR DESCRIPTION
## Summary
- fetch token and user from `localStorage` at component mount
- send auth headers consistently on product and category pages
- keep modal and edit page in sync with current token
- note auth header fix in `ERR_LOG`

## Testing
- `npm run lint` *(failed: next not found)*
- `npx tsc --noEmit` *(failed: numerous module resolution errors)*

------
https://chatgpt.com/codex/tasks/task_e_684657861968832c9f65db28050bd5e2