### PR TITLE
Add signup/checkout tests and docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,6 +85,7 @@ Crie um arquivo `.env.local` na raiz e defina as seguintes variáveis:
 - `PB_ADMIN_PASSWORD` - senha do administrador
 - `ASAAS_API_KEY` - chave da API do Asaas para geração de pagamentos
 - `ASAAS_WEBHOOK_SECRET` - segredo para validar webhooks do Asaas
+- `ASAAS_API_URL` - URL base da API do Asaas (ex.: `https://sandbox.asaas.com/api/v3/`)
 - `NEXT_PUBLIC_SITE_URL` - endereço do site (opcional)
 
 Esta integração realiza chamadas HTTP diretamente na API do Asaas, sem utilizar o SDK oficial.
@@ -96,6 +97,15 @@ Esta integração realiza chamadas HTTP diretamente na API do Asaas, sem utiliza
 
 
 2. Utilize as variáveis `PB_ADMIN_EMAIL` e `PB_ADMIN_PASSWORD` para autenticar a aplicação.
+
+## Fluxo de Cadastro e Checkout
+
+1. O usuário preenche o formulário e os dados são enviados para `criarInscricao`.
+2. A função valida os campos e retorna uma inscrição com status `pendente`.
+3. Em seguida `criarPedido` gera o pedido vinculado à inscrição.
+4. A API `/admin/api/asaas` recebe o `pedidoId` e devolve a `url` de pagamento,
+   que é salva em `link_pagamento`.
+5. O usuário é redirecionado para essa URL para concluir o pagamento.
 
 ## Perfis de Acesso
 

--- a/__tests__/orderFlow.test.ts
+++ b/__tests__/orderFlow.test.ts
@@ -14,6 +14,12 @@ const dadosValidos = {
 }
 
 describe('Fluxo de inscrição e pedido', () => {
+  it('cria inscrição válida com status pendente', () => {
+    const inscricao = criarInscricao(dadosValidos)
+    expect(inscricao.status).toBe('pendente')
+    expect(inscricao.id).toMatch(/^insc_/)
+  })
+
   it('falha quando campos obrigatórios estão vazios', () => {
     expect(() =>
       criarInscricao({ ...dadosValidos, nome: '' })
@@ -25,6 +31,17 @@ describe('Fluxo de inscrição e pedido', () => {
     const pedido = criarPedido(inscricao)
     expect(pedido.id_inscricao).toBe(inscricao.id)
     expect(pedido.valor).toBe('10.00')
+    expect(pedido.status).toBe('pendente')
+  })
+
+  it('gera pedido para kit completo com valor 50', () => {
+    const inscricao = criarInscricao({
+      ...dadosValidos,
+      produto: 'Kit Camisa + Pulseira'
+    })
+    const pedido = criarPedido(inscricao)
+    expect(pedido.valor).toBe('50.00')
+    expect(pedido.email).toBe('sememail@teste.com')
     expect(pedido.status).toBe('pendente')
   })
 })

--- a/logs/DOC_LOG.md
+++ b/logs/DOC_LOG.md
@@ -47,3 +47,4 @@
 ## [2025-06-09] Adicionado o uso do rawEnvKey nas requisições para o asaas.
 ## [2025-06-09] Removida pagina duplicada de login na loja e criado redirecionamento para /login.
 ## [2025-06-10] Adicionado componente CartPreview com documentação no Storybook.
+## [2025-06-10] Adicionados testes de cadastro/checkout e documentação do fluxo no README.


### PR DESCRIPTION
## Summary
- extend orderFlow tests with signup and checkout cases
- document signup + checkout flow and Asaas variables in README
- log documentation update

## Testing
- `npm run lint`
- `npm run test`

------
https://chatgpt.com/codex/tasks/task_e_6847390010dc832cb059f379ce87b3a1