### PR TITLE
Fix product type mismatch and optimize blog images

### DIFF
--- a/app/blog/BlogClient.tsx
+++ b/app/blog/BlogClient.tsx
@@ -6,7 +6,6 @@ import BlogSidebar from "./components/BlogSidebar";
 import BlogHeroCarousel from "./components/BlogHeroCarousel";
 import Link from "next/link";
 import Image from "next/image";
-import { isExternalUrl } from "@/utils/isExternalUrl";
 
 interface Post {
   title: string;
@@ -99,22 +98,15 @@ export default function BlogClient() {
                       key={post.slug}
                       className="bg-[var(--background)] dark:bg-neutral-900 rounded-xl shadow-md hover:shadow-lg transition overflow-hidden flex flex-col"
                     >
-                      {post.thumbnail &&
-                        (isExternalUrl(post.thumbnail) ? (
-                          <img
-                            src={post.thumbnail}
-                            alt={`Imagem de capa do post: ${post.title}`}
-                            className="w-full h-56 object-cover"
-                          />
-                        ) : (
-                          <Image
-                            src={post.thumbnail}
-                            alt={`Imagem de capa do post: ${post.title}`}
-                            width={640}
-                            height={320}
-                            className="w-full h-56 object-cover"
-                          />
-                        ))}
+                      {post.thumbnail && (
+                        <Image
+                          src={post.thumbnail}
+                          alt={`Imagem de capa do post: ${post.title}`}
+                          width={640}
+                          height={320}
+                          className="w-full h-56 object-cover"
+                        />
+                      )}
                       <div className="p-6 flex-1 flex flex-col justify-between">
                         {post.category && (
                           <span className="inline-block bg-primary-50 text-primary-800 text-xs font-semibold px-3 py-1 rounded-full mb-2 uppercase tracking-wide">

--- a/app/login/page.tsx
+++ b/app/login/page.tsx
@@ -1,12 +1,22 @@
 "use client";
 
-import { useEffect, useState } from "react";
+import { Suspense, useEffect, useState } from "react";
+
+export default function LoginPage() {
+  return (
+    <Suspense>
+      <LoginClient />
+    </Suspense>
+  );
+}
+
 import { useSearchParams } from "next/navigation";
 import LoginForm from "../components/LoginForm";
 import SignUpForm from "../components/SignUpForm";
 import LayoutWrapper from "../components/LayoutWrapper";
 
-export default function LoginPage() {
+function LoginClient() {
+  "use client";
   const searchParams = useSearchParams();
   const initial = searchParams.get("view") === "signup" ? "signup" : "login";
   const [view, setView] = useState<"login" | "signup">(initial);

--- a/app/loja/produtos/[slug]/page.tsx
+++ b/app/loja/produtos/[slug]/page.tsx
@@ -7,19 +7,7 @@ import { Suspense } from "react";
 import { useAuthContext } from "@/lib/context/AuthContext";
 import createPocketBase from "@/lib/pocketbase";
 import ProdutoInterativo from "./ProdutoInterativo";
-
-interface Produto {
-  id: string;
-  nome: string;
-  preco: number;
-  imagens: string[] | Record<string, string[]>;
-  slug: string;
-  descricao?: string;
-  cores?: string | string[];
-  tamanhos?: string | string[];
-  generos?: string | string[];
-  checkout_url?: string;
-}
+import type { Produto } from "@/types";
 export default function ProdutoDetalhe() {
   const { slug } = useParams<{ slug: string }>();
   const [produto, setProduto] = useState<Produto | null>(null);

--- a/logs/ERR_LOG.md
+++ b/logs/ERR_LOG.md
@@ -47,3 +47,4 @@
 ## [2025-06-09] Corrigido erro de imagem sem src na loja/produtos - dev - 1937fbf
 ## [2025-06-10] Corrigido carregamento de slug e imagens absolutas em loja/produtos/[slug] - dev - 3a448ad
 ## [2025-06-12] Corrigido erro de build por importacao de fs/promises no bundle de cliente - dev - 94b6508
+## [2025-06-12] Ajustado tipo Produto em loja/produtos/[slug] para compatibilidade com types - dev - 707ff02

--- a/logs/ERR_LOG.md
+++ b/logs/ERR_LOG.md
@@ -48,3 +48,4 @@
 ## [2025-06-10] Corrigido carregamento de slug e imagens absolutas em loja/produtos/[slug] - dev - 3a448ad
 ## [2025-06-12] Corrigido erro de build por importacao de fs/promises no bundle de cliente - dev - 94b6508
 ## [2025-06-12] Ajustado tipo Produto em loja/produtos/[slug] para compatibilidade com types - dev - 707ff02
+## [2025-06-12] Corrigido erro de build em login por falta de Suspense - dev - 823ad2b

--- a/next.config.ts
+++ b/next.config.ts
@@ -3,7 +3,12 @@ import type { NextConfig } from "next";
 const nextConfig: NextConfig = {
   reactStrictMode: true,
   images: {
-    domains: ["asaas.com", "umadeus-production.up.railway.app"],
+    domains: [
+      "asaas.com",
+      "umadeus-production.up.railway.app",
+      "images.unsplash.com",
+      "picsum.photos",
+    ],
   },
   redirects: async () => [
     {

--- a/types/color-namer.d.ts
+++ b/types/color-namer.d.ts
@@ -1,0 +1,1 @@
+declare module 'color-namer';


### PR DESCRIPTION
## Summary
- use shared `Produto` type in product details page
- show thumbnails with `next/image` in blog client
- allow Unsplash and Picsum domains
- log product type fix in ERR_LOG

## Testing
- `npx next@15.3.2 lint` *(fails: It looks like you're trying to use TypeScript but do not have the required package(s) installed)*

------
https://chatgpt.com/codex/tasks/task_e_684a6374db1c832cb07dd8f86819d4ac