### PR TITLE
Fix categoria modal on editar produto

### DIFF
--- a/app/admin/produtos/editar/[id]/page.tsx
+++ b/app/admin/produtos/editar/[id]/page.tsx
@@ -3,6 +3,7 @@
 import { useEffect, useState, useCallback, useRef } from "react";
 import { useParams, useRouter } from "next/navigation";
 import { useAuthContext } from "@/lib/context/AuthContext";
+import ModalCategoria from "../../categorias/ModalCategoria";
 
 interface Categoria {
   id: string;
@@ -428,6 +429,14 @@ export default function EditarProdutoPage() {
           </div>
         </form>
       </main>
+      {categoriaModalOpen && (
+        <ModalCategoria
+          open={categoriaModalOpen}
+          onClose={() => setCategoriaModalOpen(false)}
+          onSubmit={handleNovaCategoria}
+          initial={null}
+        />
+      )}
     </>
   );
 }


### PR DESCRIPTION
## Summary
- wire ModalCategoria in edit product page so categories can be created inline

## Testing
- `npm run lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_684845a14328832c944fdf5778ecedc6