### PR TITLE
Implement Minhas Compras page

### DIFF
--- a/app/components/Header.tsx
+++ b/app/components/Header.tsx
@@ -205,6 +205,15 @@ export default function Header() {
                       </Link>
                     </li>
                     <li>
+                      <Link
+                        href="/loja/compras"
+                        className="block px-4 py-2 hover:bg-zinc-100 dark:hover:bg-zinc-800"
+                        onClick={() => setClientOpen(false)}
+                      >
+                        Minhas compras
+                      </Link>
+                    </li>
+                    <li>
                       <button
                         onClick={handleLogout}
                         className="block w-full text-left px-4 py-2 text-red-600 hover:bg-zinc-100 dark:hover:bg-zinc-800"
@@ -289,6 +298,13 @@ export default function Header() {
                   onClick={() => setOpen(false)}
                 >
                   Área do Cliente
+                </Link>
+                <Link
+                  href="/loja/compras"
+                  className="text-platinum hover:text-primary-400 transition py-2 text-base font-medium"
+                  onClick={() => setOpen(false)}
+                >
+                  Minhas compras
                 </Link>
                 <button
                   onClick={handleLogout}

--- a/app/loja/api/compras/route.ts
+++ b/app/loja/api/compras/route.ts
@@ -1,0 +1,20 @@
+import { NextRequest, NextResponse } from "next/server";
+import { requireRole } from "@/lib/apiAuth";
+
+export async function GET(req: NextRequest) {
+  const auth = requireRole(req, "usuario");
+  if ("error" in auth) {
+    return NextResponse.json({ error: auth.error }, { status: auth.status });
+  }
+  const { pb, user } = auth;
+  try {
+    const compras = await pb.collection("compras").getFullList({
+      filter: `usuario = "${user.id}"`,
+      sort: "-created",
+    });
+    return NextResponse.json(compras, { status: 200 });
+  } catch (err) {
+    console.error("Erro ao listar compras:", err);
+    return NextResponse.json({ error: "Erro ao listar" }, { status: 500 });
+  }
+}

--- a/app/loja/compras/page.tsx
+++ b/app/loja/compras/page.tsx
@@ -1,0 +1,80 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { useAuthGuard } from "@/lib/hooks/useAuthGuard";
+import type { Compra } from "@/types";
+
+export default function MinhasComprasPage() {
+  const { user, pb, authChecked } = useAuthGuard(["usuario"]);
+  const [compras, setCompras] = useState<Compra[]>([]);
+  const [loading, setLoading] = useState(true);
+
+  useEffect(() => {
+    if (!authChecked || !user) return;
+    const token = pb.authStore.token;
+    fetch("/loja/api/compras", {
+      headers: {
+        Authorization: `Bearer ${token}`,
+        "X-PB-User": JSON.stringify(user),
+      },
+    })
+      .then((res) => res.json())
+      .then((data) => setCompras(Array.isArray(data) ? data : []))
+      .catch((err) => {
+        console.error("Erro ao carregar compras", err);
+        setCompras([]);
+      })
+      .finally(() => setLoading(false));
+  }, [authChecked, user, pb]);
+
+  if (!authChecked) return null;
+
+  if (loading) {
+    return <p className="p-6 text-center text-sm">Carregando compras...</p>;
+  }
+
+  return (
+    <main className="max-w-5xl mx-auto px-4 py-8">
+      <h2 className="heading">Minhas Compras</h2>
+      {compras.length === 0 ? (
+        <p className="text-center text-gray-500">Nenhuma compra encontrada.</p>
+      ) : (
+        <div className="overflow-x-auto rounded-lg border border-gray-200 shadow-sm">
+          <table className="table-base">
+            <thead>
+              <tr>
+                <th>Valor</th>
+                <th>Status</th>
+                <th>Método</th>
+                <th>Checkout</th>
+              </tr>
+            </thead>
+            <tbody>
+              {compras.map((c) => (
+                <tr key={c.id}>
+                  <td>{Number(c.valor_total).toFixed(2)}</td>
+                  <td className="capitalize">{c.status}</td>
+                  <td>{c.metodo_pagamento}</td>
+                  <td className="text-xs break-all">
+                    {c.checkout_url ? (
+                      <a
+                        href={c.checkout_url}
+                        className="text-blue-600 underline"
+                        target="_blank"
+                        rel="noreferrer"
+                      >
+                        link
+                      </a>
+                    ) : (
+                      "—"
+                    )}
+                  </td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+      )}
+    </main>
+  );
+}

--- a/arquitetura.md
+++ b/arquitetura.md
@@ -48,6 +48,7 @@ Todas coexistem no mesmo projeto Next.js (App Router) hospedado na **Vercel**.
 │   ├── categorias/        # Filtros e páginas de cada categoria de produto
 │   ├── checkout/          # Processo de pagamento e finalização do pedido
 │   ├── cliente/           # Área do cliente com pedidos e dados pessoais
+│   ├── compras/           # Histórico do usuário com suas compras
 │   ├── login/             # Rotas de autenticação da loja
 │   ├── components/        # Componentes reutilizáveis da loja
 │   ├── eventos/           # Formulário de inscrição em eventos

--- a/logs/DOC_LOG.md
+++ b/logs/DOC_LOG.md
@@ -77,3 +77,4 @@
 ## [2025-06-13] Documentado formato de externalReference e atualizados testes de checkout
 ## [2025-06-13] README atualizado sobre ASAAS_API_KEY e .env.example ajustado
 ## [2025-06-12] Documentada coleção de compras e página no admin
+## [2025-06-13] Adicionada página Minhas compras na loja e link no menu do usuário


### PR DESCRIPTION
## Summary
- create /loja/compras page using `useAuthGuard` to fetch user purchases
- expose GET /loja/api/compras for authenticated users
- add link "Minhas compras" in Header user menu
- document new folder in architecture
- log documentation update

## Testing
- `npm run lint` *(fails: next not found)*
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_684a53bddcd0832cad6e825e3fcd824c