### PR TITLE
Implement tenant filtering for categorias and eventos

### DIFF
--- a/app/api/eventos/route.ts
+++ b/app/api/eventos/route.ts
@@ -1,11 +1,15 @@
-import { NextResponse } from "next/server";
+import { NextRequest, NextResponse } from "next/server";
 import createPocketBase from "@/lib/pocketbase";
 import { EventoRecord, atualizarStatus } from "@/lib/events";
 
-export async function GET() {
+export async function GET(req: NextRequest) {
   const pb = createPocketBase();
+  const tenant = req.nextUrl.searchParams.get("tenant") || undefined;
   try {
-    const eventos = await pb.collection("eventos").getFullList<EventoRecord>({ sort: "-data" });
+    const eventos = await pb.collection("eventos").getFullList<EventoRecord>({
+      sort: "-data",
+      filter: tenant ? `cliente='${tenant}'` : undefined,
+    });
     await atualizarStatus(eventos, pb);
     const comUrls = eventos.map((e) => ({
       ...e,

--- a/app/loja/categorias/[slug]/page.tsx
+++ b/app/loja/categorias/[slug]/page.tsx
@@ -22,9 +22,10 @@ export default async function CategoriaDetalhe({
 }) {
   const { slug } = await params;
   const pb = createPocketBase();
+  const tenantId = process.env.NEXT_PUBLIC_TENANT_ID;
 
   const produtosPB: Produto[] = await pb.collection("produtos").getFullList({
-    filter: `ativo = true && categoria = '${slug}'`,
+    filter: `ativo = true && categoria = '${slug}' && cliente='${tenantId}'`,
     sort: "-created",
   });
 

--- a/app/loja/categorias/page.tsx
+++ b/app/loja/categorias/page.tsx
@@ -10,9 +10,10 @@ interface Categoria {
 
 export default async function CategoriasPage() {
   const pb = createPocketBase();
+  const tenantId = process.env.NEXT_PUBLIC_TENANT_ID;
   const categorias: Categoria[] = await pb
     .collection("categorias")
-    .getFullList({ sort: "nome" });
+    .getFullList({ sort: "nome", filter: `cliente='${tenantId}'` });
 
   return (
     <main className="p-8 text-platinum font-sans">

--- a/app/loja/eventos/page.tsx
+++ b/app/loja/eventos/page.tsx
@@ -19,7 +19,8 @@ export default function EventosPage() {
   const [eventos, setEventos] = useState<Evento[]>([]);
 
   useEffect(() => {
-    fetch("/api/eventos")
+    const tenantId = localStorage.getItem("tenant_id");
+    fetch(`/api/eventos?tenant=${tenantId ?? ""}`)
       .then((r) => r.json())
       .then((data) => Array.isArray(data) ? setEventos(data) : setEventos([]))
       .catch((err) => {


### PR DESCRIPTION
## Summary
- filter categorias by tenant id
- filter category products by tenant id
- update eventos API to filter by tenant query parameter
- ensure tenant id sent when fetching eventos

## Testing
- `npm run lint`
- `npm test -- -t ''`

------
https://chatgpt.com/codex/tasks/task_e_684a5109c918832c93e46e7f204436a5