### PR TITLE
Apply tenant filter to queries

### DIFF
--- a/app/admin/inscricoes/page.tsx
+++ b/app/admin/inscricoes/page.tsx
@@ -103,7 +103,7 @@ export default function ListaInscricoesPage() {
     if (user.role === "coordenador") {
       pb
         .collection("campos")
-        .getFullList({ sort: "nome" })
+        .getFullList({ sort: "nome", filter: `cliente='${tenantId}'` })
         .then(() => {
           // noop
         })

--- a/app/api/campos/route.ts
+++ b/app/api/campos/route.ts
@@ -11,6 +11,10 @@ export async function GET(req: NextRequest) {
 
   const { user, pbSafe } = auth;
 
+  const tenantId =
+    (user && (user as Record<string, any>).cliente) ||
+    process.env.NEXT_PUBLIC_TENANT_ID;
+
   if (user.role !== "coordenador") {
     return NextResponse.json({ error: "Acesso negado" }, { status: 403 });
   }
@@ -18,6 +22,7 @@ export async function GET(req: NextRequest) {
   try {
     const campos = await pbSafe.collection("campos").getFullList({
       sort: "nome",
+      filter: tenantId ? `cliente='${tenantId}'` : undefined,
     });
 
     return NextResponse.json(campos, { status: 200 });
@@ -48,6 +53,10 @@ export async function POST(req: NextRequest) {
     return NextResponse.json({ error: "Acesso negado" }, { status: 403 });
   }
 
+  const tenantId =
+    (user && (user as Record<string, any>).cliente) ||
+    process.env.NEXT_PUBLIC_TENANT_ID;
+
   try {
     const { nome } = await req.json();
     logInfo("📥 Requisição para criar campo recebida");
@@ -56,7 +65,9 @@ export async function POST(req: NextRequest) {
       return NextResponse.json({ error: "Nome inválido" }, { status: 400 });
     }
 
-    const campo = await pbSafe.collection("campos").create({ nome });
+    const campo = await pbSafe
+      .collection("campos")
+      .create({ nome, ...(tenantId ? { cliente: tenantId } : {}) });
 
     logInfo("✅ Campo criado com sucesso");
 

--- a/app/api/eventos/route.ts
+++ b/app/api/eventos/route.ts
@@ -4,8 +4,12 @@ import { EventoRecord, atualizarStatus } from "@/lib/events";
 
 export async function GET() {
   const pb = createPocketBase();
+  const tenantId = process.env.NEXT_PUBLIC_TENANT_ID;
   try {
-    const eventos = await pb.collection("eventos").getFullList<EventoRecord>({ sort: "-data" });
+    const eventos = await pb.collection("eventos").getFullList<EventoRecord>({
+      sort: "-data",
+      filter: tenantId ? `cliente='${tenantId}'` : undefined,
+    });
     await atualizarStatus(eventos, pb);
     const comUrls = eventos.map((e) => ({
       ...e,

--- a/app/api/produtos/route.ts
+++ b/app/api/produtos/route.ts
@@ -6,11 +6,13 @@ export async function GET(req: NextRequest) {
 
   const pb = createPocketBase();
   const categoria = req.nextUrl.searchParams.get("categoria") || undefined;
+  const tenantId = process.env.NEXT_PUBLIC_TENANT_ID;
 
   try {
+    const baseFilter = tenantId ? `ativo = true && cliente='${tenantId}'` : "ativo = true";
     const filterString = categoria
-      ? `ativo = true && categoria = '${categoria}'`
-      : "ativo = true";
+      ? `${baseFilter} && categoria = '${categoria}'`
+      : baseFilter;
 
     const produtos = await pb
       .collection("produtos")

--- a/app/loja/categorias/[slug]/page.tsx
+++ b/app/loja/categorias/[slug]/page.tsx
@@ -22,9 +22,10 @@ export default async function CategoriaDetalhe({
 }) {
   const { slug } = await params;
   const pb = createPocketBase();
+  const tenantId = process.env.NEXT_PUBLIC_TENANT_ID;
 
   const produtosPB: Produto[] = await pb.collection("produtos").getFullList({
-    filter: `ativo = true && categoria = '${slug}'`,
+    filter: `ativo = true && categoria = '${slug}'${tenantId ? ` && cliente='${tenantId}'` : ""}`,
     sort: "-created",
   });
 

--- a/app/loja/categorias/page.tsx
+++ b/app/loja/categorias/page.tsx
@@ -10,9 +10,13 @@ interface Categoria {
 
 export default async function CategoriasPage() {
   const pb = createPocketBase();
+  const tenantId = process.env.NEXT_PUBLIC_TENANT_ID;
   const categorias: Categoria[] = await pb
     .collection("categorias")
-    .getFullList({ sort: "nome" });
+    .getFullList({
+      sort: "nome",
+      ...(tenantId ? { filter: `cliente='${tenantId}'` } : {}),
+    });
 
   return (
     <main className="p-8 text-platinum font-sans">


### PR DESCRIPTION
## Summary
- include tenant ID in fields API and auto-set tenant on create
- filter public products and events routes by tenant
- list categories by tenant in the store
- fetch products by category with tenant filter
- restrict admin fields list to current tenant

## Testing
- `npm run lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_684a5123f710832c91ab892bcdc93454