### PR TITLE
Atualiza docs sobre checkout na loja

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,8 +100,9 @@ Esta integração realiza chamadas HTTP diretamente na API do Asaas, sem utiliza
 1. O usuário preenche o formulário e os dados são enviados para `criarInscricao`.
 2. A função valida os campos e retorna uma inscrição com status `pendente`.
 3. Em seguida `criarPedido` gera o pedido vinculado à inscrição.
-4. A API `/admin/api/asaas` recebe o `pedidoId` e devolve a `url` de pagamento,
-   que é salva em `link_pagamento`.
+4. Compras feitas na loja enviam o `pedidoId` para o endpoint `/checkouts`, que
+   comunica-se com `/admin/api/asaas` para gerar a `url` de pagamento e salvá-la
+   em `link_pagamento`.
 5. O usuário é redirecionado para essa URL para concluir o pagamento.
 
 ## Perfis de Acesso

--- a/logs/DOC_LOG.md
+++ b/logs/DOC_LOG.md
@@ -53,3 +53,4 @@
 ## [2025-06-10] README traduzido e introducao atualizada; adicionada nota de personalizacao.
 ## [2025-06-10] Atualizadas classes de cor para uso de bg-primary-* e text-primary-* nas páginas e docs.
 ## [2025-06-10] Padronizada sintaxe theme('colors.*') em globals.css e stories para compatibilidade com Tailwind.
+## [2025-06-10] README atualizado incluindo novo endpoint /checkouts


### PR DESCRIPTION
## Summary
- documenta endpoint `/checkouts` no fluxo de cadastro e checkout
- registra atualização de documentação no log

## Testing
- `npm run lint` *(fails: no-unused-vars, unexpected any)*
- `npm run test`

------
https://chatgpt.com/codex/tasks/task_e_68489333ef54832c8e96562c66b50873