### PR TITLE
Implementação de páginas de detalhes de compras

### DIFF
--- a/README.md
+++ b/README.md
@@ -161,6 +161,12 @@ Registra as compras feitas na loja. Campos principais:
 - `endereco_entrega` – dados de entrega (opcional).
 - `created` / `updated` – gerenciados pelo PocketBase.
 
+### Rotas de Compras
+
+- `/admin/compras` – listagem de compras para coordenadores.
+- `/admin/compras/[id]` – detalhes de uma compra.
+- `/loja/compras/[id]` – página de detalhes acessível pelo usuário.
+
 ## Perfis de Acesso
 
 O sistema possui três níveis de usuário:

--- a/app/admin/compras/[id]/page.tsx
+++ b/app/admin/compras/[id]/page.tsx
@@ -1,0 +1,68 @@
+"use client";
+
+import { useParams } from "next/navigation";
+import { useEffect, useState } from "react";
+import { useAuthGuard } from "@/lib/hooks/useAuthGuard";
+import type { Compra } from "@/types";
+
+function formatCurrency(v: number) {
+  return `R$ ${v.toFixed(2).replace(".", ",")}`;
+}
+
+function formatEndereco(endereco: Record<string, unknown> | undefined) {
+  if (!endereco) return "-";
+  const { endereco: rua, numero, cidade, estado, cep } = endereco as Record<string, string>;
+  return [rua, numero, cidade, estado, cep].filter(Boolean).join(", ");
+}
+
+export default function DetalheCompraAdmin() {
+  const { id } = useParams<{ id: string }>();
+  const { pb, authChecked } = useAuthGuard();
+  const [compra, setCompra] = useState<Compra | null>(null);
+  const [loading, setLoading] = useState(true);
+
+  useEffect(() => {
+    if (!authChecked) return;
+    pb.collection("compras")
+      .getOne<Compra>(id)
+      .then(setCompra)
+      .catch(() => setCompra(null))
+      .finally(() => setLoading(false));
+  }, [authChecked, pb, id]);
+
+  if (!authChecked) return null;
+
+  if (loading) {
+    return <p className="p-6 text-center text-sm">Carregando compra...</p>;
+  }
+
+  if (!compra) {
+    return <p className="p-6 text-center text-sm">Compra não encontrada.</p>;
+  }
+
+  return (
+    <main className="max-w-3xl mx-auto px-4 py-8 space-y-4">
+      <h2 className="heading">Detalhes da Compra</h2>
+      <p>
+        <strong>Valor Total:</strong> {formatCurrency(Number(compra.valor_total))}
+      </p>
+      <p>
+        <strong>Status:</strong> {compra.status}
+      </p>
+      <p>
+        <strong>Método de Pagamento:</strong> {compra.metodo_pagamento}
+      </p>
+      <p>
+        <strong>Endereço:</strong> {formatEndereco(compra.endereco_entrega)}
+      </p>
+      <div>
+        <h3 className="font-bold mt-4 mb-2">Itens</h3>
+        <ul className="list-disc list-inside space-y-1 text-sm">
+          {compra.itens.map((item, idx) => (
+            <li key={idx}>{JSON.stringify(item)}</li>
+          ))}
+        </ul>
+      </div>
+    </main>
+  );
+}

--- a/app/admin/compras/page.tsx
+++ b/app/admin/compras/page.tsx
@@ -57,6 +57,7 @@ export default function ComprasPage() {
                 <th>Status</th>
                 <th>Método</th>
                 <th>Checkout</th>
+                <th></th>
               </tr>
             </thead>
             <tbody>
@@ -78,6 +79,14 @@ export default function ComprasPage() {
                     ) : (
                       "—"
                     )}
+                  </td>
+                  <td>
+                    <a
+                      href={`/admin/compras/${c.id}`}
+                      className="text-blue-600 underline text-xs"
+                    >
+                      Ver detalhes
+                    </a>
                   </td>
                 </tr>
               ))}

--- a/app/loja/cliente/page.tsx
+++ b/app/loja/cliente/page.tsx
@@ -82,7 +82,12 @@ export default function AreaCliente() {
                 <td>{p.status}</td>
                 <td>{p.pagamento}</td>
                 <td className="flex gap-2">
-                  <button className="btn btn-secondary">Ver detalhes</button>
+                  <a
+                    href={`/loja/compras/${p.id}`}
+                    className="btn btn-secondary"
+                  >
+                    Ver detalhes
+                  </a>
                   <button className="btn btn-primary">Recomprar</button>
                 </td>
               </tr>

--- a/app/loja/compras/[id]/page.tsx
+++ b/app/loja/compras/[id]/page.tsx
@@ -1,0 +1,68 @@
+"use client";
+
+import { useParams } from "next/navigation";
+import { useEffect, useState } from "react";
+import { useAuthGuard } from "@/lib/hooks/useAuthGuard";
+import type { Compra } from "@/types";
+
+function formatCurrency(v: number) {
+  return `R$ ${v.toFixed(2).replace(".", ",")}`;
+}
+
+function formatEndereco(endereco: Record<string, unknown> | undefined) {
+  if (!endereco) return "-";
+  const { endereco: rua, numero, cidade, estado, cep } = endereco as Record<string, string>;
+  return [rua, numero, cidade, estado, cep].filter(Boolean).join(", ");
+}
+
+export default function DetalheCompraUsuario() {
+  const { id } = useParams<{ id: string }>();
+  const { pb, authChecked } = useAuthGuard(["usuario"]);
+  const [compra, setCompra] = useState<Compra | null>(null);
+  const [loading, setLoading] = useState(true);
+
+  useEffect(() => {
+    if (!authChecked) return;
+    pb.collection("compras")
+      .getOne<Compra>(id)
+      .then(setCompra)
+      .catch(() => setCompra(null))
+      .finally(() => setLoading(false));
+  }, [authChecked, pb, id]);
+
+  if (!authChecked) return null;
+
+  if (loading) {
+    return <p className="p-6 text-center text-sm">Carregando compra...</p>;
+  }
+
+  if (!compra) {
+    return <p className="p-6 text-center text-sm">Compra não encontrada.</p>;
+  }
+
+  return (
+    <main className="max-w-xl mx-auto px-4 py-8 space-y-4">
+      <h2 className="text-xl font-bold">Detalhes da Compra</h2>
+      <p>
+        <strong>Valor Total:</strong> {formatCurrency(Number(compra.valor_total))}
+      </p>
+      <p>
+        <strong>Status:</strong> {compra.status}
+      </p>
+      <p>
+        <strong>Método de Pagamento:</strong> {compra.metodo_pagamento}
+      </p>
+      <p>
+        <strong>Endereço:</strong> {formatEndereco(compra.endereco_entrega)}
+      </p>
+      <div>
+        <h3 className="font-semibold mt-4 mb-2">Itens</h3>
+        <ul className="list-disc list-inside space-y-1 text-sm">
+          {compra.itens.map((item, idx) => (
+            <li key={idx}>{JSON.stringify(item)}</li>
+          ))}
+        </ul>
+      </div>
+    </main>
+  );
+}

--- a/arquitetura.md
+++ b/arquitetura.md
@@ -53,6 +53,7 @@ Todas coexistem no mesmo projeto Next.js (App Router) hospedado na **Vercel**.
 │   ├── eventos/           # Formulário de inscrição em eventos
 │   ├── inscricoes/        # Envio e visualização pública (se necessário)
 │   ├── produtos/          # Listagem e detalhes dos produtos
+│   ├── compras/           # Detalhes de compras realizadas
 │   ├── layout.tsx         # Layout público da loja
 │   └── page.tsx           # Home da loja
 ├──

--- a/logs/DOC_LOG.md
+++ b/logs/DOC_LOG.md
@@ -77,3 +77,4 @@
 ## [2025-06-13] Documentado formato de externalReference e atualizados testes de checkout
 ## [2025-06-13] README atualizado sobre ASAAS_API_KEY e .env.example ajustado
 ## [2025-06-12] Documentada coleção de compras e página no admin
+## [2025-06-13] Adicionadas páginas de detalhes de compras e links na listagem.


### PR DESCRIPTION
## Summary
- adicionar link para detalhes em `/admin/compras`
- incluir link em pedidos do cliente
- criar página `/admin/compras/[id]` para coordenadores
- criar página `/loja/compras/[id]` para usuários
- documentar rotas de compras no README
- registrar a nova pasta em `arquitetura.md`
- atualizar `DOC_LOG.md`

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_684a53c2bca8832c8211e91ecfe85442