### PR TITLE
Adicionar link para loja e cadastro rápido de categorias

### DIFF
--- a/app/admin/components/Header.tsx
+++ b/app/admin/components/Header.tsx
@@ -28,6 +28,7 @@ const getNavLinks = (role?: string) => {
       { href: "/admin/lider-painel", label: "Painel" },
       { href: "/admin/inscricoes", label: "Inscrições" },
       { href: "/admin/pedidos", label: "Pedidos" },
+      { href: "/loja", label: "Ver loja" },
     ];
   }
 
@@ -40,6 +41,7 @@ const getNavLinks = (role?: string) => {
     { href: "/admin/produtos", label: "Produtos" },
     { href: "/admin/eventos", label: "Eventos" },
     { href: "/admin/posts", label: "Posts" },
+    { href: "/loja", label: "Ver loja" },
 
   ];
 };


### PR DESCRIPTION
## Summary
- exibir link *Ver loja* no menu do admin
- permitir cadastrar categoria diretamente na criação e edição de produtos

## Testing
- `npm run lint` *(fails: createHmac defined but never used, etc.)*

------
https://chatgpt.com/codex/tasks/task_e_684734e29e94832ca2385b3006ec7fa1