### PR TITLE
Melhora redirecionamento para login

### DIFF
--- a/app/admin/produtos/editar/[id]/page.tsx
+++ b/app/admin/produtos/editar/[id]/page.tsx
@@ -51,7 +51,7 @@ export default function EditarProdutoPage() {
       .then((data) => {
         setCategorias(Array.isArray(data) ? data : []);
       })
-      .catch((err) => {
+      .catch(() => {
         setCategorias([]);
       });
     fetch(`/admin/api/produtos/${id}`, {

--- a/app/components/Header.tsx
+++ b/app/components/Header.tsx
@@ -7,7 +7,6 @@ import Link from "next/link";
 import Image from "next/image";
 import { useAuthContext } from "@/lib/context/AuthContext";
 import { useAppConfig } from "@/lib/context/AppConfigContext";
-import AuthModal from "./AuthModal";
 
 type UserRole = "visitante" | "usuario" | "lider" | "coordenador";
 
@@ -24,7 +23,6 @@ export default function Header() {
   const [open, setOpen] = useState(false);
   const [adminOpen, setAdminOpen] = useState(false);
   const [clientOpen, setClientOpen] = useState(false);
-  const [showAuth, setShowAuth] = useState(false);
   const { user, isLoggedIn, logout } = useAuthContext();
   const { config } = useAppConfig();
   const adminMenuRef = useRef<HTMLUListElement>(null);
@@ -223,12 +221,14 @@ export default function Header() {
             )}
 
             {!isLoggedIn && (
-              <button
-                onClick={() => setShowAuth(true)}
-                className="btn btn-primary"
-              >
-                Acessar sua conta
-              </button>
+              <>
+                <Link href="/login" className="btn btn-primary">
+                  Acessar sua conta
+                </Link>
+                <Link href="/login?view=signup" className="btn btn-secondary">
+                  Crie sua conta
+                </Link>
+              </>
             )}
           </nav>
 
@@ -301,15 +301,22 @@ export default function Header() {
             )}
 
             {!isLoggedIn && (
-              <button
-                onClick={() => {
-                  setShowAuth(true);
-                  setOpen(false);
-                }}
-                className="btn btn-primary text-sm text-center mt-2"
-              >
-                Acessar sua conta
-              </button>
+              <>
+                <Link
+                  href="/login"
+                  className="btn btn-primary text-sm text-center mt-2"
+                  onClick={() => setOpen(false)}
+                >
+                  Acessar sua conta
+                </Link>
+                <Link
+                  href="/login?view=signup"
+                  className="btn btn-secondary text-sm text-center"
+                  onClick={() => setOpen(false)}
+                >
+                  Crie sua conta
+                </Link>
+              </>
             )}
 
             {isLoggedIn && (
@@ -320,9 +327,6 @@ export default function Header() {
           </div>
         )}
       </header>
-      {showAuth && (
-        <AuthModal open={showAuth} onClose={() => setShowAuth(false)} />
-      )}
     </>
   );
 }

--- a/app/components/LoginForm.tsx
+++ b/app/components/LoginForm.tsx
@@ -7,7 +7,11 @@ import Image from "next/image";
 import RedefinirSenhaModal from "@/app/admin/components/RedefinirSenhaModal";
 import "@/app/globals.css"; // Certifique-se de que o CSS global está importado
 
-export default function LoginForm() {
+export default function LoginForm({
+  redirectTo,
+}: {
+  redirectTo?: string;
+}) {
   const router = useRouter();
   const { login, isLoggedIn, isLoading, user } = useAuthContext();
 
@@ -20,7 +24,9 @@ export default function LoginForm() {
   // Redirecionamento pós-login
   useEffect(() => {
     if (!isLoading && isLoggedIn && user) {
-      if (user.role === "coordenador") {
+      if (redirectTo) {
+        router.replace(redirectTo);
+      } else if (user.role === "coordenador") {
         router.replace("/admin/dashboard");
       } else if (user.role === "lider") {
         router.replace("/admin/lider-painel");
@@ -28,7 +34,7 @@ export default function LoginForm() {
         router.replace("/loja/cliente");
       }
     }
-  }, [isLoading, isLoggedIn, user, router]);
+  }, [isLoading, isLoggedIn, user, router, redirectTo]);
 
   if (!isLoading && isLoggedIn) {
     return null; // impede que o componente renderize novamente

--- a/app/login/page.tsx
+++ b/app/login/page.tsx
@@ -1,10 +1,56 @@
+"use client";
+import { useRouter, useSearchParams } from "next/navigation";
+import { useState, useEffect } from "react";
 import LoginForm from "../components/LoginForm";
+import SignUpForm from "../components/SignUpForm";
 import LayoutWrapper from "../components/LayoutWrapper";
 
 export default function LoginPage() {
+  const router = useRouter();
+  const searchParams = useSearchParams();
+  const initial = searchParams.get("view") === "signup" ? "signup" : "login";
+  const [view, setView] = useState<"login" | "signup">(initial);
+
+  useEffect(() => {
+    setView(initial);
+  }, [initial]);
+
+  function switchView(v: "login" | "signup") {
+    setView(v);
+    const params = new URLSearchParams(Array.from(searchParams.entries()));
+    if (v === "signup") {
+      params.set("view", "signup");
+    } else {
+      params.delete("view");
+    }
+    router.replace(`/login?${params.toString()}`);
+  }
+
+  const redirectTo = searchParams.get("redirect") || undefined;
+
   return (
     <LayoutWrapper>
-      <LoginForm />
+      <div className="max-w-md mx-auto my-12 p-6 bg-white dark:bg-neutral-900 rounded-xl shadow space-y-6">
+        <div className="flex justify-center gap-4">
+          <button
+            onClick={() => switchView("login")}
+            className={`px-4 py-1 rounded-full text-sm ${view === "login" ? "bg-black text-white" : "bg-neutral-200"}`}
+          >
+            Entrar
+          </button>
+          <button
+            onClick={() => switchView("signup")}
+            className={`px-4 py-1 rounded-full text-sm ${view === "signup" ? "bg-black text-white" : "bg-neutral-200"}`}
+          >
+            Criar conta
+          </button>
+        </div>
+        {view === "login" ? (
+          <LoginForm redirectTo={redirectTo} />
+        ) : (
+          <SignUpForm onSuccess={() => switchView("login")} />
+        )}
+      </div>
     </LayoutWrapper>
   );
 }

--- a/app/loja/carrinho/page.tsx
+++ b/app/loja/carrinho/page.tsx
@@ -2,10 +2,8 @@
 
 import { useCart } from "@/lib/context/CartContext";
 import Image from "next/image";
-import { useState } from "react";
 import { useRouter } from "next/navigation";
 import { useAuthContext } from "@/lib/context/AuthContext";
-import AuthModal from "@/app/components/AuthModal";
 
 function formatCurrency(n: number) {
   return `R$ ${n.toFixed(2).replace(".", ",")}`;
@@ -15,11 +13,10 @@ export default function CarrinhoPage() {
   const { itens, removeItem, clearCart } = useCart();
   const { isLoggedIn } = useAuthContext();
   const router = useRouter();
-  const [showAuth, setShowAuth] = useState(false);
   const total = itens.reduce((sum, i) => sum + i.preco * i.quantidade, 0);
 
   function handleCheckout() {
-    if (!isLoggedIn) setShowAuth(true);
+    if (!isLoggedIn) router.push("/login?redirect=/loja/checkout");
     else router.push("/loja/checkout");
   }
 
@@ -93,9 +90,6 @@ export default function CarrinhoPage() {
             Finalizar compra
           </button>
         </div>
-        {showAuth && (
-          <AuthModal open={showAuth} onClose={() => setShowAuth(false)} />
-        )}
       </div>
     </main>
   );

--- a/app/loja/checkout/page.tsx
+++ b/app/loja/checkout/page.tsx
@@ -2,7 +2,8 @@
 
 import { useCart } from "@/lib/context/CartContext";
 import { useRouter, useSearchParams } from "next/navigation";
-import { Suspense, useState } from "react";
+import { Suspense, useState, useEffect } from "react";
+import { useAuthContext } from "@/lib/context/AuthContext";
 
 function formatCurrency(n: number) {
   return `R$ ${n.toFixed(2).replace(".", ",")}`;
@@ -12,12 +13,19 @@ function CheckoutContent() {
   const { itens, clearCart } = useCart();
   const router = useRouter();
   const searchParams = useSearchParams();
+  const { isLoggedIn } = useAuthContext();
 
   const [nome, setNome] = useState("");
   const [telefone, setTelefone] = useState("");
   const [email, setEmail] = useState("");
   const [endereco, setEndereco] = useState("");
   const [loading, setLoading] = useState(false);
+
+  useEffect(() => {
+    if (!isLoggedIn) {
+      router.replace("/login?redirect=/loja/checkout");
+    }
+  }, [isLoggedIn, router]);
 
   const pedidoId = searchParams.get("pedido") || Date.now().toString();
   const total = itens.reduce((sum, i) => sum + i.preco * i.quantidade, 0);
@@ -53,7 +61,7 @@ function CheckoutContent() {
         throw new Error("Falha ao gerar link de pagamento");
       clearCart();
       window.location.href = data.checkoutUrl;
-    } catch (err) {
+    } catch {
       alert("Erro ao processar pagamento. Tente novamente.");
     } finally {
       setLoading(false);

--- a/app/loja/page.tsx
+++ b/app/loja/page.tsx
@@ -1,9 +1,8 @@
 "use client";
 
-import { ChevronLeft, ChevronRight } from "lucide-react";
 import Image from "next/image";
 import Link from "next/link";
-import { useEffect, useRef, useState } from "react";
+import { useEffect, useState } from "react";
 import createPocketBase from "@/lib/pocketbase";
 
 interface Produto {
@@ -15,7 +14,6 @@ interface Produto {
 }
 
 export default function Home() {
-  const carouselRef = useRef<HTMLDivElement>(null);
   const [produtosDestaque, setProdutosDestaque] = useState<Produto[]>([]);
 
   useEffect(() => {
@@ -37,16 +35,6 @@ export default function Home() {
     fetchProdutos();
   }, []);
 
-  // Se quiser carrossel nos produtos, use funções abaixo:
-  const scrollBy = (direction: "left" | "right") => {
-    const el = carouselRef.current;
-    if (!el) return;
-    const offset = el.offsetWidth * 0.8 + 16;
-    el.scrollBy({
-      left: direction === "right" ? offset : -offset,
-      behavior: "smooth",
-    });
-  };
 
   return (
     <>

--- a/app/loja/produtos/[slug]/ProdutoInterativo.tsx
+++ b/app/loja/produtos/[slug]/ProdutoInterativo.tsx
@@ -3,8 +3,8 @@ import { useState, useRef, useEffect } from "react";
 import Image from "next/image";
 import { useRouter } from "next/navigation";
 
-import AuthModal from "@/app/components/AuthModal";
 import AddToCartButton from "./AddToCartButton";
+import type { Produto } from "@/types";
 
 // Componente para seleção de gênero e tamanho (reutilizável)
 function DetalhesSelecao({
@@ -105,7 +105,6 @@ export default function ProdutoInterativo({
   descricao,
   produto,
   isLoggedIn,
-  onRequireAuth,
 }: {
   imagens: Record<string, string[]>;
   generos: string[];
@@ -113,9 +112,8 @@ export default function ProdutoInterativo({
   nome: string;
   preco: number;
   descricao?: string;
-  produto: any;
+  produto: Produto;
   isLoggedIn: boolean;
-  onRequireAuth: () => void;
 }) {
   // Padronização dos gêneros:
   const generosNorm = generos.map((g) =>
@@ -135,7 +133,6 @@ export default function ProdutoInterativo({
   const [cor, setCor] = useState(coresList[0] || "");
   const [indexImg, setIndexImg] = useState(0);
   const pauseRef = useRef(false);
-  const [showAuth, setShowAuth] = useState(false);
   const router = useRouter();
 
   const imgs = imagens[genero] || imagens[generosNorm[0]];
@@ -261,22 +258,18 @@ export default function ProdutoInterativo({
         </div>
         {/* Botões em linha */}
         <div className="flex flex-col md:flex-row gap-3 mt-4">
-          <a
-            href={produto.checkout_url}
-            target="_blank"
-            rel="noopener noreferrer"
-            onClick={(e) => {
+          <button
+            onClick={() => {
               if (!isLoggedIn) {
-                onRequireAuth();
+                router.push("/login?redirect=/loja/checkout");
               } else {
-                e.preventDefault();
                 router.push("/loja/checkout");
               }
             }}
             className="w-full md:w-auto btn btn-primary text-center"
           >
             Quero essa pra brilhar no Congresso!
-          </a>
+          </button>
           <div className="w-full md:w-auto">
             <AddToCartButton
               produto={{
@@ -292,9 +285,6 @@ export default function ProdutoInterativo({
           </div>
         </div>
         {/* Resto dos detalhes */}
-        {showAuth && (
-          <AuthModal open={showAuth} onClose={() => setShowAuth(false)} />
-        )}
         {descricao && (
           <p className="text-sm text-[var(--text-primary)]/80 mt-4 whitespace-pre-line">
             {descricao}

--- a/app/loja/produtos/[slug]/page.tsx
+++ b/app/loja/produtos/[slug]/page.tsx
@@ -4,7 +4,6 @@ import { useParams } from "next/navigation";
 import Link from "next/link";
 import { Suspense } from "react";
 
-import AuthModal from "@/app/components/AuthModal";
 import { useAuthContext } from "@/lib/context/AuthContext";
 import createPocketBase from "@/lib/pocketbase";
 import ProdutoInterativo from "./ProdutoInterativo";
@@ -25,7 +24,6 @@ export default function ProdutoDetalhe() {
   const { slug } = useParams<{ slug: string }>();
   const [produto, setProduto] = useState<Produto | null>(null);
   const [erro, setErro] = useState(false);
-  const [showAuth, setShowAuth] = useState(false);
   const { isLoggedIn } = useAuthContext();
 
   useEffect(() => {
@@ -108,12 +106,8 @@ export default function ProdutoDetalhe() {
           descricao={produto.descricao}
           produto={produto}
           isLoggedIn={isLoggedIn}
-          onRequireAuth={() => setShowAuth(true)}
         />
       </Suspense>
-      {showAuth && (
-        <AuthModal open={showAuth} onClose={() => setShowAuth(false)} />
-      )}
     </main>
   );
 }


### PR DESCRIPTION
## Summary
- redirect checkout process to login page when unauthenticated
- add signup tab option in login page
- support optional redirect in LoginForm
- add "Crie sua conta" link in header (desktop and mobile)
- update product and cart flows to use login page instead of modal
- melhorar redirecionamentos e ajustes de lint

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_684999f1dddc832cafbe510bf8137f7c