### PR TITLE
feat: refine store checkout flow

### DIFF
--- a/app/loja/carrinho/page.tsx
+++ b/app/loja/carrinho/page.tsx
@@ -4,6 +4,7 @@ import { useCart } from "@/lib/context/CartContext";
 import Image from "next/image";
 import { useRouter } from "next/navigation";
 import { useAuthContext } from "@/lib/context/AuthContext";
+import { useState } from "react";
 
 function formatCurrency(n: number) {
   return `R$ ${n.toFixed(2).replace(".", ",")}`;
@@ -13,11 +14,20 @@ export default function CarrinhoPage() {
   const { itens, removeItem, clearCart } = useCart();
   const { isLoggedIn } = useAuthContext();
   const router = useRouter();
+  const [showPrompt, setShowPrompt] = useState(false);
   const total = itens.reduce((sum, i) => sum + i.preco * i.quantidade, 0);
 
   function handleCheckout() {
-    if (!isLoggedIn) router.push("/login?redirect=/loja/checkout");
-    else router.push("/loja/checkout");
+    if (!isLoggedIn) {
+      setShowPrompt(true);
+      return;
+    }
+    router.push("/loja/checkout");
+  }
+
+  const goToSignup = () =>
+    router.push("/login?view=signup&redirect=/loja/checkout");
+  const goToLogin = () => router.push("/login?redirect=/loja/checkout");
   }
 
   if (itens.length === 0) {
@@ -57,6 +67,10 @@ export default function CarrinhoPage() {
               )}
               <div className="flex-1">
                 <p className="font-medium text-accent">{item.nome}</p>
+                <p className="text-xs text-gray-400">
+                  Modelo: {item.generos?.[0] || "-"} | Tamanho:{" "}
+                  {item.tamanhos?.[0] || "-"} | Cor: {item.cores?.[0] || "-"}
+                </p>
                 <p className="text-xs text-gray-400">Qtd: {item.quantidade}</p>
               </div>
               <div className="font-semibold text-accent">
@@ -89,6 +103,19 @@ export default function CarrinhoPage() {
           >
             Finalizar compra
           </button>
+          {showPrompt && !isLoggedIn && (
+            <div className="text-sm text-center text-gray-600 mt-4 w-full">
+              É necessário ter uma conta para prosseguir.{' '}
+              <button onClick={goToSignup} className="underline">
+                Criar conta
+              </button>{' '}
+              ou{' '}
+              <button onClick={goToLogin} className="underline">
+                fazer login
+              </button>
+              .
+            </div>
+          )}
         </div>
       </div>
     </main>

--- a/app/loja/checkout/page.tsx
+++ b/app/loja/checkout/page.tsx
@@ -13,13 +13,22 @@ function CheckoutContent() {
   const { itens, clearCart } = useCart();
   const router = useRouter();
   const searchParams = useSearchParams();
-  const { isLoggedIn } = useAuthContext();
+  const { isLoggedIn, user } = useAuthContext();
 
-  const [nome, setNome] = useState("");
-  const [telefone, setTelefone] = useState("");
-  const [email, setEmail] = useState("");
-  const [endereco, setEndereco] = useState("");
+  const [nome, setNome] = useState(user?.nome || "");
+  const [telefone, setTelefone] = useState(String(user?.telefone ?? ""));
+  const [email, setEmail] = useState(user?.email || "");
+  const [endereco, setEndereco] = useState(String(user?.endereco ?? ""));
   const [loading, setLoading] = useState(false);
+
+  useEffect(() => {
+    if (user) {
+      setNome(user.nome || "");
+      setTelefone(String(user.telefone ?? ""));
+      setEmail(user.email || "");
+      setEndereco(String(user.endereco ?? ""));
+    }
+  }, [user]);
 
   useEffect(() => {
     if (!isLoggedIn) {
@@ -166,8 +175,10 @@ function CheckoutContent() {
                 <div>
                   <div className="font-medium">{item.nome}</div>
                   <div className="text-xs text-gray-400">
-                    Qtd: {item.quantidade}
+                    Modelo: {item.generos?.[0] || "-"} | Tamanho:{" "}
+                    {item.tamanhos?.[0] || "-"} | Cor: {item.cores?.[0] || "-"}
                   </div>
+                  <div className="text-xs text-gray-400">Qtd: {item.quantidade}</div>
                 </div>
                 <div className="font-semibold">
                   {formatCurrency(item.preco * item.quantidade)}

--- a/logs/DOC_LOG.md
+++ b/logs/DOC_LOG.md
@@ -64,3 +64,4 @@
 ## [2025-06-11] Atualizado cadastro com novos campos e payload do checkout
 ## [2025-06-11] Foto do produto (base64) agora enviada no item do checkout, removida do cadastro de usuário
 ## [2025-06-11] Incluídos campos de endereço no cadastro e adequação do payload do checkout ao novo modelo do Asaas
+## [2025-06-12] Exibidos detalhes de cor, tamanho e modelo no carrinho e checkout com aviso de cadastro obrigatório


### PR DESCRIPTION
## Summary
- show item color, size and model in cart & checkout
- prompt login/signup from cart when user not logged in
- preload user info on checkout form
- log documentation update

## Testing
- `npm run lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_684a1c57e094832cadc44badd971f67d