### PR TITLE
Add header/footer to login page

### DIFF
--- a/app/login/page.tsx
+++ b/app/login/page.tsx
@@ -1,5 +1,10 @@
 import LoginForm from "../components/LoginForm";
+import LayoutWrapper from "../components/LayoutWrapper";
 
 export default function LoginPage() {
-  return <LoginForm />;
+  return (
+    <LayoutWrapper>
+      <LoginForm />
+    </LayoutWrapper>
+  );
 }


### PR DESCRIPTION
## Summary
- include `LayoutWrapper` on the login page so the header and footer render

## Testing
- `npm run lint` *(fails: createHmac defined but not used, etc.)*
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68472c77f3a8832c8a32be771f68c812