### PR TITLE
Atualiza redirecionamentos de login do admin

### DIFF
--- a/app/admin/campos/page.tsx
+++ b/app/admin/campos/page.tsx
@@ -25,7 +25,7 @@ export default function GerenciarCamposPage() {
 
   useEffect(() => {
     if (!token || !user || user.role !== "coordenador") {
-      router.replace("/admin/login");
+      router.replace("/login");
     }
   }, [token, user, router]);
 

--- a/app/admin/components/Header.tsx
+++ b/app/admin/components/Header.tsx
@@ -59,7 +59,7 @@ export default function Header() {
     pb.authStore.clear();
     localStorage.removeItem("pb_token");
     localStorage.removeItem("pb_user");
-    window.location.href = "/admin/login";
+    window.location.href = "/login";
   };
 
   return (
@@ -171,7 +171,7 @@ export default function Header() {
 
           {!isLoggedIn && (
             <Link
-              href="/admin/login"
+              href="/login"
               className="text-sm underline text-[var(--text-header-primary)] hover:text-white cursor-pointer"
             >
               Entrar
@@ -253,7 +253,7 @@ export default function Header() {
 
             {!isLoggedIn && (
               <Link
-                href="/admin/login"
+                href="/login"
                 onClick={() => setMenuAberto(false)}
                 className="text-left px-4 py-2 text-sm underline text-[var(--text-header-primary)] hover:text-white"
               >

--- a/app/admin/eventos/editar/[id]/page.tsx
+++ b/app/admin/eventos/editar/[id]/page.tsx
@@ -12,7 +12,7 @@ export default function EditarEventoPage() {
 
   useEffect(() => {
     if (!isLoggedIn || !user || user.role !== "coordenador") {
-      router.replace("/admin/login");
+      router.replace("/login");
     }
   }, [isLoggedIn, user, router]);
 

--- a/app/admin/eventos/page.tsx
+++ b/app/admin/eventos/page.tsx
@@ -30,7 +30,7 @@ export default function AdminEventosPage() {
   useEffect(() => {
     const { token, user } = getAuth();
     if (!isLoggedIn || !token || !user || user.role !== "coordenador") {
-      router.replace("/admin/login");
+      router.replace("/login");
     }
   }, [isLoggedIn, router, getAuth]);
 

--- a/app/admin/lider-painel/page.tsx
+++ b/app/admin/lider-painel/page.tsx
@@ -26,7 +26,7 @@ export default function LiderDashboardPage() {
 
   useEffect(() => {
     if (!isLoggedIn || !user || user.role !== "lider") {
-      router.replace("/admin/login");
+      router.replace("/login");
       return;
     }
 

--- a/app/admin/pedidos/page.tsx
+++ b/app/admin/pedidos/page.tsx
@@ -34,7 +34,7 @@ export default function PedidosPage() {
   // Redireciona se não for coordenador
   useEffect(() => {
     if (!isLoggedIn || !user) {
-      router.replace("/admin/login");
+      router.replace("/login");
     }
   }, [isLoggedIn, user, router]);
 

--- a/app/admin/posts/editar/[slug]/page.tsx
+++ b/app/admin/posts/editar/[slug]/page.tsx
@@ -28,7 +28,7 @@ export default function EditarPostPage() {
 
   useEffect(() => {
     if (!isLoggedIn || !user) {
-      router.replace("/admin/login");
+      router.replace("/login");
     }
   }, [isLoggedIn, user, router]);
 

--- a/app/admin/posts/novo/page.tsx
+++ b/app/admin/posts/novo/page.tsx
@@ -16,7 +16,7 @@ export default function NovoPostPage() {
 
   useEffect(() => {
     if (!isLoggedIn || !user) {
-      router.replace("/admin/login");
+      router.replace("/login");
     }
   }, [isLoggedIn, user, router]);
 

--- a/app/admin/posts/page.tsx
+++ b/app/admin/posts/page.tsx
@@ -23,7 +23,7 @@ export default function AdminPostsPage() {
 
   useEffect(() => {
     if (!isLoggedIn || !user) {
-      router.replace("/admin/login");
+      router.replace("/login");
     }
   }, [isLoggedIn, user, router]);
 

--- a/app/admin/produtos/categorias/page.tsx
+++ b/app/admin/produtos/categorias/page.tsx
@@ -30,7 +30,7 @@ export default function CategoriasAdminPage() {
   useEffect(() => {
     const { token, user } = getAuth();
     if (!isLoggedIn || !token || !user || user.role !== "coordenador") {
-      router.replace("/admin/login");
+      router.replace("/login");
     }
   }, [isLoggedIn, router, getAuth]);
 

--- a/app/admin/produtos/editar/[id]/page.tsx
+++ b/app/admin/produtos/editar/[id]/page.tsx
@@ -29,7 +29,7 @@ export default function EditarProdutoPage() {
   useEffect(() => {
     const { token, user } = getAuth();
     if (!isLoggedIn || !token || !user || user.role !== "coordenador") {
-      router.replace("/admin/login");
+      router.replace("/login");
     }
   }, [isLoggedIn, router, getAuth]);
 
@@ -59,7 +59,7 @@ export default function EditarProdutoPage() {
       })
       .then(async (r) => {
         if (r.status === 401) {
-          router.replace("/admin/login");
+          router.replace("/login");
           return null;
         }
         return r.json();

--- a/app/admin/produtos/page.tsx
+++ b/app/admin/produtos/page.tsx
@@ -28,7 +28,7 @@ export default function AdminProdutosPage() {
   useEffect(() => {
     const { token, user } = getAuth();
     if (!isLoggedIn || !token || !user || user.role !== "coordenador") {
-      router.replace("/admin/login");
+      router.replace("/login");
     }
   }, [isLoggedIn, router, getAuth]);
 

--- a/lib/hooks/useAuthGuard.ts
+++ b/lib/hooks/useAuthGuard.ts
@@ -21,7 +21,7 @@ export function useAuthGuard(
 
     if (!isLoggedIn || !temPermissao) {
       pb.authStore.clear();
-      router.replace("/admin/login");
+      router.replace("/login");
     } else {
       setAuthChecked(true);
     }

--- a/logs/DOC_LOG.md
+++ b/logs/DOC_LOG.md
@@ -41,3 +41,4 @@
 ## [2025-06-08] Atualizadas regras de acesso: produtos agora vinculados ao campo `user_org` e consultas filtradas por usuário.
 ## [2025-06-09] Movido rota de inscricoes do admin para raiz e atualizados caminhos.
 ## [2025-06-09] Adicionado role 'usuario' e documentada seção de perfis de acesso no README.
+## [2025-06-09] Atualizadas rotas de login do admin para "/login" e ajustadas referencias no Header.


### PR DESCRIPTION
## Sumário
- ajusta links para `/login` no Header do admin
- redireciona páginas do admin que usavam `router.replace('/admin/login')`
- registra atualização em `DOC_LOG.md`

## Testes
- `npm run lint` *(falhou: `next` não encontrado)*

------
https://chatgpt.com/codex/tasks/task_e_6846f0209f24832cb74ac71040cf67a4