### PR TITLE
Add CartPreview component with hover modal

### DIFF
--- a/app/components/CartButton.tsx
+++ b/app/components/CartButton.tsx
@@ -2,6 +2,7 @@
 
 import Link from "next/link";
 import { useCart } from "@/lib/context/CartContext";
+import CartPreview from "./CartPreview";
 
 function CartIcon({ filled }: { filled?: boolean }) {
   return filled ? (
@@ -40,14 +41,19 @@ export default function CartButton() {
   const filled = itens.length > 0;
 
   return (
-    <Link href="/loja/carrinho" aria-label="Carrinho" className="relative" prefetch={false}>
-      <CartIcon filled={filled} />
-      <span
-        className={`absolute -top-1 -right-1 rounded-full text-xs w-5 h-5 flex items-center justify-center ${filled ? "bg-red-600 text-white" : "bg-gray-400 text-black"}`}
-      >
-        {itens.reduce((sum, i) => sum + i.quantidade, 0)}
-      </span>
-    </Link>
+    <div className="relative group">
+      <Link href="/loja/carrinho" aria-label="Carrinho" className="relative" prefetch={false}>
+        <CartIcon filled={filled} />
+        <span
+          className={`absolute -top-1 -right-1 rounded-full text-xs w-5 h-5 flex items-center justify-center ${filled ? "bg-red-600 text-white" : "bg-gray-400 text-black"}`}
+        >
+          {itens.reduce((sum, i) => sum + i.quantidade, 0)}
+        </span>
+      </Link>
+      <div className="absolute right-0 mt-2 z-50 hidden group-hover:block">
+        <CartPreview />
+      </div>
+    </div>
   );
 }
 

--- a/app/components/CartPreview.tsx
+++ b/app/components/CartPreview.tsx
@@ -1,0 +1,59 @@
+"use client";
+
+import Link from "next/link";
+import Image from "next/image";
+import { useCart } from "@/lib/context/CartContext";
+
+export default function CartPreview() {
+  const { itens } = useCart();
+  const total = itens.reduce((sum, i) => sum + i.preco * i.quantidade, 0);
+
+  if (itens.length === 0) {
+    return (
+      <div className="card bg-[var(--background)] text-sm shadow-lg w-64">
+        <p className="text-center">Seu carrinho está vazio</p>
+      </div>
+    );
+  }
+
+  return (
+    <div className="card bg-[var(--background)] text-sm shadow-lg w-64">
+      <ul className="divide-y divide-neutral-200 dark:divide-neutral-700 max-h-48 overflow-y-auto">
+        {itens.map((item) => (
+          <li key={item.id} className="flex items-center gap-2 py-2">
+            {item.imagens?.[0] && (
+              <Image
+                src={item.imagens[0]}
+                alt={item.nome}
+                width={32}
+                height={32}
+                className="rounded"
+              />
+            )}
+            <div className="flex-1">
+              <p className="font-medium text-xs">{item.nome}</p>
+              <p className="text-xs text-neutral-600 dark:text-neutral-400">
+                x{item.quantidade}
+              </p>
+            </div>
+            <span className="text-xs font-semibold">
+              R$ {(item.preco * item.quantidade).toFixed(2).replace(".", ",")}
+            </span>
+          </li>
+        ))}
+      </ul>
+      <div className="flex justify-between items-center pt-2 border-t border-neutral-200 dark:border-neutral-700 mt-2">
+        <span className="font-semibold text-sm">Total:</span>
+        <span className="font-semibold text-sm">
+          R$ {total.toFixed(2).replace(".", ",")}
+        </span>
+      </div>
+      <Link
+        href="/loja/carrinho"
+        className="mt-3 btn btn-primary w-full text-center"
+      >
+        Ver Carrinho
+      </Link>
+    </div>
+  );
+}

--- a/logs/DOC_LOG.md
+++ b/logs/DOC_LOG.md
@@ -46,3 +46,4 @@
 ## [2025-06-09] Adicionado menu de usuário no Header com link para "Área do Cliente" e botão de sair.
 ## [2025-06-09] Adicionado o uso do rawEnvKey nas requisições para o asaas.
 ## [2025-06-09] Removida pagina duplicada de login na loja e criado redirecionamento para /login.
+## [2025-06-10] Adicionado componente CartPreview com documentação no Storybook.

--- a/stories/CartPreview.stories.tsx
+++ b/stories/CartPreview.stories.tsx
@@ -1,0 +1,24 @@
+import type { Meta, StoryObj } from '@storybook/nextjs';
+import CartPreview from '../app/components/CartPreview';
+import { CartProvider } from '../lib/context/CartContext';
+import { ThemeProvider } from '../lib/context/ThemeContext';
+
+const meta = {
+  title: 'Components/CartPreview',
+  component: CartPreview,
+  decorators: [
+    (Story) => (
+      <ThemeProvider>
+        <CartProvider>
+          <Story />
+        </CartProvider>
+      </ThemeProvider>
+    ),
+  ],
+  tags: ['autodocs'],
+} satisfies Meta<typeof CartPreview>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {};


### PR DESCRIPTION
## Summary
- show cart preview on hover and keep cart nav link working
- list items in CartPreview modal component
- document CartPreview in Storybook
- log documentation update

## Testing
- `npm run lint` *(fails: unused vars in route.ts)*
- `npm run test`


------
https://chatgpt.com/codex/tasks/task_e_684720d2755c832c8be025520adece77