### PR TITLE
Update Asaas key docs

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -2,6 +2,7 @@
 NEXT_PUBLIC_PB_URL=
 PB_ADMIN_EMAIL=
 PB_ADMIN_PASSWORD=
+# Opcional. O backend procura primeiro `asaas_api_key` em `m24_clientes`.
 ASAAS_API_KEY=
 ASAAS_WEBHOOK_SECRET=
 NEXT_PUBLIC_SITE_URL=

--- a/README.md
+++ b/README.md
@@ -80,18 +80,18 @@ Crie um arquivo `.env.local` na raiz e defina as seguintes variáveis:
 - `NEXT_PUBLIC_PB_URL` - URL do PocketBase
 - `PB_ADMIN_EMAIL` - e-mail do administrador do PocketBase
 - `PB_ADMIN_PASSWORD` - senha do administrador
-- `ASAAS_API_KEY` - chave da API do Asaas para geração de pagamentos
+- `ASAAS_API_KEY` - (opcional) chave padrão da API do Asaas
 - `ASAAS_WEBHOOK_SECRET` - segredo para validar webhooks do Asaas
 - `ASAAS_API_URL` - URL base da API do Asaas (ex.: `https://api-sandbox.asaas.com/api/v3/`)
 - `NEXT_PUBLIC_SITE_URL` - endereço do site (opcional)
+
+Cada registro em `m24_clientes` contém o campo `asaas_api_key`. A aplicação busca a chave correta deste cliente antes de criar cobranças ou checkouts, garantindo que cada subconta do Asaas seja utilizada separadamente.
 
 Esta integração realiza chamadas HTTP diretamente na API do Asaas, sem utilizar o SDK oficial.
 
 ## Conectando ao PocketBase
 
-
 1. Defina `NEXT_PUBLIC_PB_URL` apontando para a URL onde o PocketBase está rodando, por exemplo:
-
 
 2. Utilize as variáveis `PB_ADMIN_EMAIL` e `PB_ADMIN_PASSWORD` para autenticar a aplicação.
 
@@ -172,7 +172,6 @@ Após salvar as alterações, execute o comando abaixo para gerar
 ```bash
 npm run generate-posts
 ```
-
 
 ## Testes
 

--- a/logs/DOC_LOG.md
+++ b/logs/DOC_LOG.md
@@ -75,3 +75,4 @@
 ## [2025-06-12] Criada página /loja/perfil com inputs de CPF, telefone e data de nascimento. Atualizados Header e rotas da loja para incluir o novo caminho.
 ## [2025-06-12] Ajustado contexto de autenticação para armazenar tenantId e filtros multi-tenant
 ## [2025-06-13] Documentado formato de externalReference e atualizados testes de checkout
+## [2025-06-13] README atualizado sobre ASAAS_API_KEY e .env.example ajustado


### PR DESCRIPTION
## Summary
- clarify that each cliente holds its own `asaas_api_key` and the app fetches it before creating charges or checkouts
- mark `ASAAS_API_KEY` as optional in README and environment example
- log documentation update

## Testing
- `npm run lint` *(fails: next not found)*
- `npm run test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_684a4b5cd12c832cb1b91f7031005087