### PR TITLE
Implement AuthModal with SignUp

### DIFF
--- a/app/components/AuthModal.tsx
+++ b/app/components/AuthModal.tsx
@@ -1,0 +1,48 @@
+"use client";
+
+import { useState } from "react";
+import LoginForm from "./LoginForm";
+import SignUpForm from "./SignUpForm";
+
+export default function AuthModal({
+  open,
+  onClose,
+  defaultView = "login",
+}: {
+  open: boolean;
+  onClose: () => void;
+  defaultView?: "login" | "signup";
+}) {
+  const [view, setView] = useState<"login" | "signup">(defaultView);
+
+  if (!open) return null;
+
+  return (
+    <div className="fixed inset-0 bg-black/60 backdrop-blur-sm flex items-center justify-center z-50 p-4">
+      <div className="bg-white dark:bg-zinc-900 text-black dark:text-white p-6 rounded-xl shadow-xl w-full max-w-md relative">
+        <button
+          onClick={onClose}
+          className="absolute top-2 right-2 text-xl leading-none"
+          aria-label="Fechar"
+        >
+          &times;
+        </button>
+        <div className="flex justify-center gap-4 mb-4">
+          <button
+            onClick={() => setView("login")}
+            className={`px-4 py-1 rounded-full text-sm ${view === "login" ? "bg-black text-white" : "bg-neutral-200"}`}
+          >
+            Entrar
+          </button>
+          <button
+            onClick={() => setView("signup")}
+            className={`px-4 py-1 rounded-full text-sm ${view === "signup" ? "bg-black text-white" : "bg-neutral-200"}`}
+          >
+            Criar conta
+          </button>
+        </div>
+        {view === "login" ? <LoginForm /> : <SignUpForm onSuccess={onClose} />}
+      </div>
+    </div>
+  );
+}

--- a/app/components/Header.tsx
+++ b/app/components/Header.tsx
@@ -7,6 +7,7 @@ import Link from "next/link";
 import Image from "next/image";
 import { useAuthContext } from "@/lib/context/AuthContext";
 import { useAppConfig } from "@/lib/context/AppConfigContext";
+import AuthModal from "./AuthModal";
 
 type UserRole = "visitante" | "usuario" | "lider" | "coordenador";
 
@@ -23,6 +24,7 @@ export default function Header() {
   const [open, setOpen] = useState(false);
   const [adminOpen, setAdminOpen] = useState(false);
   const [clientOpen, setClientOpen] = useState(false);
+  const [showAuth, setShowAuth] = useState(false);
   const { user, isLoggedIn, logout } = useAuthContext();
   const { config } = useAppConfig();
   const adminMenuRef = useRef<HTMLUListElement>(null);
@@ -218,9 +220,9 @@ export default function Header() {
         )}
 
         {!isLoggedIn && (
-          <Link href="/login" className="btn btn-primary">
+          <button onClick={() => setShowAuth(true)} className="btn btn-primary">
             Acessar sua conta
-          </Link>
+          </button>
         )}
       </nav>
 
@@ -293,13 +295,15 @@ export default function Header() {
           )}
 
           {!isLoggedIn && (
-            <Link
-              href="/login"
-              onClick={() => setOpen(false)}
+            <button
+              onClick={() => {
+                setShowAuth(true);
+                setOpen(false);
+              }}
               className="btn btn-primary text-sm text-center mt-2"
             >
               Acessar sua conta
-            </Link>
+            </button>
           )}
 
           {isLoggedIn && (
@@ -308,5 +312,8 @@ export default function Header() {
         </div>
       )}
     </header>
+    {showAuth && (
+      <AuthModal open={showAuth} onClose={() => setShowAuth(false)} />
+    )}
   );
 }

--- a/app/components/SignUpForm.tsx
+++ b/app/components/SignUpForm.tsx
@@ -1,0 +1,78 @@
+"use client";
+
+import { useState } from "react";
+import { useAuthContext } from "@/lib/context/AuthContext";
+
+export default function SignUpForm({ onSuccess }: { onSuccess?: () => void }) {
+  const { signUp } = useAuthContext();
+  const [nome, setNome] = useState("");
+  const [email, setEmail] = useState("");
+  const [senha, setSenha] = useState("");
+  const [senhaConfirm, setSenhaConfirm] = useState("");
+  const [erro, setErro] = useState("");
+  const [loading, setLoading] = useState(false);
+
+  async function handleSubmit(e: React.FormEvent) {
+    e.preventDefault();
+    setErro("");
+    if (senha !== senhaConfirm) {
+      setErro("As senhas não coincidem.");
+      return;
+    }
+    setLoading(true);
+    try {
+      await signUp(nome, email, senha);
+      onSuccess?.();
+    } catch (err) {
+      console.error("Erro no cadastro:", err);
+      setErro("Não foi possível criar a conta.");
+    } finally {
+      setLoading(false);
+    }
+  }
+
+  return (
+    <form onSubmit={handleSubmit} className="space-y-4">
+      {erro && <p className="text-sm text-center text-error">{erro}</p>}
+      <input
+        type="text"
+        placeholder="Nome"
+        value={nome}
+        onChange={(e) => setNome(e.target.value)}
+        className="input-base"
+        required
+      />
+      <input
+        type="email"
+        placeholder="E-mail"
+        value={email}
+        onChange={(e) => setEmail(e.target.value)}
+        className="input-base"
+        required
+      />
+      <input
+        type="password"
+        placeholder="Senha"
+        value={senha}
+        onChange={(e) => setSenha(e.target.value)}
+        className="input-base"
+        required
+      />
+      <input
+        type="password"
+        placeholder="Confirme a senha"
+        value={senhaConfirm}
+        onChange={(e) => setSenhaConfirm(e.target.value)}
+        className="input-base"
+        required
+      />
+      <button
+        type="submit"
+        disabled={loading}
+        className={`btn btn-primary w-full ${loading ? "opacity-50" : ""}`}
+      >
+        {loading ? "Enviando..." : "Criar conta"}
+      </button>
+    </form>
+  );
+}

--- a/app/loja/categorias/[slug]/ProdutosFiltrados.tsx
+++ b/app/loja/categorias/[slug]/ProdutosFiltrados.tsx
@@ -2,6 +2,8 @@
 
 import Image from "next/image";
 import { useState } from "react";
+import { useAuthContext } from "@/lib/context/AuthContext";
+import AuthModal from "@/app/components/AuthModal";
 
 interface Produto {
   id: string;
@@ -24,6 +26,8 @@ export default function ProdutosFiltrados({
 }) {
   const [tamanho, setTamanho] = useState("");
   const [genero, setGenero] = useState("");
+  const [showAuth, setShowAuth] = useState(false);
+  const { isLoggedIn } = useAuthContext();
 
   const filtrados = produtos.filter((p) => {
     const matchTamanho =
@@ -89,6 +93,12 @@ export default function ProdutosFiltrados({
 
             <a
               href={p.checkout_url}
+              onClick={(e) => {
+                if (!isLoggedIn) {
+                  e.preventDefault();
+                  setShowAuth(true);
+                }
+              }}
               className="block mt-3 bg-black_bean text-white text-center py-2 rounded text-sm font-bold hover:bg-black_bean/90"
             >
               Comprar agora
@@ -96,6 +106,9 @@ export default function ProdutosFiltrados({
           </div>
         ))}
       </div>
+      {showAuth && (
+        <AuthModal open={showAuth} onClose={() => setShowAuth(false)} />
+      )}
     </>
   );
 }

--- a/app/loja/produtos/[slug]/page.tsx
+++ b/app/loja/produtos/[slug]/page.tsx
@@ -6,6 +6,8 @@ import Link from "next/link";
 import createPocketBase from "@/lib/pocketbase";
 import AddToCartButton from "./AddToCartButton";
 import { Suspense } from "react";
+import { useAuthContext } from "@/lib/context/AuthContext";
+import AuthModal from "@/app/components/AuthModal";
 
 interface Produto {
   id: string;
@@ -34,6 +36,8 @@ function ProdutoInterativo({
   checkout_url,
   descricao,
   produto,
+  isLoggedIn,
+  onRequireAuth,
 }: {
   imagens: Record<string, string[]>;
   generos: string[];
@@ -43,6 +47,8 @@ function ProdutoInterativo({
   checkout_url: string;
   descricao?: string;
   produto: Produto;
+  isLoggedIn: boolean;
+  onRequireAuth: () => void;
 }) {
   const [genero, setGenero] = useState(generos[0]);
   const [tamanho, setTamanho] = useState(tamanhos[0]);
@@ -131,6 +137,12 @@ function ProdutoInterativo({
           href={checkout_url}
           target="_blank"
           rel="noopener noreferrer"
+          onClick={(e) => {
+            if (!isLoggedIn) {
+              e.preventDefault();
+              onRequireAuth();
+            }
+          }}
           className="block w-full bg-cornell_red-600 hover:bg-cornell_red-700 text-white text-center py-3 rounded-full font-semibold transition text-lg"
         >
           Quero essa pra brilhar no Congresso!
@@ -267,6 +279,8 @@ function DetalhesSelecao({
 export default function ProdutoDetalhe({ params }: { params: Params }) {
   const [produto, setProduto] = useState<Produto | null>(null);
   const [erro, setErro] = useState(false);
+  const [showAuth, setShowAuth] = useState(false);
+  const { isLoggedIn } = useAuthContext();
 
   useEffect(() => {
     const pb = createPocketBase();
@@ -338,8 +352,13 @@ export default function ProdutoDetalhe({ params }: { params: Params }) {
           checkout_url={produto.checkout_url}
           descricao={produto.descricao}
           produto={produto}
+          isLoggedIn={isLoggedIn}
+          onRequireAuth={() => setShowAuth(true)}
         />
       </Suspense>
+      {showAuth && (
+        <AuthModal open={showAuth} onClose={() => setShowAuth(false)} />
+      )}
     </main>
   );
 }

--- a/lib/context/AuthContext.tsx
+++ b/lib/context/AuthContext.tsx
@@ -19,6 +19,7 @@ type AuthContextType = {
   isLoggedIn: boolean;
   isLoading: boolean;
   login: (email: string, password: string) => Promise<void>;
+  signUp: (nome: string, email: string, password: string) => Promise<void>;
   logout: () => void;
 };
 
@@ -27,6 +28,7 @@ const AuthContext = createContext<AuthContextType>({
   isLoggedIn: false,
   isLoading: true,
   login: async () => {},
+  signUp: async () => {},
   logout: () => {},
 });
 
@@ -88,6 +90,17 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
     setIsLoggedIn(true);
   };
 
+  const signUp = async (nome: string, email: string, password: string) => {
+    await pb.collection("usuarios").create({
+      nome,
+      email,
+      password,
+      passwordConfirm: password,
+      role: "usuario",
+    });
+    await login(email, password);
+  };
+
   const logout = () => {
     pb.authStore.clear();
     clearBaseAuth();
@@ -99,7 +112,7 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
 
   return (
     <AuthContext.Provider
-      value={{ user, isLoggedIn, isLoading, login, logout }}
+      value={{ user, isLoggedIn, isLoading, login, signUp, logout }}
     >
       {children}
     </AuthContext.Provider>

--- a/logs/DOC_LOG.md
+++ b/logs/DOC_LOG.md
@@ -47,3 +47,4 @@
 ## [2025-06-09] Adicionado o uso do rawEnvKey nas requisições para o asaas.
 ## [2025-06-09] Removida pagina duplicada de login na loja e criado redirecionamento para /login.
 ## [2025-06-10] Adicionado componente CartPreview com documentação no Storybook.
+## [2025-06-10] Implementado AuthModal com Login e Cadastro e integrado ao Header e páginas de produto.

--- a/stories/AuthModal.stories.tsx
+++ b/stories/AuthModal.stories.tsx
@@ -1,0 +1,25 @@
+import type { Meta, StoryObj } from '@storybook/nextjs';
+import AuthModal from '../app/components/AuthModal';
+import { AuthProvider } from '../lib/context/AuthContext';
+import { ThemeProvider } from '../lib/context/ThemeContext';
+
+const meta = {
+  title: 'Components/AuthModal',
+  component: AuthModal,
+  args: { open: true },
+  decorators: [
+    (Story) => (
+      <ThemeProvider>
+        <AuthProvider>
+          <Story />
+        </AuthProvider>
+      </ThemeProvider>
+    ),
+  ],
+  tags: ['autodocs'],
+} satisfies Meta<typeof AuthModal>;
+
+export default meta;
+export type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {};


### PR DESCRIPTION
## Summary
- create SignUpForm component
- add AuthModal to switch between login and register
- show AuthModal from Header and product pages
- trigger AuthModal when clicking "Comprar" if not logged in
- document new feature

## Testing
- `npx next lint` *(fails: next not found)*
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_684738ee92c8832ca1e24cf85100993e