### PR TITLE
Adiciona ícone de tour e link de compras

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,8 @@ Este repositório reúne portal institucional, blog, loja virtual e painel admin
 Visitantes navegam pelo portal e pelo blog, realizam compras na loja e os coordenadores gerenciam tudo pelo admin.
 Consulte [arquitetura.md](arquitetura.md) para entender a divisão de pastas e responsabilidades.
 Para personalizar a interface utilize as orientações de [docs/design-system.md](docs/design-system.md).
+Para um passo a passo inicial do sistema consulte [docs/iniciar-tour.md](docs/iniciar-tour.md).
+O tour pode ser iniciado clicando no ícone de mapa ao lado do sino de notificações ou acessando `/iniciar-tour` diretamente.
 
 ## Primeiros Passos
 

--- a/app/admin/components/LayoutWrapper.tsx
+++ b/app/admin/components/LayoutWrapper.tsx
@@ -5,6 +5,7 @@ import Header from "@/app/admin/components/Header";
 import Footer from "@/app/components/Footer";
 import BackToTopButton from "@/app/admin/components/BackToTopButton";
 import NotificationBell from "@/app/admin/components/NotificationBell";
+import TourIcon from "@/app/admin/components/TourIcon";
 import { useAuthContext } from "@/lib/context/AuthContext";
 
 export default function LayoutWrapper({
@@ -24,7 +25,12 @@ export default function LayoutWrapper({
         {children}
       </main>
       <Footer />
-      {isLoggedIn && user?.role === "coordenador" && <NotificationBell />}
+      {isLoggedIn && user?.role === "coordenador" && (
+        <>
+          <NotificationBell />
+          <TourIcon />
+        </>
+      )}
       <BackToTopButton />
     </>
   );

--- a/app/admin/components/TourIcon.tsx
+++ b/app/admin/components/TourIcon.tsx
@@ -1,0 +1,45 @@
+"use client";
+
+import { useEffect, useState, useMemo } from "react";
+import { MapPinned } from "lucide-react";
+import { useRouter } from "next/navigation";
+import createPocketBase from "@/lib/pocketbase";
+import { useAuthContext } from "@/lib/context/AuthContext";
+
+export default function TourIcon() {
+  const { user, isLoggedIn } = useAuthContext();
+  const [visible, setVisible] = useState(false);
+  const pb = useMemo(() => createPocketBase(), []);
+  const router = useRouter();
+
+  useEffect(() => {
+    if (!isLoggedIn || !user) return setVisible(false);
+    const fezTour = Boolean((user as any).tour);
+    setVisible(!fezTour);
+  }, [isLoggedIn, user]);
+
+  if (!visible) return null;
+
+  async function iniciarTour() {
+    const confirmar = window.confirm("Iniciar tour?");
+    if (!confirmar || !user) return;
+    try {
+      await pb.collection("usuarios").update(user.id, { tour: true });
+    } catch (err) {
+      console.error("Erro ao registrar tour", err);
+    }
+    router.push("/iniciar-tour");
+  }
+
+  return (
+    <div className="fixed bottom-32 right-4 z-50">
+      <button
+        onClick={iniciarTour}
+        aria-label="Iniciar tour"
+        className="bg-[var(--color-secondary)] text-[var(--background)] p-2 rounded-full shadow"
+      >
+        <MapPinned className="w-5 h-5" />
+      </button>
+    </div>
+  );
+}

--- a/app/components/Header.tsx
+++ b/app/components/Header.tsx
@@ -13,6 +13,7 @@ type UserRole = "visitante" | "usuario" | "lider" | "coordenador";
 const baseLinks = [
   { href: "/", label: "Início" },
   { href: "/loja/produtos", label: "Produtos" },
+  { href: "/loja/compras", label: "Compras" },
   { href: "/blog", label: "Blog" },
   { href: "/loja/eventos", label: "Eventos" },
   { href: "/loja/faq", label: "FAQ" },

--- a/app/components/LayoutWrapper.tsx
+++ b/app/components/LayoutWrapper.tsx
@@ -4,6 +4,7 @@ import Header from "./Header";
 import Footer from "./Footer";
 import BackToTopButton from "@/app/admin/components/BackToTopButton";
 import NotificationBell from "@/app/admin/components/NotificationBell";
+import TourIcon from "@/app/admin/components/TourIcon";
 import { useAuthContext } from "@/lib/context/AuthContext";
 import { useMemo } from "react";
 
@@ -29,7 +30,12 @@ export default function LayoutWrapper({
         {children}
       </main>
       <Footer />
-      {role === "coordenador" && <NotificationBell />}
+      {role === "coordenador" && (
+        <>
+          <NotificationBell />
+          <TourIcon />
+        </>
+      )}
       <BackToTopButton />
     </>
   );

--- a/app/iniciar-tour/page.tsx
+++ b/app/iniciar-tour/page.tsx
@@ -1,0 +1,71 @@
+import LayoutWrapper from "../components/LayoutWrapper";
+
+export const metadata = {
+  title: "Iniciar Tour",
+  description: "Guia de primeiro acesso para novos clientes",
+};
+
+export default function IniciarTourPage() {
+  return (
+    <LayoutWrapper>
+      <div className="max-w-2xl mx-auto px-6 py-10 space-y-8">
+        <h1 className="text-3xl font-bold">Iniciar Tour</h1>
+
+        <section>
+          <h2 className="text-2xl font-semibold mt-6">1. Acesso inicial</h2>
+          <ol className="list-decimal space-y-2 pl-5 mt-2">
+            <li>Abra a URL do site e clique em <strong>Login</strong>.</li>
+            <li>Insira as credenciais fornecidas durante o cadastro.</li>
+            <li>
+              Na primeira visita, clique em <strong>Iniciar Tour</strong> para seguir as etapas abaixo.
+            </li>
+          </ol>
+        </section>
+
+        <section>
+          <h2 className="text-2xl font-semibold mt-6">2. Loja</h2>
+          <ol className="list-decimal space-y-2 pl-5 mt-2">
+            <li>Explore a vitrine de produtos em <strong>Loja</strong>.</li>
+            <li>Adicione itens ao carrinho e finalize em <strong>Checkout</strong>.</li>
+            <li>Acompanhe seus pedidos em <strong>Minhas compras</strong>.</li>
+          </ol>
+        </section>
+
+        <section>
+          <h2 className="text-2xl font-semibold mt-6">3. Painel Administrativo</h2>
+          <ol className="list-decimal space-y-2 pl-5 mt-2">
+            <li>Acesse <strong>Admin</strong> para abrir o painel de gestão.</li>
+            <li>No menu lateral, visite cada seção:</li>
+            <li className="list-none">
+              <ul className="list-disc pl-5 space-y-1">
+                <li><strong>Dashboard</strong> – visão geral de inscrições e vendas.</li>
+                <li><strong>Inscrições</strong> – lista e aprovação de participantes.</li>
+                <li><strong>Pedidos</strong> – pagamentos relacionados às inscrições.</li>
+                <li><strong>Compras</strong> – histórico de compras na loja.</li>
+                <li><strong>Produtos</strong> – cadastro e edição de itens.</li>
+                <li><strong>Clientes</strong> – dados de cada tenant e domínio.</li>
+                <li><strong>Campos</strong> – gerenciamento das áreas de atuação.</li>
+                <li><strong>Configurações</strong> – logo, cores e opções do sistema.</li>
+              </ul>
+            </li>
+          </ol>
+        </section>
+
+        <section>
+          <h2 className="text-2xl font-semibold mt-6">4. Blog</h2>
+          <ol className="list-decimal space-y-2 pl-5 mt-2">
+            <li>Acesse a aba <strong>Blog</strong> para ler ou criar posts (via admin).</li>
+            <li>Utilize o editor para publicar novidades no portal.</li>
+          </ol>
+        </section>
+
+        <section>
+          <h2 className="text-2xl font-semibold mt-6">5. Conclusão</h2>
+          <p className="mt-2">
+            Ao final do tour, você estará apto a navegar entre loja, admin e blog, gerenciando suas informações de forma centralizada.
+          </p>
+        </section>
+      </div>
+    </LayoutWrapper>
+  );
+}

--- a/docs/iniciar-tour.md
+++ b/docs/iniciar-tour.md
@@ -1,0 +1,37 @@
+# Iniciar Tour
+
+Este guia apresenta um passo a passo para novos clientes conhecerem as principais funcionalidades do sistema.
+
+## 1. Acesso inicial
+
+1. Abra a URL do site e clique em **Login**.
+2. Insira as credenciais fornecidas durante o cadastro.
+3. Na primeira visita, clique em **Iniciar Tour** para seguir as etapas abaixo.
+
+## 2. Loja
+
+1. Na área pública, explore a vitrine de produtos em **Loja**.
+2. Adicione itens ao carrinho e finalize em **Checkout**.
+3. Após a compra, acompanhe seus pedidos em **Minhas compras**.
+
+## 3. Painel Administrativo
+
+1. Acesse **Admin** para abrir o painel de gestão.
+2. No menu lateral, visite cada seção:
+   - **Dashboard** – visão geral de inscrições e vendas.
+   - **Inscrições** – lista e aprovação de participantes.
+   - **Pedidos** – pagamentos relacionados às inscrições.
+   - **Compras** – histórico de compras na loja.
+   - **Produtos** – cadastro e edição de itens.
+   - **Clientes** – dados de cada tenant e domínio.
+   - **Campos** – gerenciamento das áreas de atuação.
+   - **Configurações** – logo, cores e opções do sistema.
+
+## 4. Blog
+
+1. Acesse a aba **Blog** para ler ou criar posts (via admin).
+2. Utilize o editor para publicar novidades no portal.
+
+## 5. Conclusão
+
+Ao final do tour, você estará apto a navegar entre loja, admin e blog, gerenciando suas informações de forma centralizada.

--- a/lib/context/AuthContext.tsx
+++ b/lib/context/AuthContext.tsx
@@ -11,6 +11,7 @@ type UserModel = {
   id: string;
   nome: string;
   role: "coordenador" | "lider" | "usuario";
+  tour?: boolean;
   [key: string]: unknown;
 };
 
@@ -160,6 +161,7 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
       passwordConfirm: password,
       role: "usuario",
       cliente: clienteId,
+      tour: false,
     });
     await login(email, password);
   };

--- a/logs/DOC_LOG.md
+++ b/logs/DOC_LOG.md
@@ -80,3 +80,7 @@
 ## [2025-06-13] Documentado acesso restrito de /admin/compras aos coordenadores e atualizada proteção do código
 ## [2025-06-13] Adicionada página Minhas compras na loja e link no menu do usuário
 ## [2025-06-13] Adicionadas páginas de detalhes de compras e links na listagem.
+## [2025-06-12] Adicionado guia iniciar-tour.md com passo a passo para clientes
+## [2025-06-12] Criada página /iniciar-tour com guia de primeiro acesso e link atualizado no README
+## [2025-06-12] Removido link Iniciar Tour do menu; adicionado ícone de tour junto ao sino
+## [2025-06-12] Campo booleano 'tour' registrado para usuários e link Compras incluído no header

--- a/types/UserModel.ts
+++ b/types/UserModel.ts
@@ -4,5 +4,6 @@ export type UserModel = {
   email: string;
   role: "coordenador" | "lider" | "usuario";
   cliente?: string;
+  tour?: boolean;
   [key: string]: unknown;
 };


### PR DESCRIPTION
## Summary
- cria `TourIcon` para iniciar o guia de onboarding a partir do sino de notificações
- registra campo booleano `tour` para usuários no PocketBase
- remove link 'Iniciar Tour' do menu e adiciona 'Compras'
- documenta o novo acesso ao tour pelo ícone
- atualiza registros em `DOC_LOG.md`

## Testing
- `npm run lint` *(fails: next not found)*
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_684a59fca2fc832ca6355be12d345778