### PR TITLE
fix formData multi-select fields

### DIFF
--- a/app/admin/produtos/editar/[id]/page.tsx
+++ b/app/admin/produtos/editar/[id]/page.tsx
@@ -161,14 +161,16 @@ export default function EditarProdutoPage() {
         "input[name='tamanhos']:checked"
       )
     ).map((el) => el.value);
-    formData.set("tamanhos", tamanhos.join(","));
+    formData.delete("tamanhos");
+    tamanhos.forEach((t) => formData.append("tamanhos", t));
 
     const generos = Array.from(
       formElement.querySelectorAll<HTMLInputElement>(
         "input[name='generos']:checked"
       )
     ).map((el) => el.value);
-    formData.set("generos", generos.join(","));
+    formData.delete("generos");
+    generos.forEach((g) => formData.append("generos", g));
 
     // Categoria enviada sempre pelo id
     const catValue = selectedCategoria;

--- a/app/admin/produtos/page.tsx
+++ b/app/admin/produtos/page.tsx
@@ -68,10 +68,10 @@ export default function AdminProdutosPage() {
       formData.set("checkout_url", String(form.checkout_url));
     if (form.categoria) formData.set("categoria", String(form.categoria));
     if (Array.isArray(form.tamanhos)) {
-      formData.set("tamanhos", form.tamanhos.join(","));
+      form.tamanhos.forEach((t) => formData.append("tamanhos", t));
     }
     if (Array.isArray(form.generos)) {
-      formData.set("generos", form.generos.join(","));
+      form.generos.forEach((g) => formData.append("generos", g));
     }
     if (form.descricao) formData.set("descricao", String(form.descricao));
     if (form.detalhes) formData.set("detalhes", String(form.detalhes));


### PR DESCRIPTION
## Summary
- send each size or gender selection as a separate `FormData` field

## Testing
- `npm run lint` *(fails: 'categoriaModalOpen' is assigned a value but never used, etc.)*

------
https://chatgpt.com/codex/tasks/task_e_68483bf66824832cb52f9c5e58c9c177