### PR TITLE
Implement tenant filtering

### DIFF
--- a/app/admin/api/inscricoes/route.ts
+++ b/app/admin/api/inscricoes/route.ts
@@ -14,6 +14,7 @@ interface DadosInscricao {
   status: "pendente";
   produto: string;
   tamanho?: string;
+  cliente?: string;
 }
 
 
@@ -103,6 +104,7 @@ export async function POST(req: NextRequest) {
       criado_por: liderId,
       status: "pendente",
       produto,
+      cliente: lider.cliente,
     };
     if (tamanho) dadosInscricao.tamanho = tamanho;
 

--- a/app/admin/api/pedidos/route.tsx
+++ b/app/admin/api/pedidos/route.tsx
@@ -43,6 +43,7 @@ export async function POST(req: NextRequest) {
       email: inscricao.email,
       campo: campoId,
       responsavel: responsavelId,
+      cliente: inscricao.cliente,
     });
 
     return NextResponse.json({

--- a/app/admin/api/produtos/route.ts
+++ b/app/admin/api/produtos/route.ts
@@ -10,7 +10,7 @@ export async function GET(req: NextRequest) {
   try {
     const produtos = await pb.collection("produtos").getFullList({
       sort: "-created",
-      filter: `user_org = "${user.id}"`,
+      filter: `user_org = "${user.id}" && cliente="${user.cliente}"`,
     });
     return NextResponse.json(produtos, { status: 200 });
   } catch (err) {
@@ -28,6 +28,7 @@ export async function POST(req: NextRequest) {
   try {
     const formData = await req.formData();
     formData.set("user_org", user.id);
+    formData.set("cliente", user.cliente as string);
     const produto = await pb.collection("produtos").create(formData);
     return NextResponse.json(produto, { status: 201 });
   } catch (err) {

--- a/app/admin/api/usuarios/route.ts
+++ b/app/admin/api/usuarios/route.ts
@@ -9,12 +9,13 @@ export async function GET(req: NextRequest) {
     return NextResponse.json({ error: auth.error }, { status: auth.status });
   }
 
-  const { pb } = auth;
+  const { pb, user } = auth;
 
   try {
     const usuarios = await pb.collection("usuarios").getFullList({
       sort: "nome",
       expand: "campo",
+      filter: `cliente='${user.cliente}'`,
     });
 
     logInfo(`📦 ${usuarios.length} usuários encontrados.`);
@@ -40,7 +41,7 @@ export async function POST(req: NextRequest) {
     return NextResponse.json({ error: auth.error }, { status: auth.status });
   }
 
-  const { pb } = auth;
+  const { pb, user } = auth;
 
   try {
     const { nome, email, password, passwordConfirm, role, campo } =
@@ -64,6 +65,7 @@ export async function POST(req: NextRequest) {
       passwordConfirm,
       role,
       campo,
+      cliente: user.cliente,
     });
 
     logInfo("✅ Usuário criado com sucesso");

--- a/app/loja/page.tsx
+++ b/app/loja/page.tsx
@@ -20,9 +20,13 @@ export default function Home() {
     async function fetchProdutos() {
       try {
         const pb = createPocketBase();
+        const tenantId = localStorage.getItem("tenant_id");
         const list = await pb
           .collection("produtos")
-          .getList<Produto>(1, 6, { filter: "ativo = true", sort: "-created" });
+          .getList<Produto>(1, 6, {
+            filter: `ativo = true && cliente='${tenantId}'`,
+            sort: "-created",
+          });
         const prods = list.items.map((p) => ({
           ...p,
           imagens: (p.imagens || []).map((img) => pb.files.getURL(p, img)),

--- a/app/loja/produtos/[slug]/page.tsx
+++ b/app/loja/produtos/[slug]/page.tsx
@@ -29,9 +29,10 @@ export default function ProdutoDetalhe() {
   useEffect(() => {
     if (!slug) return;
     const pb = createPocketBase();
+    const tenantId = localStorage.getItem("tenant_id");
     pb
       .collection("produtos")
-      .getFirstListItem<Produto>(`slug = '${slug}'`)
+      .getFirstListItem<Produto>(`slug = '${slug}' && cliente='${tenantId}'`)
       .then((p) => {
         const imgs = Array.isArray(p.imagens)
           ? p.imagens.map((img) => pb.files.getURL(p, img))

--- a/app/loja/produtos/page.tsx
+++ b/app/loja/produtos/page.tsx
@@ -13,8 +13,9 @@ interface Produto {
 
 export default async function ProdutosPage() {
   const pb = createPocketBase();
+  const tenantId = process.env.NEXT_PUBLIC_TENANT_ID;
   const list = await pb.collection("produtos").getList<Produto>(1, 50, {
-    filter: "ativo = true",
+    filter: `ativo = true && cliente='${tenantId}'`,
     sort: "-created",
   });
   const produtosPB: Produto[] = list.items;

--- a/lib/context/AuthContext.tsx
+++ b/lib/context/AuthContext.tsx
@@ -16,6 +16,8 @@ type UserModel = {
 
 type AuthContextType = {
   user: UserModel | null;
+  /** ID do cliente (tenant) */
+  tenantId: string | null;
   isLoggedIn: boolean;
   isLoading: boolean;
   login: (email: string, password: string) => Promise<void>;
@@ -36,6 +38,7 @@ type AuthContextType = {
 
 const AuthContext = createContext<AuthContextType>({
   user: null,
+  tenantId: null,
   isLoggedIn: false,
   isLoading: true,
   login: async () => {},
@@ -46,6 +49,7 @@ const AuthContext = createContext<AuthContextType>({
 export function AuthProvider({ children }: { children: React.ReactNode }) {
   const pb = useMemo(() => createPocketBase(), []);
   const [user, setUser] = useState<UserModel | null>(null);
+  const [tenantId, setTenantId] = useState<string | null>(null);
   const [isLoggedIn, setIsLoggedIn] = useState(false);
   const [isLoading, setIsLoading] = useState(true);
 
@@ -53,6 +57,7 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
     try {
       const token = localStorage.getItem("pb_token");
       const rawUser = localStorage.getItem("pb_user");
+      const storedTenant = localStorage.getItem("tenant_id");
 
       if (token && rawUser) {
         const parsedRecord = JSON.parse(rawUser) as RecordModel;
@@ -60,6 +65,7 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
         updateBaseAuth(token, parsedRecord);
 
         setUser(parsedRecord as unknown as UserModel);
+        setTenantId(storedTenant);
         setIsLoggedIn(true);
       }
     } catch (err: unknown) {
@@ -70,7 +76,9 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
       clearBaseAuth();
       localStorage.removeItem("pb_token");
       localStorage.removeItem("pb_user");
+      localStorage.removeItem("tenant_id");
       setUser(null);
+      setTenantId(null);
       setIsLoggedIn(false);
     }
 
@@ -91,6 +99,17 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
     await pb.collection("usuarios").authWithPassword(email, password);
 
     const model = pb.authStore.model as unknown as UserModel;
+
+    const dominio = window.location.hostname;
+    try {
+      const cliente = await pb
+        .collection("m24_clientes")
+        .getFirstListItem(`dominio='${dominio}'`);
+      localStorage.setItem("tenant_id", cliente.id);
+      setTenantId(cliente.id);
+    } catch {
+      setTenantId(null);
+    }
 
     localStorage.setItem("pb_token", pb.authStore.token);
     localStorage.setItem("pb_user", JSON.stringify(model));
@@ -113,6 +132,19 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
     cidade: string,
     password: string
   ) => {
+    const dominio = window.location.hostname;
+    let clienteId: string | null = null;
+    try {
+      const cliente = await pb
+        .collection("m24_clientes")
+        .getFirstListItem(`dominio='${dominio}'`);
+      clienteId = cliente.id;
+      localStorage.setItem("tenant_id", clienteId);
+      setTenantId(clienteId);
+    } catch {
+      setTenantId(null);
+    }
+
     await pb.collection("usuarios").create({
       nome,
       email,
@@ -126,6 +158,7 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
       password,
       passwordConfirm: password,
       role: "usuario",
+      cliente: clienteId,
     });
     await login(email, password);
   };
@@ -135,13 +168,15 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
     clearBaseAuth();
     localStorage.removeItem("pb_token");
     localStorage.removeItem("pb_user");
+    localStorage.removeItem("tenant_id");
     setUser(null);
+    setTenantId(null);
     setIsLoggedIn(false);
   };
 
   return (
     <AuthContext.Provider
-      value={{ user, isLoggedIn, isLoading, login, signUp, logout }}
+      value={{ user, tenantId, isLoggedIn, isLoading, login, signUp, logout }}
     >
       {children}
     </AuthContext.Provider>

--- a/logs/DOC_LOG.md
+++ b/logs/DOC_LOG.md
@@ -73,3 +73,4 @@
 ## [2025-06-12] Ajustado checkout para enviar dados completos do cliente e imagens dos produtos; página de checkout atualizada com novos campos
 ## [2025-06-12] Checkout carrega cpf, endereço e inclui data de nascimento
 ## [2025-06-12] Criada página /loja/perfil com inputs de CPF, telefone e data de nascimento. Atualizados Header e rotas da loja para incluir o novo caminho.
+## [2025-06-12] Ajustado contexto de autenticação para armazenar tenantId e filtros multi-tenant

--- a/types/UserModel.ts
+++ b/types/UserModel.ts
@@ -3,5 +3,6 @@ export type UserModel = {
   nome: string;
   email: string;
   role: "coordenador" | "lider" | "usuario";
+  cliente?: string;
   [key: string]: unknown;
 };

--- a/types/index.ts
+++ b/types/index.ts
@@ -11,6 +11,7 @@ export type Inscricao = {
   data_nascimento?: string;
   criado_por?: string;
   campo?: string;
+  cliente?: string;
   cpf?: string;
   confirmado_por_lider?: boolean;
   created?: string;
@@ -46,6 +47,7 @@ export type Pedido = {
   cor: string;
   genero?: string;
   responsavel?: string;
+  cliente?: string;
   email: string;
   created?: string;
   valor: string;
@@ -87,6 +89,7 @@ export type Produto = {
   checkoutUrl?: string; // alias usado no formulário do admin
   ativo?: boolean;
   user_org?: string;
+  cliente?: string;
   categoria?: string;
   created?: string;
   expand?: {


### PR DESCRIPTION
## Summary
- add tenantId to auth context and keep it in localStorage
- update types with optional `cliente`
- include tenant filter for product queries on store pages
- create products and users with tenant info
- log doc update about multi-tenant auth context

## Testing
- `npm run lint` *(fails: next not found)*
- `npm run test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_684a3b521088832cbbb4d597ff05e29c