### PR TITLE
Add zod validation to checkout API

### DIFF
--- a/__tests__/asaasCheckout.test.ts
+++ b/__tests__/asaasCheckout.test.ts
@@ -29,12 +29,42 @@ describe('checkout route', () => {
 
     const req = new Request('http://test', {
       method: 'POST',
-      body: JSON.stringify({ valor: 10, itens: [], successUrl: 's', errorUrl: 'e' })
+      body: JSON.stringify({
+        valor: 10,
+        itens: [{ name: 'p', quantity: 1, value: 10 }],
+        successUrl: 's',
+        errorUrl: 'e'
+      })
     });
 
     const res = await POST(req as unknown as NextRequest);
     const data = await res.json();
     expect(fetchMock).toHaveBeenCalledWith('https://asaas/checkouts', expect.any(Object));
     expect(data.checkoutUrl).toBe('url');
+  });
+
+  it('retorna 400 quando corpo inválido', async () => {
+    const req = new Request('http://test', {
+      method: 'POST',
+      body: JSON.stringify({ valor: 'a', itens: [], successUrl: 's', errorUrl: 'e' })
+    });
+
+    const res = await POST(req as unknown as NextRequest);
+    expect(res.status).toBe(400);
+  });
+
+  it('retorna 400 quando itens incompletos', async () => {
+    const req = new Request('http://test', {
+      method: 'POST',
+      body: JSON.stringify({
+        valor: 10,
+        itens: [{ quantity: 1, value: 10 }],
+        successUrl: 's',
+        errorUrl: 'e'
+      })
+    });
+
+    const res = await POST(req as unknown as NextRequest);
+    expect(res.status).toBe(400);
   });
 });

--- a/package-lock.json
+++ b/package-lock.json
@@ -24,7 +24,8 @@
         "react-chartjs-2": "^5.3.0",
         "react-dom": "^18.2.0",
         "tippy.js": "^6.3.7",
-        "xlsx": "^0.18.5"
+        "xlsx": "^0.18.5",
+        "zod": "^3.25.61"
       },
       "devDependencies": {
         "@eslint/eslintrc": "^3",
@@ -17354,6 +17355,15 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/zod": {
+      "version": "3.25.61",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.61.tgz",
+      "integrity": "sha512-fzfJgUw78LTNnHujj9re1Ov/JJQkRZZGDMcYqSx7Hp4rPOkKywaFHq0S6GoHeXs0wGNE/sIOutkXgnwzrVOGCQ==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
       }
     },
     "node_modules/zwitch": {

--- a/package.json
+++ b/package.json
@@ -29,7 +29,8 @@
     "react-chartjs-2": "^5.3.0",
     "react-dom": "^18.2.0",
     "tippy.js": "^6.3.7",
-    "xlsx": "^0.18.5"
+    "xlsx": "^0.18.5",
+    "zod": "^3.25.61"
   },
   "devDependencies": {
     "@eslint/eslintrc": "^3",


### PR DESCRIPTION
## Summary
- validate checkout request payload with zod
- include zod in dependencies
- update checkout tests to use valid payload
- add tests for invalid body cases

## Testing
- `npm test`
- `npm run lint` *(fails: unused vars in unrelated files)*

------
https://chatgpt.com/codex/tasks/task_e_6849824c2520832c8f34953286ae82ba