### PR TITLE
Fix ProdutosFiltrados memo deps

### DIFF
--- a/app/loja/produtos/ProdutosFiltrados.tsx
+++ b/app/loja/produtos/ProdutosFiltrados.tsx
@@ -41,7 +41,7 @@ export default function ProdutosFiltrados({ produtos }: { produtos: Produto[] })
       res = [...res].sort((a, b) => b.preco - a.preco);
     }
     return res;
-  }, [busca, faixasSelecionadas, ordem, produtos]);
+  }, [busca, faixasSelecionadas, ordem, produtos, faixasPreco]);
 
   function toggleFaixa(label: string) {
     setFaixasSelecionadas((prev) =>


### PR DESCRIPTION
## Summary
- include `faixasPreco` in ProdutosFiltrados memo dependencies

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_684845a49b18832cb8a5384b6e3ee749