### PR TITLE
feat: mostrar nome da cor no carrinho

### DIFF
--- a/app/loja/carrinho/page.tsx
+++ b/app/loja/carrinho/page.tsx
@@ -4,6 +4,8 @@ import { useCart } from "@/lib/context/CartContext";
 import Image from "next/image";
 import { useRouter } from "next/navigation";
 import { useAuthContext } from "@/lib/context/AuthContext";
+import { useState } from "react";
+import { hexToPtName } from "@/utils/colorNamePt";
 
 function formatCurrency(n: number) {
   return `R$ ${n.toFixed(2).replace(".", ",")}`;
@@ -13,12 +15,25 @@ export default function CarrinhoPage() {
   const { itens, removeItem, clearCart } = useCart();
   const { isLoggedIn } = useAuthContext();
   const router = useRouter();
+  const [showPrompt, setShowPrompt] = useState(false);
   const total = itens.reduce((sum, i) => sum + i.preco * i.quantidade, 0);
 
   function handleCheckout() {
-    if (!isLoggedIn) router.push("/login?redirect=/loja/checkout");
-    else router.push("/loja/checkout");
+    if (!isLoggedIn) {
+      setShowPrompt(true);
+      return;
+    }
+    router.push("/loja/checkout");
   }
+
+  const goToSignup = () => {
+    setShowPrompt(false);
+    router.push("/login?view=signup&redirect=/loja/checkout");
+  };
+  const goToLogin = () => {
+    setShowPrompt(false);
+    router.push("/login?redirect=/loja/checkout");
+  };
 
   if (itens.length === 0) {
     return (
@@ -57,6 +72,11 @@ export default function CarrinhoPage() {
               )}
               <div className="flex-1">
                 <p className="font-medium text-accent">{item.nome}</p>
+                <p className="text-xs text-gray-400">
+                  Modelo: {item.generos?.[0] || "-"} | Tamanho:{" "}
+                  {item.tamanhos?.[0] || "-"} | Cor:{" "}
+                  {item.cores?.[0] ? hexToPtName(item.cores[0]) : "-"}
+                </p>
                 <p className="text-xs text-gray-400">Qtd: {item.quantidade}</p>
               </div>
               <div className="font-semibold text-accent">
@@ -89,6 +109,19 @@ export default function CarrinhoPage() {
           >
             Finalizar compra
           </button>
+          {showPrompt && !isLoggedIn && (
+            <div className="text-sm text-center text-gray-600 mt-4 w-full">
+              Para finalizar a compra, é preciso ter uma conta.{' '}
+              <button onClick={goToSignup} className="underline">
+                Criar conta
+              </button>{' '}
+              ou{' '}
+              <button onClick={goToLogin} className="underline">
+                fazer login
+              </button>
+              .
+            </div>
+          )}
         </div>
       </div>
     </main>

--- a/app/loja/checkout/page.tsx
+++ b/app/loja/checkout/page.tsx
@@ -4,6 +4,7 @@ import { useCart } from "@/lib/context/CartContext";
 import { useRouter, useSearchParams } from "next/navigation";
 import { Suspense, useState, useEffect } from "react";
 import { useAuthContext } from "@/lib/context/AuthContext";
+import { hexToPtName } from "@/utils/colorNamePt";
 
 function formatCurrency(n: number) {
   return `R$ ${n.toFixed(2).replace(".", ",")}`;
@@ -13,13 +14,22 @@ function CheckoutContent() {
   const { itens, clearCart } = useCart();
   const router = useRouter();
   const searchParams = useSearchParams();
-  const { isLoggedIn } = useAuthContext();
+  const { isLoggedIn, user } = useAuthContext();
 
-  const [nome, setNome] = useState("");
-  const [telefone, setTelefone] = useState("");
-  const [email, setEmail] = useState("");
-  const [endereco, setEndereco] = useState("");
+  const [nome, setNome] = useState(user?.nome || "");
+  const [telefone, setTelefone] = useState(String(user?.telefone ?? ""));
+  const [email, setEmail] = useState(user?.email || "");
+  const [endereco, setEndereco] = useState(String(user?.endereco ?? ""));
   const [loading, setLoading] = useState(false);
+
+  useEffect(() => {
+    if (user) {
+      setNome(user.nome || "");
+      setTelefone(String(user.telefone ?? ""));
+      setEmail(user.email || "");
+      setEndereco(String(user.endereco ?? ""));
+    }
+  }, [user]);
 
   useEffect(() => {
     if (!isLoggedIn) {
@@ -166,8 +176,11 @@ function CheckoutContent() {
                 <div>
                   <div className="font-medium">{item.nome}</div>
                   <div className="text-xs text-gray-400">
-                    Qtd: {item.quantidade}
+                    Modelo: {item.generos?.[0] || "-"} | Tamanho:{" "}
+                    {item.tamanhos?.[0] || "-"} | Cor:{" "}
+                    {item.cores?.[0] ? hexToPtName(item.cores[0]) : "-"}
                   </div>
+                  <div className="text-xs text-gray-400">Qtd: {item.quantidade}</div>
                 </div>
                 <div className="font-semibold">
                   {formatCurrency(item.preco * item.quantidade)}

--- a/logs/DOC_LOG.md
+++ b/logs/DOC_LOG.md
@@ -64,3 +64,5 @@
 ## [2025-06-11] Atualizado cadastro com novos campos e payload do checkout
 ## [2025-06-11] Foto do produto (base64) agora enviada no item do checkout, removida do cadastro de usuário
 ## [2025-06-11] Incluídos campos de endereço no cadastro e adequação do payload do checkout ao novo modelo do Asaas
+## [2025-06-12] Exibidos detalhes de cor, tamanho e modelo no carrinho e checkout com aviso de cadastro obrigatório
+## [2025-06-12] Cores do carrinho e checkout agora exibem nome da cor

--- a/package-lock.json
+++ b/package-lock.json
@@ -15,6 +15,7 @@
         "@tiptap/react": "^2.14.0",
         "@tiptap/starter-kit": "^2.14.0",
         "chart.js": "^4.4.9",
+        "color-namer": "^1.4.0",
         "file-saver": "^2.0.5",
         "gray-matter": "^4.0.3",
         "lucide-react": "^0.511.0",
@@ -7391,6 +7392,11 @@
         "node": ">= 6"
       }
     },
+    "node_modules/chroma-js": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/chroma-js/-/chroma-js-1.4.1.tgz",
+      "integrity": "sha512-jTwQiT859RTFN/vIf7s+Vl/Z2LcMrvMv3WUFmd/4u76AdlFC0NTNgqEEFPcRiHmAswPsMiQEDZLM8vX8qXpZNQ=="
+    },
     "node_modules/chrome-trace-event": {
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/chrome-trace-event/-/chrome-trace-event-1.0.4.tgz",
@@ -7488,6 +7494,16 @@
       "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
       "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
       "devOptional": true
+    },
+    "node_modules/color-namer": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/color-namer/-/color-namer-1.4.0.tgz",
+      "integrity": "sha512-3mQMY9MJyfdV2uhe+xjQWcKHtYnPtl5svGjt89V2WWT2MlaLAd7C02886Wq7H1MTjjIIEa/NJLYPNF/Lhxhq2A==",
+      "license": "MIT",
+      "dependencies": {
+        "chroma-js": "^1.3.4",
+        "es6-weak-map": "^2.0.3"
+      }
     },
     "node_modules/color-string": {
       "version": "1.9.1",
@@ -7825,6 +7841,19 @@
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.1.3.tgz",
       "integrity": "sha512-M1uQkMl8rQK/szD0LNhtqxIPLpimGm8sOBwU7lLnCpSbTyY3yeU1Vc7l4KT5zT4s/yOxHH5O7tIuuLOCnLADRw==",
       "devOptional": true
+    },
+    "node_modules/d": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/d/-/d-1.0.2.tgz",
+      "integrity": "sha512-MOqHvMWF9/9MX6nza0KgvFH4HpMU0EF5uUDXqX/BtxtU8NfB0QzRtJ8Oe/6SuS4kbhyzVJwjd97EA4PKrzJ8bw==",
+      "license": "ISC",
+      "dependencies": {
+        "es5-ext": "^0.10.64",
+        "type": "^2.7.2"
+      },
+      "engines": {
+        "node": ">=0.12"
+      }
     },
     "node_modules/damerau-levenshtein": {
       "version": "1.0.8",
@@ -8522,6 +8551,58 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/es5-ext": {
+      "version": "0.10.64",
+      "resolved": "https://registry.npmjs.org/es5-ext/-/es5-ext-0.10.64.tgz",
+      "integrity": "sha512-p2snDhiLaXe6dahss1LddxqEm+SkuDvV8dnIQG0MWjyHpcMNfXKPE+/Cc0y+PhxJX3A4xGNeFCj5oc0BUh6deg==",
+      "hasInstallScript": true,
+      "license": "ISC",
+      "dependencies": {
+        "es6-iterator": "^2.0.3",
+        "es6-symbol": "^3.1.3",
+        "esniff": "^2.0.1",
+        "next-tick": "^1.1.0"
+      },
+      "engines": {
+        "node": ">=0.10"
+      }
+    },
+    "node_modules/es6-iterator": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/es6-iterator/-/es6-iterator-2.0.3.tgz",
+      "integrity": "sha512-zw4SRzoUkd+cl+ZoE15A9o1oQd920Bb0iOJMQkQhl3jNc03YqVjAhG7scf9C5KWRU/R13Orf588uCC6525o02g==",
+      "license": "MIT",
+      "dependencies": {
+        "d": "1",
+        "es5-ext": "^0.10.35",
+        "es6-symbol": "^3.1.1"
+      }
+    },
+    "node_modules/es6-symbol": {
+      "version": "3.1.4",
+      "resolved": "https://registry.npmjs.org/es6-symbol/-/es6-symbol-3.1.4.tgz",
+      "integrity": "sha512-U9bFFjX8tFiATgtkJ1zg25+KviIXpgRvRHS8sau3GfhVzThRQrOeksPeT0BWW2MNZs1OEWJ1DPXOQMn0KKRkvg==",
+      "license": "ISC",
+      "dependencies": {
+        "d": "^1.0.2",
+        "ext": "^1.7.0"
+      },
+      "engines": {
+        "node": ">=0.12"
+      }
+    },
+    "node_modules/es6-weak-map": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/es6-weak-map/-/es6-weak-map-2.0.3.tgz",
+      "integrity": "sha512-p5um32HOTO1kP+w7PRnB+5lQ43Z6muuMuIMffvDN8ZB4GcnjLBV6zGStpbASIMk4DCAvEaamhe2zhyCb/QXXsA==",
+      "license": "ISC",
+      "dependencies": {
+        "d": "1",
+        "es5-ext": "^0.10.46",
+        "es6-iterator": "^2.0.3",
+        "es6-symbol": "^3.1.1"
+      }
+    },
     "node_modules/esbuild": {
       "version": "0.21.5",
       "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.21.5.tgz",
@@ -8956,6 +9037,21 @@
         "url": "https://opencollective.com/eslint"
       }
     },
+    "node_modules/esniff": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/esniff/-/esniff-2.0.1.tgz",
+      "integrity": "sha512-kTUIGKQ/mDPFoJ0oVfcmyJn4iBDRptjNVIzwIFR7tqWXdVI9xfA2RMwY/gbSpJG3lkdWNEjLap/NqVHZiJsdfg==",
+      "license": "ISC",
+      "dependencies": {
+        "d": "^1.0.1",
+        "es5-ext": "^0.10.62",
+        "event-emitter": "^0.3.5",
+        "type": "^2.7.2"
+      },
+      "engines": {
+        "node": ">=0.10"
+      }
+    },
     "node_modules/espree": {
       "version": "10.3.0",
       "resolved": "https://registry.npmjs.org/espree/-/espree-10.3.0.tgz",
@@ -9108,6 +9204,16 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/event-emitter": {
+      "version": "0.3.5",
+      "resolved": "https://registry.npmjs.org/event-emitter/-/event-emitter-0.3.5.tgz",
+      "integrity": "sha512-D9rRn9y7kLPnJ+hMq7S/nhvoKwwvVJahBi2BPmx3bvbsEdK3W9ii8cBSGjP+72/LnM4n6fo3+dkCX5FeTQruXA==",
+      "license": "MIT",
+      "dependencies": {
+        "d": "1",
+        "es5-ext": "~0.10.14"
+      }
+    },
     "node_modules/event-target-shim": {
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/event-target-shim/-/event-target-shim-5.0.1.tgz",
@@ -9161,6 +9267,15 @@
       },
       "funding": {
         "url": "https://github.com/sindresorhus/execa?sponsor=1"
+      }
+    },
+    "node_modules/ext": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/ext/-/ext-1.7.0.tgz",
+      "integrity": "sha512-6hxeJYaL110a9b5TEJSj0gojyHQAmA2ch5Os+ySCiA1QGdS697XWY1pzsrSjqA9LDEEgdB/KypIlR59RcLuHYw==",
+      "license": "ISC",
+      "dependencies": {
+        "type": "^2.7.2"
       }
     },
     "node_modules/extend": {
@@ -12437,6 +12552,12 @@
           "optional": true
         }
       }
+    },
+    "node_modules/next-tick": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/next-tick/-/next-tick-1.1.0.tgz",
+      "integrity": "sha512-CXdUiJembsNjuToQvxayPZF9Vqht7hewsvy2sOWafLvi2awflj9mOC6bHIg50orX8IJvWKY9wYQ/zB2kogPslQ==",
+      "license": "ISC"
     },
     "node_modules/next/node_modules/postcss": {
       "version": "8.4.31",
@@ -16129,6 +16250,12 @@
       "dependencies": {
         "@mixmark-io/domino": "^2.2.0"
       }
+    },
+    "node_modules/type": {
+      "version": "2.7.3",
+      "resolved": "https://registry.npmjs.org/type/-/type-2.7.3.tgz",
+      "integrity": "sha512-8j+1QmAbPvLZow5Qpi6NCaN8FB60p/6x8/vfNqOk/hC+HuvFZhL4+WfekuhQLiqFZXOgQdrs3B+XxEmCc6b3FQ==",
+      "license": "ISC"
     },
     "node_modules/type-check": {
       "version": "0.4.0",

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
     "@tiptap/react": "^2.14.0",
     "@tiptap/starter-kit": "^2.14.0",
     "chart.js": "^4.4.9",
+    "color-namer": "^1.4.0",
     "file-saver": "^2.0.5",
     "gray-matter": "^4.0.3",
     "lucide-react": "^0.511.0",

--- a/utils/colorNamePt.ts
+++ b/utils/colorNamePt.ts
@@ -1,0 +1,33 @@
+import namer from 'color-namer'
+
+const ptMap: Record<string, string> = {
+  red: 'vermelho',
+  green: 'verde',
+  blue: 'azul',
+  yellow: 'amarelo',
+  orange: 'laranja',
+  purple: 'roxo',
+  violet: 'violeta',
+  pink: 'rosa',
+  brown: 'marrom',
+  black: 'preto',
+  white: 'branco',
+  gray: 'cinza',
+  grey: 'cinza',
+  cyan: 'ciano',
+  magenta: 'magenta',
+  gold: 'dourado',
+  silver: 'prata'
+}
+
+export function hexToPtName(hex: string): string {
+  if (!hex) return ''
+  try {
+    const basic = namer(hex).basic[0]
+    if (!basic) return hex
+    const base = basic.name.toLowerCase().split(' ')[0]
+    return ptMap[base] || basic.name
+  } catch {
+    return hex
+  }
+}


### PR DESCRIPTION
## Summary
- mostrar nome da cor em carrinho e checkout
- util para converter hex em nome de cor em pt-br
- registrado ajuste no DOC_LOG
- aprimorado prompt de login e tratativas do util

## Testing
- `npm run lint` *(fails: next not found)*
- `npm run test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_684a1c57e094832cadc44badd971f67d