### PR TITLE
Add loja perfil page

### DIFF
--- a/app/loja/cliente/page.tsx
+++ b/app/loja/cliente/page.tsx
@@ -50,7 +50,7 @@ export default function AreaCliente() {
         </p>
 
         <div className="flex flex-wrap gap-2 pt-4">
-          <a href="/admin/perfil" className="btn btn-secondary">
+          <a href="/loja/perfil" className="btn btn-secondary">
             Alterar dados pessoais
           </a>
           <a href="/admin/redefinir-senha" className="btn btn-secondary">

--- a/app/loja/perfil/page.tsx
+++ b/app/loja/perfil/page.tsx
@@ -1,0 +1,82 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { useAuthGuard } from "@/lib/hooks/useAuthGuard";
+import ModalEditarPerfil from "@/app/admin/perfil/components/ModalEditarPerfil";
+
+interface UsuarioAuthModel {
+  id: string;
+  email: string;
+  nome: string;
+  telefone?: string;
+  cpf?: string;
+  data_nascimento?: string;
+  role: "coordenador" | "lider" | "usuario" | string;
+  campo?: string;
+  expand?: {
+    campo?: {
+      nome: string;
+    };
+  };
+}
+
+export default function PerfilPage() {
+  const { pb, authChecked } = useAuthGuard(["usuario"]);
+  const [usuario, setUsuario] = useState<UsuarioAuthModel | null>(null);
+  const [mostrarModal, setMostrarModal] = useState(false);
+
+  useEffect(() => {
+    if (!authChecked) return;
+
+    const handleAuthChange = () => {
+      const model = pb.authStore.model as unknown as UsuarioAuthModel;
+      setUsuario(model);
+    };
+
+    handleAuthChange();
+    const unsubscribe = pb.authStore.onChange(handleAuthChange);
+    return () => unsubscribe();
+  }, [authChecked, pb]);
+
+  if (!authChecked || !usuario) return null;
+
+  return (
+    <div className="max-w-2xl mx-auto mt-10 p-6 bg-white dark:bg-zinc-900 rounded-xl shadow space-y-6">
+      <h2 className="text-2xl font-bold text-zinc-800 dark:text-white">
+        Seu Perfil
+      </h2>
+
+      <div className="space-y-2 text-zinc-700 dark:text-zinc-200">
+        <p>
+          <span className="font-semibold">Nome:</span> {usuario.nome}
+        </p>
+        <p>
+          <span className="font-semibold">E-mail:</span> {usuario.email}
+        </p>
+        <p>
+          <span className="font-semibold">Campo de Atuação:</span>{" "}
+          {usuario.expand?.campo?.nome || "Não vinculado"}
+        </p>
+      </div>
+
+      <div className="flex justify-end">
+        <button
+          onClick={() => setMostrarModal(true)}
+          className="bg-black dark:bg-white text-white dark:text-black px-4 py-2 rounded-lg hover:opacity-90"
+        >
+          Editar Perfil
+        </button>
+      </div>
+
+      {mostrarModal && (
+        <ModalEditarPerfil
+          onClose={() => {
+            setMostrarModal(false);
+            const model = pb.authStore.model as unknown as UsuarioAuthModel;
+            setUsuario(model);
+          }}
+        />
+      )}
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- create /loja/perfil page mirroring admin logic but guarded for user role
- update client profile link in loja/cliente

## Testing
- `npm run lint` *(fails: Unexpected any in app/loja/checkout/page.tsx)*

------
https://chatgpt.com/codex/tasks/task_e_684a2b78c2e8832c853aed92b61967c9