### PR TITLE
Fix SignUpForm type for children

### DIFF
--- a/app/api/asaas/webhook/route.ts
+++ b/app/api/asaas/webhook/route.ts
@@ -1,6 +1,6 @@
 import { NextRequest, NextResponse } from "next/server";
 import createPocketBase from "@/lib/pocketbase";
-import { logConciliacaoErro } from "@/lib/logger";
+import { logConciliacaoErro } from "@/lib/server/logger";
 import type { RecordModel } from "pocketbase";
 
 export async function POST(req: NextRequest) {

--- a/app/components/SignUpForm.tsx
+++ b/app/components/SignUpForm.tsx
@@ -5,8 +5,10 @@ import { useAuthContext } from "@/lib/context/AuthContext";
 
 export default function SignUpForm({
   onSuccess,
+  children,
 }: {
   onSuccess?: () => void;
+  children?: React.ReactNode;
 }) {
   const { signUp } = useAuthContext();
   const [nome, setNome] = useState("");
@@ -151,6 +153,9 @@ export default function SignUpForm({
       >
         {loading ? "Enviando..." : "Criar conta"}
       </button>
+      {children && (
+        <div className="text-sm text-gray-300 text-center">{children}</div>
+      )}
     </form>
   );
 }

--- a/lib/logger.ts
+++ b/lib/logger.ts
@@ -3,18 +3,3 @@ export function logInfo(...args: unknown[]) {
     console.info(...args);
   }
 }
-
-import { appendFile } from "fs/promises";
-import path from "path";
-
-export async function logConciliacaoErro(message: string) {
-  const date = new Date().toISOString().split("T")[0];
-  const env = process.env.NODE_ENV || "dev";
-  const line = `## [${date}] ${message} - ${env}\n`;
-  try {
-    const logPath = path.join(process.cwd(), "logs", "ERR_LOG.md");
-    await appendFile(logPath, line);
-  } catch (err) {
-    console.error("Falha ao registrar ERR_LOG", err);
-  }
-}

--- a/lib/server/logger.ts
+++ b/lib/server/logger.ts
@@ -1,0 +1,14 @@
+import { appendFile } from "fs/promises";
+import path from "path";
+
+export async function logConciliacaoErro(message: string) {
+  const date = new Date().toISOString().split("T")[0];
+  const env = process.env.NODE_ENV || "dev";
+  const line = `## [${date}] ${message} - ${env}\n`;
+  try {
+    const logPath = path.join(process.cwd(), "logs", "ERR_LOG.md");
+    await appendFile(logPath, line);
+  } catch (err) {
+    console.error("Falha ao registrar ERR_LOG", err);
+  }
+}


### PR DESCRIPTION
## Summary
- allow SignUpForm to accept `children`

## Testing
- `npm run lint` *(fails: Unexpected any)*

------
https://chatgpt.com/codex/tasks/task_e_684a5814a478832cbd9e0a6f43de32df