### PR TITLE
Implement tenant filtering

### DIFF
--- a/app/admin/api/asaas/checkout/route.ts
+++ b/app/admin/api/asaas/checkout/route.ts
@@ -105,33 +105,21 @@ export async function POST(req: NextRequest) {
       paymentMethods,
     });
 
-<<<<<<< HEAD
-    const checkoutUrl = await createCheckout({
-      valor,
-      itens,
-      successUrl,
-      errorUrl,
-      clienteId,
-      usuarioId,
-      inscricaoId,
-      cliente,
-      installments,
-      paymentMethods,
-    });
-=======
     const checkoutUrl = await createCheckout(
       {
         valor,
         itens,
         successUrl,
         errorUrl,
+        clienteId,
+        usuarioId,
+        inscricaoId,
         cliente,
         installments,
         paymentMethods,
       },
       apiKey
     );
->>>>>>> origin/codex/adicionar-campo-asaas_api_key-e-integração
 
     console.log("✅ Checkout criado com sucesso:", checkoutUrl);
 

--- a/app/admin/api/campos/route.ts
+++ b/app/admin/api/campos/route.ts
@@ -9,11 +9,12 @@ export async function GET(req: NextRequest) {
     return NextResponse.json({ error: auth.error }, { status: auth.status });
   }
 
-  const { pb } = auth;
+  const { pb, user } = auth;
 
   try {
     const campos = await pb.collection("campos").getFullList({
       sort: "nome",
+      filter: `cliente='${user.cliente}'`,
     });
 
     return NextResponse.json(campos, { status: 200 });
@@ -38,7 +39,7 @@ export async function POST(req: NextRequest) {
     return NextResponse.json({ error: auth.error }, { status: auth.status });
   }
 
-  const { pb } = auth;
+  const { pb, user } = auth;
 
   try {
     const { nome } = await req.json();
@@ -48,7 +49,7 @@ export async function POST(req: NextRequest) {
       return NextResponse.json({ error: "Nome inválido" }, { status: 400 });
     }
 
-    const campo = await pb.collection("campos").create({ nome });
+    const campo = await pb.collection("campos").create({ nome, cliente: user.cliente });
 
     logInfo("✅ Campo criado: " + JSON.stringify(campo));
 

--- a/app/admin/api/categorias/route.ts
+++ b/app/admin/api/categorias/route.ts
@@ -6,9 +6,12 @@ export async function GET(req: NextRequest) {
   if ("error" in auth) {
     return NextResponse.json({ error: auth.error }, { status: auth.status });
   }
-  const { pb } = auth;
+  const { pb, user } = auth;
   try {
-    const categorias = await pb.collection("categorias").getFullList({ sort: "nome" });
+    const categorias = await pb.collection("categorias").getFullList({
+      sort: "nome",
+      filter: `cliente='${user.cliente}'`,
+    });
     return NextResponse.json(categorias, { status: 200 });
   } catch (err) {
     console.error("Erro ao listar categorias:", err);
@@ -21,14 +24,16 @@ export async function POST(req: NextRequest) {
   if ("error" in auth) {
     return NextResponse.json({ error: auth.error }, { status: auth.status });
   }
-  const { pb } = auth;
+  const { pb, user } = auth;
   try {
     const { nome } = await req.json();
     if (!nome || nome.length < 2) {
       return NextResponse.json({ error: "Nome inválido" }, { status: 400 });
     }
     const slug = nome.toLowerCase().replace(/\s+/g, "-");
-    const categoria = await pb.collection("categorias").create({ nome, slug });
+    const categoria = await pb
+      .collection("categorias")
+      .create({ nome, slug, cliente: user.cliente });
     return NextResponse.json(categoria, { status: 201 });
   } catch (err) {
     console.error("Erro ao criar categoria:", err);

--- a/app/admin/api/eventos/route.ts
+++ b/app/admin/api/eventos/route.ts
@@ -7,10 +7,13 @@ export async function GET(req: NextRequest) {
   if ("error" in auth) {
     return NextResponse.json({ error: auth.error }, { status: auth.status });
   }
-  const { pb } = auth;
+  const { pb, user } = auth;
   logInfo("PocketBase host:", pb.baseUrl);
   try {
-    const eventos = await pb.collection("eventos").getFullList({ sort: "-created" });
+    const eventos = await pb.collection("eventos").getFullList({
+      sort: "-created",
+      filter: `cliente='${user.cliente}'`,
+    });
     return NextResponse.json(eventos, { status: 200 });
   } catch (err) {
     console.error("Erro ao listar eventos:", err);
@@ -23,11 +26,13 @@ export async function POST(req: NextRequest) {
   if ("error" in auth) {
     return NextResponse.json({ error: auth.error }, { status: auth.status });
   }
-  const { pb } = auth;
+  const { pb, user } = auth;
   logInfo("PocketBase host:", pb.baseUrl);
   try {
     const data = await req.json();
-    const evento = await pb.collection("eventos").create(data);
+    const evento = await pb
+      .collection("eventos")
+      .create({ ...data, cliente: user.cliente });
     return NextResponse.json(evento, { status: 201 });
   } catch (err) {
     console.error("Erro ao criar evento:", err);

--- a/app/admin/api/recuperar-link/route.ts
+++ b/app/admin/api/recuperar-link/route.ts
@@ -9,7 +9,7 @@ pb.autoCancellation(false);
 
 export async function POST(req: NextRequest) {
   try {
-    const { cpf, telefone } = await req.json();
+    const { cpf, telefone, cliente } = await req.json();
 
     console.log("📨 Dados recebidos:", { cpf, telefone });
 
@@ -17,6 +17,13 @@ export async function POST(req: NextRequest) {
       logInfo("⚠️ CPF ou telefone não fornecido");
       return NextResponse.json(
         { error: "Informe o CPF ou telefone." },
+        { status: 400 }
+      );
+    }
+
+    if (!cliente) {
+      return NextResponse.json(
+        { error: "Cliente ausente." },
         { status: 400 }
       );
     }
@@ -30,7 +37,8 @@ export async function POST(req: NextRequest) {
       logInfo("✅ Autenticado com sucesso.");
     }
 
-    const filtro = cpf ? `cpf = "${cpf}"` : `telefone = "${telefone}"`;
+    const filtroBase = cpf ? `cpf = "${cpf}"` : `telefone = "${telefone}"`;
+    const filtro = `${filtroBase} && cliente='${cliente}'`;
     console.log("🔎 Filtro usado:", filtro);
 
     const inscricoes = await pb.collection("inscricoes").getFullList({

--- a/app/admin/clientes/page.tsx
+++ b/app/admin/clientes/page.tsx
@@ -6,9 +6,11 @@ import ListaClientes from "./components/ListaClientes";
 import ModalEditarInscricao from "../inscricoes/componentes/ModalEdit";
 import type { Inscricao } from "@/types";
 import { useToast } from "@/lib/context/ToastContext";
+import { useAuthContext } from "@/lib/context/AuthContext";
 
 export default function ClientesPage() {
   const pb = useMemo(() => createPocketBase(), []);
+  const { tenantId } = useAuthContext();
   const { showError, showSuccess } = useToast();
   const [clientes, setClientes] = useState<Inscricao[]>([]);
   const [loading, setLoading] = useState(true);
@@ -20,6 +22,7 @@ export default function ClientesPage() {
         const lista = await pb.collection("inscricoes").getFullList<Inscricao>({
           expand: "pedido",
           sort: "-created",
+          filter: `cliente='${tenantId}'`,
         });
         setClientes(lista);
       } catch (err) {
@@ -31,7 +34,7 @@ export default function ClientesPage() {
     }
 
     fetchClientes();
-  }, [pb, showError]);
+  }, [pb, tenantId, showError]);
 
   const salvarEdicao = async (atualizada: Partial<Inscricao>) => {
     if (!clienteEmEdicao) return;

--- a/app/admin/components/NotificationBell.tsx
+++ b/app/admin/components/NotificationBell.tsx
@@ -4,9 +4,11 @@ import { useEffect, useState, useMemo } from "react";
 import { Bell, X } from "lucide-react";
 import createPocketBase from "@/lib/pocketbase";
 import type { Inscricao } from "@/types";
+import { useAuthContext } from "@/lib/context/AuthContext";
 
 export default function NotificationBell() {
   const pb = useMemo(() => createPocketBase(), []);
+  const { tenantId } = useAuthContext();
   const [count, setCount] = useState(0);
   const [inscricoes, setInscricoes] = useState<Inscricao[]>([]);
   const [open, setOpen] = useState(false);
@@ -16,13 +18,13 @@ export default function NotificationBell() {
       try {
         const [insList, pedidos] = await Promise.all([
           pb.collection("inscricoes").getList<Inscricao>(1, 5, {
-            filter: 'status="pendente"',
+            filter: `status='pendente' && cliente='${tenantId}'`,
             expand: "campo",
             sort: "-created",
             $autoCancel: false,
           }),
           pb.collection("pedidos").getList(1, 1, {
-            filter: 'status="pendente"',
+            filter: `status='pendente' && cliente='${tenantId}'`,
             $autoCancel: false,
           }),
         ]);
@@ -37,7 +39,7 @@ export default function NotificationBell() {
     fetchData();
     const id = setInterval(fetchData, 30000);
     return () => clearInterval(id);
-  }, [pb]);
+  }, [pb, tenantId]);
 
   return (
     <div className="fixed bottom-20 right-4 z-50">

--- a/app/admin/lider-painel/page.tsx
+++ b/app/admin/lider-painel/page.tsx
@@ -9,7 +9,7 @@ import type { Inscricao, Pedido } from "@/types";
 
 export default function LiderDashboardPage() {
   const router = useRouter();
-  const { user, isLoggedIn } = useAuthContext();
+  const { user, isLoggedIn, tenantId } = useAuthContext();
   const pb = useMemo(() => createPocketBase(), []);
 
   const [inscricoes, setInscricoes] = useState<Inscricao[]>([]);
@@ -41,10 +41,18 @@ export default function LiderDashboardPage() {
         const [inscricoesRes, pedidosRes] = await Promise.all([
           pb
             .collection("inscricoes")
-            .getList(page, perPage, { filter: `campo="${campoId}"`, expand: "campo,criado_por,pedido", signal }),
+            .getList(page, perPage, {
+              filter: `campo="${campoId}" && cliente='${tenantId}'`,
+              expand: "campo,criado_por,pedido",
+              signal,
+            }),
           pb
             .collection("pedidos")
-            .getList(page, perPage, { filter: `campo="${campoId}"`, expand: "campo,criado_por", signal }),
+            .getList(page, perPage, {
+              filter: `campo="${campoId}" && cliente='${tenantId}'`,
+              expand: "campo,criado_por",
+              signal,
+            }),
         ]);
         const rawInscricoes = inscricoesRes.items;
         const rawPedidos = pedidosRes.items;
@@ -125,7 +133,7 @@ export default function LiderDashboardPage() {
       isMounted.current = false;
       controller.abort();
     };
-  }, [pb, isLoggedIn, user, router, page]);
+  }, [pb, isLoggedIn, tenantId, user, router, page]);
 
   if (loading) {
     return <p className="p-6 text-center text-sm">Carregando dashboard...</p>;

--- a/app/admin/pedidos/page.tsx
+++ b/app/admin/pedidos/page.tsx
@@ -11,7 +11,7 @@ import { useToast } from "@/lib/context/ToastContext";
 
 export default function PedidosPage() {
   const router = useRouter();
-  const { user, isLoggedIn } = useAuthContext();
+  const { user, isLoggedIn, tenantId } = useAuthContext();
   const pb = useMemo(() => createPocketBase(), []);
 
   const [pedidos, setPedidos] = useState<Pedido[]>([]);
@@ -44,8 +44,11 @@ export default function PedidosPage() {
     const fetchPedidos = async () => {
       setLoading(true);
       try {
+        const baseFiltro = `cliente='${tenantId}'`;
         const filtro =
-          user.role === "coordenador" ? "" : `campo = "${user.campo}"`;
+          user.role === "coordenador"
+            ? baseFiltro
+            : `campo = "${user.campo}" && ${baseFiltro}`;
 
         const res = await pb.collection("pedidos").getList<Pedido>(pagina, 10, {
           filter: filtro,
@@ -64,7 +67,7 @@ export default function PedidosPage() {
     };
 
     fetchPedidos();
-  }, [pb, pagina, ordem, user, showError]);
+  }, [pb, pagina, ordem, tenantId, user, showError]);
 
   const pedidosFiltrados = pedidos.filter((p) => {
     const matchStatus = filtroStatus === "" || p.status === filtroStatus;


### PR DESCRIPTION
## Summary
- filter `pb.collection.getList` calls using `cliente` from AuthContext
- restrict admin APIs to current tenant on reads and creation
- fix leftover merge conflict in Asaas checkout route

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_684a4b4667f8832c8de82c3bd40b6793