### PR TITLE
Fix product links and filtering

### DIFF
--- a/app/admin/produtos/editar/[id]/page.tsx
+++ b/app/admin/produtos/editar/[id]/page.tsx
@@ -69,14 +69,24 @@ export default function EditarProdutoPage() {
       })
       .then((data) => {
         if (!data) return;
+        const tams = Array.isArray(data.tamanhos)
+          ? data.tamanhos
+          : typeof data.tamanhos === "string"
+          ? data.tamanhos.split(",").map((s: string) => s.trim())
+          : [];
+        const gens = Array.isArray(data.generos)
+          ? data.generos
+          : typeof data.generos === "string"
+          ? data.generos.split(",").map((s: string) => s.trim())
+          : [];
         setInitial({
           nome: data.nome,
           preco: data.preco,
           descricao: data.descricao,
           detalhes: data.detalhes,
-          checkoutUrl: data.checkout_url,
-          tamanhos: data.tamanhos,
-          generos: data.generos,
+          checkout_url: data.checkout_url,
+          tamanhos: tams,
+          generos: gens,
           categoria: data.categoria,
           ativo: data.ativo,
           cores:
@@ -84,7 +94,7 @@ export default function EditarProdutoPage() {
               ? data.cores
               : Array.isArray(data.cores)
               ? data.cores.join(", ")
-              : "", // trata string[] ou string
+              : "",
         });
         setSelectedCategoria(
           Array.isArray(data.categoria)
@@ -151,16 +161,14 @@ export default function EditarProdutoPage() {
         "input[name='tamanhos']:checked"
       )
     ).map((el) => el.value);
-    formData.delete("tamanhos");
-    tamanhos.forEach((t) => formData.append("tamanhos", t));
+    formData.set("tamanhos", tamanhos.join(","));
 
     const generos = Array.from(
       formElement.querySelectorAll<HTMLInputElement>(
         "input[name='generos']:checked"
       )
     ).map((el) => el.value);
-    formData.delete("generos");
-    generos.forEach((g) => formData.append("generos", g));
+    formData.set("generos", generos.join(","));
 
     // Categoria enviada sempre pelo id
     const catValue = selectedCategoria;
@@ -243,9 +251,9 @@ export default function EditarProdutoPage() {
           />
           <input
             className="input-base"
-            name="checkoutUrl"
+            name="checkout_url"
             type="url"
-            defaultValue={String(initial.checkoutUrl || "")}
+            defaultValue={String(initial.checkout_url || "")}
           />
 
           {/* Campo de cores HEX separadas por vírgula */}

--- a/app/admin/produtos/novo/ModalProduto.tsx
+++ b/app/admin/produtos/novo/ModalProduto.tsx
@@ -16,7 +16,7 @@ export interface ModalProdutoProps<T extends Record<string, unknown>> {
     generos?: string[];
     descricao?: string;
     detalhes?: string;
-    checkoutUrl?: string;
+    checkout_url?: string;
     categoria?: string;
     ativo?: boolean;
     cores?: string | string[];
@@ -259,10 +259,10 @@ export function ModalProduto<T extends Record<string, unknown>>({
             <label className="label-base">Checkout URL</label>
             <input
               className="input-base"
-              name="checkoutUrl"
+              name="checkout_url"
               placeholder="Checkout URL"
               type="url"
-              defaultValue={initial.checkoutUrl || ""}
+              defaultValue={initial.checkout_url || ""}
             />
           </div>
         </div>

--- a/app/admin/produtos/page.tsx
+++ b/app/admin/produtos/page.tsx
@@ -64,12 +64,15 @@ export default function AdminProdutosPage() {
     const formData = new FormData();
     formData.set("nome", String(form.nome ?? ""));
     formData.set("preco", String(form.preco ?? 0));
-    if (form.checkoutUrl) formData.set("checkoutUrl", String(form.checkoutUrl));
+    if (form.checkout_url)
+      formData.set("checkout_url", String(form.checkout_url));
     if (form.categoria) formData.set("categoria", String(form.categoria));
-    if (Array.isArray(form.tamanhos))
-      form.tamanhos.forEach((t) => formData.append("tamanhos", t));
-    if (Array.isArray(form.generos))
-      form.generos.forEach((g) => formData.append("generos", g));
+    if (Array.isArray(form.tamanhos)) {
+      formData.set("tamanhos", form.tamanhos.join(","));
+    }
+    if (Array.isArray(form.generos)) {
+      formData.set("generos", form.generos.join(","));
+    }
     if (form.descricao) formData.set("descricao", String(form.descricao));
     if (form.detalhes) formData.set("detalhes", String(form.detalhes));
     formData.set("ativo", String(form.ativo ? "true" : "false"));

--- a/app/loja/categorias/[slug]/ProdutosFiltrados.tsx
+++ b/app/loja/categorias/[slug]/ProdutosFiltrados.tsx
@@ -1,16 +1,15 @@
 "use client";
 
 import Image from "next/image";
+import Link from "next/link";
 import { useState } from "react";
-import { useAuthContext } from "@/lib/context/AuthContext";
-import AuthModal from "@/app/components/AuthModal";
 
 interface Produto {
   id: string;
   nome: string;
   preco: number;
   imagens: string[];
-  checkout_url: string;
+  slug: string;
   tamanhos?: string[];
   generos?: string[];
   categoria: string;
@@ -26,8 +25,6 @@ export default function ProdutosFiltrados({
 }) {
   const [tamanho, setTamanho] = useState("");
   const [genero, setGenero] = useState("");
-  const [showAuth, setShowAuth] = useState(false);
-  const { isLoggedIn } = useAuthContext();
 
   const filtrados = produtos.filter((p) => {
     const matchTamanho =
@@ -78,12 +75,8 @@ export default function ProdutosFiltrados({
                 height={400}
                 className="w-full h-auto object-cover rounded"
               />
-              <div className="absolute top-0 left-0 bg-black text-white text-xs px-2 py-1">
-                50% OFF
-              </div>
             </div>
 
-            <p className="text-xs text-gray-400 mt-2">Ver Semelhantes</p>
             <h2 className="text-sm font-medium text-black mt-1 line-clamp-2">
               {p.nome}
             </h2>
@@ -91,24 +84,15 @@ export default function ProdutosFiltrados({
               R$ {p.preco.toFixed(2).replace(".", ",")}
             </p>
 
-            <a
-              href={p.checkout_url}
-              onClick={(e) => {
-                if (!isLoggedIn) {
-                  e.preventDefault();
-                  setShowAuth(true);
-                }
-              }}
-              className="block mt-3 bg-black_bean text-white text-center py-2 rounded text-sm font-bold hover:bg-black_bean/90"
+            <Link
+              href={`/loja/produtos/${p.slug}`}
+              className="btn btn-primary w-full text-center mt-auto"
             >
-              Comprar agora
-            </a>
+              Ver detalhes
+            </Link>
           </div>
         ))}
       </div>
-      {showAuth && (
-        <AuthModal open={showAuth} onClose={() => setShowAuth(false)} />
-      )}
     </>
   );
 }

--- a/app/loja/categorias/[slug]/page.tsx
+++ b/app/loja/categorias/[slug]/page.tsx
@@ -7,7 +7,7 @@ interface Produto {
   nome: string;
   preco: number;
   imagens: string[];
-  checkout_url: string;
+  slug: string;
   categoria: string;
 }
 

--- a/app/loja/produtos/ProdutosFiltrados.tsx
+++ b/app/loja/produtos/ProdutosFiltrados.tsx
@@ -1,0 +1,136 @@
+"use client";
+
+import Image from "next/image";
+import Link from "next/link";
+import { useMemo, useState } from "react";
+
+interface Produto {
+  id: string;
+  nome: string;
+  preco: number;
+  imagens: string[];
+  slug: string;
+}
+
+export default function ProdutosFiltrados({ produtos }: { produtos: Produto[] }) {
+  const [busca, setBusca] = useState("");
+  const [faixasSelecionadas, setFaixasSelecionadas] = useState<string[]>([]);
+  const [ordem, setOrdem] = useState("recentes");
+
+  const faixasPreco = [
+    { label: "Até R$ 50", min: 0, max: 50 },
+    { label: "R$ 50 a R$ 100", min: 50, max: 100 },
+    { label: "Acima de R$ 100", min: 100, max: Infinity },
+  ];
+
+  const filtrados = useMemo(() => {
+    let res = produtos.filter((p) =>
+      p.nome.toLowerCase().includes(busca.toLowerCase())
+    );
+    if (faixasSelecionadas.length > 0) {
+      res = res.filter((p) =>
+        faixasSelecionadas.some((label) => {
+          const faixa = faixasPreco.find((f) => f.label === label);
+          return faixa ? p.preco >= faixa.min && p.preco <= faixa.max : true;
+        })
+      );
+    }
+    if (ordem === "menor-preco") {
+      res = [...res].sort((a, b) => a.preco - b.preco);
+    } else if (ordem === "maior-preco") {
+      res = [...res].sort((a, b) => b.preco - a.preco);
+    }
+    return res;
+  }, [busca, faixasSelecionadas, ordem, produtos]);
+
+  function toggleFaixa(label: string) {
+    setFaixasSelecionadas((prev) =>
+      prev.includes(label)
+        ? prev.filter((l) => l !== label)
+        : [...prev, label]
+    );
+  }
+
+  return (
+    <div className="flex gap-8">
+      <aside className="hidden md:block w-64 shrink-0 rounded-2xl bg-white/80 shadow-lg p-6 h-fit border border-[var(--accent-900)]/10">
+        <h2 className="text-lg font-semibold mb-4">Filtrar</h2>
+        <div className="mb-6">
+          <label className="block mb-2 text-sm">Buscar produto</label>
+          <input
+            type="text"
+            placeholder="Digite o nome"
+            className="input-base"
+            value={busca}
+            onChange={(e) => setBusca(e.target.value)}
+          />
+        </div>
+        <div className="mb-6">
+          <label className="block mb-2 text-sm">Preço</label>
+          <div className="space-y-2">
+            {faixasPreco.map((faixa) => (
+              <div key={faixa.label} className="flex items-center gap-2">
+                <input
+                  type="checkbox"
+                  className="accent-[var(--accent)]"
+                  checked={faixasSelecionadas.includes(faixa.label)}
+                  onChange={() => toggleFaixa(faixa.label)}
+                />
+                <span className="text-sm">{faixa.label}</span>
+              </div>
+            ))}
+          </div>
+        </div>
+        <div>
+          <label className="block mb-2 text-sm">Ordenar por</label>
+          <select
+            className="input-base"
+            value={ordem}
+            onChange={(e) => setOrdem(e.target.value)}
+          >
+            <option value="recentes">Mais recentes</option>
+            <option value="menor-preco">Menor preço</option>
+            <option value="maior-preco">Maior preço</option>
+          </select>
+        </div>
+      </aside>
+
+      <section className="flex-1">
+        <div className="md:hidden mb-4 flex gap-2">
+          <button className="btn btn-secondary">Filtrar</button>
+        </div>
+        <div className="grid grid-cols-2 sm:grid-cols-3 lg:grid-cols-4 gap-6">
+          {filtrados.map((p) => (
+            <div
+              key={p.id}
+              className="bg-white rounded-2xl shadow-lg border border-[var(--accent-900)]/10 flex flex-col items-center p-4 transition hover:shadow-xl"
+            >
+              <div className="w-full aspect-square flex items-center justify-center overflow-hidden rounded-xl mb-2 bg-neutral-100 border border-[var(--accent)]/5">
+                <Image
+                  src={p.imagens[0]}
+                  alt={p.nome}
+                  width={300}
+                  height={300}
+                  className="object-cover w-[90%] h-[90%] transition group-hover:scale-105"
+                  style={{ objectPosition: "center" }}
+                />
+              </div>
+              <h2 className="text-base font-semibold text-[var(--text-primary)] mb-1 line-clamp-2 text-center">
+                {p.nome}
+              </h2>
+              <p className="text-base font-bold text-[var(--accent-900)] mb-2">
+                R$ {p.preco.toFixed(2).replace(".", ",")}
+              </p>
+              <Link
+                href={`/loja/produtos/${p.slug}`}
+                className="btn btn-primary w-full text-center mt-auto"
+              >
+                Ver detalhes
+              </Link>
+            </div>
+          ))}
+        </div>
+      </section>
+    </div>
+  );
+}

--- a/app/loja/produtos/page.tsx
+++ b/app/loja/produtos/page.tsx
@@ -1,5 +1,5 @@
-import Image from "next/image";
 import createPocketBase from "@/lib/pocketbase";
+import ProdutosFiltrados from "./ProdutosFiltrados";
 
 interface Produto {
   id: string;
@@ -11,107 +11,21 @@ interface Produto {
 
 export default async function ProdutosPage() {
   const pb = createPocketBase();
-  const produtosPB: Produto[] = await pb.collection("produtos").getFullList({
+  const list = await pb.collection("produtos").getList<Produto>(1, 50, {
     filter: "ativo = true",
     sort: "-created",
   });
+  const produtosPB: Produto[] = list.items;
 
   const produtos = produtosPB.map((p) => ({
     ...p,
     imagens: (p.imagens || []).map((img) => pb.files.getURL(p, img)),
   }));
 
-  // Simulação de filtros estáticos, substitua por lógica dinâmica conforme necessidade
-  const faixasPreco = [
-    { label: "Até R$ 50", min: 0, max: 50 },
-    { label: "R$ 50 a R$ 100", min: 50, max: 100 },
-    { label: "Acima de R$ 100", min: 100, max: Infinity },
-  ];
-
   return (
     <main className="max-w-7xl mx-auto px-2 md:px-6 py-8 font-sans text-[var(--text-primary)]">
       <h1 className="text-2xl md:text-3xl font-bold mb-8">Produtos</h1>
-      <div className="flex gap-8">
-        {/* Sidebar */}
-        <aside className="hidden md:block w-64 shrink-0 rounded-2xl bg-white/80 shadow-lg p-6 h-fit border border-[var(--accent-900)]/10">
-          <h2 className="text-lg font-semibold mb-4">Filtrar</h2>
-          {/* Busca */}
-          <div className="mb-6">
-            <label className="block mb-2 text-sm">Buscar produto</label>
-            <input
-              type="text"
-              placeholder="Digite o nome"
-              className="input-base"
-              disabled
-            />
-          </div>
-          {/* Filtros de preço */}
-          <div className="mb-6">
-            <label className="block mb-2 text-sm">Preço</label>
-            <div className="space-y-2">
-              {faixasPreco.map((faixa) => (
-                <div key={faixa.label} className="flex items-center gap-2">
-                  <input
-                    type="checkbox"
-                    className="accent-[var(--accent)]"
-                    disabled
-                  />
-                  <span className="text-sm">{faixa.label}</span>
-                </div>
-              ))}
-            </div>
-          </div>
-          {/* Ordem */}
-          <div>
-            <label className="block mb-2 text-sm">Ordenar por</label>
-            <select className="input-base" disabled>
-              <option value="recentes">Mais recentes</option>
-              <option value="menor-preco">Menor preço</option>
-              <option value="maior-preco">Maior preço</option>
-            </select>
-          </div>
-        </aside>
-
-        {/* Grid de Produtos */}
-        <section className="flex-1">
-          {/* Filtros mobile */}
-          <div className="md:hidden mb-4 flex gap-2">
-            <button className="btn btn-secondary">Filtrar</button>
-            {/* Implemente off-canvas para filtros mobile se quiser depois */}
-          </div>
-          <div className="grid grid-cols-2 sm:grid-cols-3 lg:grid-cols-4 gap-6">
-            {produtos.map((p) => (
-              <div
-                key={p.id}
-                className="bg-white rounded-2xl shadow-lg border border-[var(--accent-900)]/10 flex flex-col items-center p-4 transition hover:shadow-xl"
-              >
-                <div className="w-full aspect-square flex items-center justify-center overflow-hidden rounded-xl mb-2 bg-neutral-100 border border-[var(--accent)]/5">
-                  <Image
-                    src={p.imagens[0]}
-                    alt={p.nome}
-                    width={300}
-                    height={300}
-                    className="object-cover w-[90%] h-[90%] transition group-hover:scale-105"
-                    style={{ objectPosition: "center" }}
-                  />
-                </div>
-                <h2 className="text-base font-semibold text-[var(--text-primary)] mb-1 line-clamp-2 text-center">
-                  {p.nome}
-                </h2>
-                <p className="text-base font-bold text-[var(--accent-900)] mb-2">
-                  R$ {p.preco.toFixed(2).replace(".", ",")}
-                </p>
-                <a
-                  href={`/loja/produtos/${p.slug}`}
-                  className="btn btn-primary w-full text-center mt-auto"
-                >
-                  Ver detalhes
-                </a>
-              </div>
-            ))}
-          </div>
-        </section>
-      </div>
+      <ProdutosFiltrados produtos={produtos} />
     </main>
   );
 }

--- a/stories/ProdutosFiltrados.stories.tsx
+++ b/stories/ProdutosFiltrados.stories.tsx
@@ -1,5 +1,5 @@
 import type { Meta, StoryObj } from '@storybook/nextjs';
-import ProdutosFiltrados from '../app/loja/categorias/[slug]/ProdutosFiltrados';
+import ProdutosFiltrados from '../app/loja/produtos/ProdutosFiltrados';
 
 const meta = {
   title: 'Loja/ProdutosFiltrados',
@@ -11,9 +11,7 @@ const meta = {
         nome: 'Camiseta Feminina',
         preco: 79.9,
         imagens: ['https://placehold.co/400'],
-        checkout_url: '#',
-        tamanhos: ['P', 'M'],
-        generos: ['feminino'],
+        slug: 'camiseta-feminina',
         categoria: 'roupas',
       },
       {
@@ -21,9 +19,7 @@ const meta = {
         nome: 'Camiseta Masculina',
         preco: 89.9,
         imagens: ['https://placehold.co/400'],
-        checkout_url: '#',
-        tamanhos: ['G', 'GG'],
-        generos: ['masculino'],
+        slug: 'camiseta-masculina',
         categoria: 'roupas',
       },
     ],


### PR DESCRIPTION
## Summary
- implement client-side search and price filters in store products page
- link product cards to detail pages instead of checkout
- keep category page filters working
- update Product interfaces and storybook data
- persist sizes and genres when creating or editing products
- load fewer products at once for faster store page

## Testing
- `npm run lint` *(fails: next not found)*
- `npm run test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68482d920938832cb1c0a7fda386641b