### PR TITLE
Fix product image loading in store

### DIFF
--- a/app/loja/produtos/page.tsx
+++ b/app/loja/produtos/page.tsx
@@ -64,13 +64,18 @@ export default async function ProdutoDetalhe({ params }: { params: Params }) {
 
       <div className="grid md:grid-cols-2 gap-12 items-start">
         <div>
-          <Image
-            src={pb.files.getURL(produto, produto.imagens[0])}
-            alt={produto.nome}
-            width={600}
-            height={600}
-            className="w-full rounded-xl border border-black_bean shadow-lg"
-          />
+          {(() => {
+            const img = produto.imagens?.[0] ?? produto.imagem;
+            return img ? (
+              <Image
+                src={pb.files.getURL(produto, img)}
+                alt={produto.nome}
+                width={600}
+                height={600}
+                className="w-full rounded-xl border border-black_bean shadow-lg"
+              />
+            ) : null;
+          })()}
 
           {/* Mostra as variações de cor */}
           {coresArray.length > 0 && (

--- a/logs/ERR_LOG.md
+++ b/logs/ERR_LOG.md
@@ -44,3 +44,4 @@
 ## [2025-06-09] Adicionada página e API de eventos com cabeçalhos de autenticação para evitar 401 - dev - a2d7bd0
 
 ## [2025-06-10] Ajustado uso de getURL nos produtos e categorias para impedir erro na loja - dev - 2b29c07
+## [2025-06-09] Corrigido erro de imagem sem src na loja/produtos - dev - 1937fbf


### PR DESCRIPTION
## Summary
- avoid rendering product image when none exists
- log the fix in `ERR_LOG.md`

## Testing
- `npm run lint` *(fails: next not found)*
- `npm run test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6847345832fc832ca4a08773849bf2c5