### PR TITLE
Add store success page

### DIFF
--- a/app/loja/sucesso/page.tsx
+++ b/app/loja/sucesso/page.tsx
@@ -1,0 +1,44 @@
+"use client";
+
+import { useSearchParams } from "next/navigation";
+import Link from "next/link";
+
+export default function SucessoPage() {
+  const searchParams = useSearchParams();
+  const pedido = searchParams.get("pedido");
+
+  return (
+    <div className="min-h-screen flex items-center justify-center bg-gradient-to-br from-primary-100 via-white to-primary-200 px-6">
+      <div className="max-w-md w-full bg-white shadow-xl rounded-2xl p-8 text-center space-y-6 border border-primary-300">
+        <h1 className="text-3xl font-extrabold text-[var(--accent)]">
+          🎉 Compra Confirmada!
+        </h1>
+
+        <p className="text-gray-700 text-base leading-relaxed">
+          {pedido ? (
+            <>Seu pedido <strong>#{pedido}</strong> foi processado com sucesso.</>
+          ) : (
+            <>Sua compra foi processada com sucesso.</>
+          )}
+        </p>
+
+        <div className="text-sm text-gray-500">
+          Verifique seu e-mail para os detalhes do pagamento.
+        </div>
+
+        <div className="pt-4 flex flex-col gap-2">
+          <Link href="/loja" className="btn btn-primary">
+            Continuar comprando
+          </Link>
+          <Link href="/loja/cliente" className="btn btn-secondary">
+            Ver meus pedidos
+          </Link>
+        </div>
+
+        <p className="text-xs text-gray-400 italic mt-6">
+          #UMADEUS2025 — Juntos na missão 💜
+        </p>
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- add success page for store checkout displaying order ID

## Testing
- `npm run lint`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684738fb8d88832cb25e94b2824acda3