### PR TITLE
Log error in produtos API

### DIFF
--- a/app/api/produtos/route.ts
+++ b/app/api/produtos/route.ts
@@ -31,6 +31,7 @@ export async function GET(req: NextRequest) {
 
     return NextResponse.json(comUrls);
   } catch (err) {
+    console.error(err);
     return NextResponse.json([], { status: 500 });
   }
 }


### PR DESCRIPTION
## Summary
- log errors when fetching products

## Testing
- `npm run lint` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_684845a2c490832cbe00560424b09d10