### PR TITLE
Implement address editing on profile

### DIFF
--- a/app/admin/perfil/components/ModalEditarPerfil.tsx
+++ b/app/admin/perfil/components/ModalEditarPerfil.tsx
@@ -17,6 +17,11 @@ export default function ModalEditarPerfil({
   const [dataNascimento, setDataNascimento] = useState(
     String(user?.data_nascimento || "")
   );
+  const [endereco, setEndereco] = useState(String(user?.endereco || ""));
+  const [numero, setNumero] = useState(String(user?.numero || ""));
+  const [estado, setEstado] = useState(String(user?.estado || ""));
+  const [cep, setCep] = useState(String(user?.cep || ""));
+  const [cidade, setCidade] = useState(String(user?.cidade || ""));
 
   const [mensagem, setMensagem] = useState("");
   const [erro, setErro] = useState("");
@@ -36,6 +41,11 @@ export default function ModalEditarPerfil({
         telefone: String(telefone).trim(),
         cpf: String(cpf).trim(),
         data_nascimento: String(dataNascimento),
+        endereco: String(endereco).trim(),
+        numero: String(numero).trim(),
+        estado: String(estado).trim(),
+        cep: String(cep).trim(),
+        cidade: String(cidade).trim(),
         role: user.role,
       });
 
@@ -83,6 +93,46 @@ export default function ModalEditarPerfil({
           className={inputStyle}
           value={String(dataNascimento)}
           onChange={(e) => setDataNascimento(e.target.value)}
+        />
+
+        <input
+          type="text"
+          placeholder="Endereço"
+          className={inputStyle}
+          value={String(endereco)}
+          onChange={(e) => setEndereco(e.target.value)}
+        />
+
+        <input
+          type="text"
+          placeholder="Número"
+          className={inputStyle}
+          value={String(numero)}
+          onChange={(e) => setNumero(e.target.value)}
+        />
+
+        <input
+          type="text"
+          placeholder="Estado"
+          className={inputStyle}
+          value={String(estado)}
+          onChange={(e) => setEstado(e.target.value)}
+        />
+
+        <input
+          type="text"
+          placeholder="CEP"
+          className={inputStyle}
+          value={String(cep)}
+          onChange={(e) => setCep(e.target.value)}
+        />
+
+        <input
+          type="text"
+          placeholder="Cidade"
+          className={inputStyle}
+          value={String(cidade)}
+          onChange={(e) => setCidade(e.target.value)}
         />
 
         <div>

--- a/app/loja/checkout/page.tsx
+++ b/app/loja/checkout/page.tsx
@@ -27,7 +27,7 @@ function CheckoutContent() {
   const [cidade, setCidade] = useState("");
   const [numero, setNumero] = useState(String(user?.numero ?? ""));
   const [dataNascimento, setDataNascimento] = useState(
-    String((user as any)?.data_nascimento ?? "")
+    String((user as { data_nascimento?: string } | null)?.data_nascimento ?? "")
   );
   const [status, setStatus] = useState<"idle" | "loading" | "success">("idle");
 
@@ -47,7 +47,9 @@ function CheckoutContent() {
       setEstado(String(user.estado ?? ""));
       setCep(String(user.cep ?? ""));
       setCidade(String(user.cidade ?? ""));
-      setDataNascimento(String((user as any).data_nascimento ?? ""));
+      setDataNascimento(
+        String((user as { data_nascimento?: string }).data_nascimento ?? "")
+      );
     }
   }, [user]);
 


### PR DESCRIPTION
## Summary
- edit profile to include address fields
- type-check user birth date fields to avoid `any` in checkout page

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_684a2f0caadc832cbb87cebc1ffa8e34