### PR TITLE
Fix category page params and build issues

### DIFF
--- a/app/admin/produtos/editar/[id]/page.tsx
+++ b/app/admin/produtos/editar/[id]/page.tsx
@@ -3,7 +3,6 @@
 import { useEffect, useState, useCallback, useRef } from "react";
 import { useParams, useRouter } from "next/navigation";
 import { useAuthContext } from "@/lib/context/AuthContext";
-import ModalCategoria from "../../categorias/ModalCategoria";
 
 interface Categoria {
   id: string;
@@ -396,14 +395,6 @@ export default function EditarProdutoPage() {
           </div>
         </form>
       </main>
-      {categoriaModalOpen && (
-        <ModalCategoria
-          open={categoriaModalOpen}
-          onClose={() => setCategoriaModalOpen(false)}
-          onSubmit={handleNovaCategoria}
-          initial={null}
-        />
-      )}
     </>
   );
 }

--- a/app/loja/categorias/[slug]/page.tsx
+++ b/app/loja/categorias/[slug]/page.tsx
@@ -11,10 +11,16 @@ interface Produto {
   categoria: string;
 }
 
-export default async function CategoriaDetalhe(
-  { params }: { params: { slug: string } }
-) {
-  const { slug } = params;
+interface Params {
+  slug: string;
+}
+
+export default async function CategoriaDetalhe({
+  params,
+}: {
+  params: Promise<Params>;
+}) {
+  const { slug } = await params;
   const pb = createPocketBase();
 
   const produtosPB: Produto[] = await pb.collection("produtos").getFullList({

--- a/app/loja/categorias/page.tsx
+++ b/app/loja/categorias/page.tsx
@@ -1,5 +1,7 @@
 import createPocketBase from "@/lib/pocketbase";
 
+export const dynamic = "force-dynamic";
+
 interface Categoria {
   id: string;
   nome: string;

--- a/app/loja/checkout/page.tsx
+++ b/app/loja/checkout/page.tsx
@@ -2,9 +2,9 @@
 
 import { useCart } from "@/lib/context/CartContext";
 import { useRouter, useSearchParams } from "next/navigation";
-import { useState } from "react";
+import { Suspense, useState } from "react";
 
-export default function CheckoutPage() {
+function CheckoutContent() {
   const { itens, clearCart } = useCart();
   const router = useRouter();
   const searchParams = useSearchParams();
@@ -90,5 +90,13 @@ export default function CheckoutPage() {
         </button>
       </div>
     </main>
+  );
+}
+
+export default function CheckoutPage() {
+  return (
+    <Suspense>
+      <CheckoutContent />
+    </Suspense>
   );
 }

--- a/app/loja/cliente/page.tsx
+++ b/app/loja/cliente/page.tsx
@@ -46,7 +46,7 @@ export default function AreaCliente() {
           <strong>E-mail:</strong> {user?.email || "-"}
         </p>
         <p>
-          <strong>Telefone:</strong> {user?.telefone || "-"}
+          <strong>Telefone:</strong> {String(user?.telefone ?? "-")}
         </p>
 
         <div className="flex flex-wrap gap-2 pt-4">

--- a/app/loja/produtos/page.tsx
+++ b/app/loja/produtos/page.tsx
@@ -1,6 +1,8 @@
 import createPocketBase from "@/lib/pocketbase";
 import ProdutosFiltrados from "./ProdutosFiltrados";
 
+export const dynamic = "force-dynamic";
+
 interface Produto {
   id: string;
   nome: string;

--- a/app/loja/sucesso/page.tsx
+++ b/app/loja/sucesso/page.tsx
@@ -2,8 +2,9 @@
 
 import { useSearchParams } from "next/navigation";
 import Link from "next/link";
+import { Suspense } from "react";
 
-export default function SucessoPage() {
+function SucessoContent() {
   const searchParams = useSearchParams();
   const pedido = searchParams.get("pedido");
 
@@ -40,5 +41,13 @@ export default function SucessoPage() {
         </p>
       </div>
     </div>
+  );
+}
+
+export default function SucessoPage() {
+  return (
+    <Suspense>
+      <SucessoContent />
+    </Suspense>
   );
 }

--- a/stories/AuthModal.stories.tsx
+++ b/stories/AuthModal.stories.tsx
@@ -22,4 +22,9 @@ const meta = {
 export default meta;
 export type Story = StoryObj<typeof meta>;
 
-export const Default: Story = {};
+export const Default: Story = {
+  args: {
+    open: true,
+    onClose: () => {},
+  },
+};

--- a/stories/ProdutosFiltrados.stories.tsx
+++ b/stories/ProdutosFiltrados.stories.tsx
@@ -12,7 +12,6 @@ const meta = {
         preco: 79.9,
         imagens: ['https://placehold.co/400'],
         slug: 'camiseta-feminina',
-        categoria: 'roupas',
       },
       {
         id: '2',
@@ -20,7 +19,6 @@ const meta = {
         preco: 89.9,
         imagens: ['https://placehold.co/400'],
         slug: 'camiseta-masculina',
-        categoria: 'roupas',
       },
     ],
   },


### PR DESCRIPTION
## Summary
- update `CategoriaDetalhe` to receive async params
- cast telefone when rendering in client area
- wrap checkout and success pages with Suspense
- mark categoria and produtos pages as dynamic to avoid build fetch
- adjust Storybook stories for strict typing
- remove unused modal from product edit page

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68484b3c9a88832ca4e220d7ac5cf797