### PR TITLE
Allow users to create compras

### DIFF
--- a/__tests__/compras.test.ts
+++ b/__tests__/compras.test.ts
@@ -1,0 +1,30 @@
+import { describe, it, expect, vi, afterEach } from 'vitest'
+import { NextRequest } from 'next/server'
+vi.mock('../lib/apiAuth', () => ({ requireRole: vi.fn() }))
+import { POST } from '../app/admin/api/compras/route'
+import { requireRole } from '../lib/apiAuth'
+
+describe('compras POST route', () => {
+  afterEach(() => {
+    vi.restoreAllMocks()
+  })
+
+  it('permite usuario criar nova compra', async () => {
+    const createMock = vi.fn().mockResolvedValue({ id: 'c1' })
+    ;(requireRole as unknown as { mockReturnValue: (v: any) => void }).mockReturnValue({
+      pb: { collection: () => ({ create: createMock }) } as any,
+      user: { cliente: 'cli1', id: 'user1' }
+    })
+
+    const req = new Request('http://test', {
+      method: 'POST',
+      body: JSON.stringify({ itens: [] })
+    })
+
+    const res = await POST(req as unknown as NextRequest)
+    expect(createMock).toHaveBeenCalledWith({ itens: [], cliente: 'cli1', usuario: 'user1' })
+    expect(res.status).toBe(201)
+    const body = await res.json()
+    expect(body.id).toBe('c1')
+  })
+})

--- a/app/admin/api/compras/route.ts
+++ b/app/admin/api/compras/route.ts
@@ -20,7 +20,7 @@ export async function GET(req: NextRequest) {
 }
 
 export async function POST(req: NextRequest) {
-  const auth = requireRole(req, "coordenador");
+  const auth = requireRole(req, "usuario");
   if ("error" in auth) {
     return NextResponse.json({ error: auth.error }, { status: auth.status });
   }
@@ -28,6 +28,7 @@ export async function POST(req: NextRequest) {
   try {
     const data = await req.json();
     data.cliente = user.cliente;
+    data.usuario = user.id;
     const compra = await pb.collection("compras").create(data);
     return NextResponse.json(compra, { status: 201 });
   } catch (err) {


### PR DESCRIPTION
## Summary
- allow POST /admin/api/compras from `usuario` role
- record user id when creating a compra
- test compra POST creation

## Testing
- `npm run lint` *(fails: `next` not found)*
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684a539318c4832ca38ce7d4115dec5a