### PR TITLE
Fix client compile error by isolating server logging

### DIFF
--- a/app/api/asaas/webhook/route.ts
+++ b/app/api/asaas/webhook/route.ts
@@ -1,6 +1,6 @@
 import { NextRequest, NextResponse } from "next/server";
 import createPocketBase from "@/lib/pocketbase";
-import { logConciliacaoErro } from "@/lib/logger";
+import { logConciliacaoErro } from "@/lib/server/logger";
 import type { RecordModel } from "pocketbase";
 
 export async function POST(req: NextRequest) {

--- a/lib/logger.ts
+++ b/lib/logger.ts
@@ -3,18 +3,3 @@ export function logInfo(...args: unknown[]) {
     console.info(...args);
   }
 }
-
-import { appendFile } from "fs/promises";
-import path from "path";
-
-export async function logConciliacaoErro(message: string) {
-  const date = new Date().toISOString().split("T")[0];
-  const env = process.env.NODE_ENV || "dev";
-  const line = `## [${date}] ${message} - ${env}\n`;
-  try {
-    const logPath = path.join(process.cwd(), "logs", "ERR_LOG.md");
-    await appendFile(logPath, line);
-  } catch (err) {
-    console.error("Falha ao registrar ERR_LOG", err);
-  }
-}

--- a/lib/server/logger.ts
+++ b/lib/server/logger.ts
@@ -1,0 +1,14 @@
+import { appendFile } from "fs/promises";
+import path from "path";
+
+export async function logConciliacaoErro(message: string) {
+  const date = new Date().toISOString().split("T")[0];
+  const env = process.env.NODE_ENV || "dev";
+  const line = `## [${date}] ${message} - ${env}\n`;
+  try {
+    const logPath = path.join(process.cwd(), "logs", "ERR_LOG.md");
+    await appendFile(logPath, line);
+  } catch (err) {
+    console.error("Falha ao registrar ERR_LOG", err);
+  }
+}


### PR DESCRIPTION
## Summary
- isolate server-side logging in its own module
- update webhook to use the server logger

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_684a5814a478832cbd9e0a6f43de32df