### PR TITLE
Fix Storybook provider and add missing story

### DIFF
--- a/.storybook/preview.ts
+++ b/.storybook/preview.ts
@@ -1,9 +1,16 @@
-ts import '../app/globals.css';
-
+import '../app/globals.css';
+import { AppConfigProvider } from '../lib/context/AppConfigContext';
 
 import type { Preview } from '@storybook/nextjs'
 
 const preview: Preview = {
+  decorators: [
+    (Story) => (
+      <AppConfigProvider>
+        <Story />
+      </AppConfigProvider>
+    ),
+  ],
   parameters: {
     controls: {
       matchers: {

--- a/logs/ERR_LOG.md
+++ b/logs/ERR_LOG.md
@@ -47,3 +47,5 @@
 ## [2025-06-09] Corrigido erro de imagem sem src na loja/produtos - dev - 1937fbf
 ## [2025-06-10] Corrigido carregamento de slug e imagens absolutas em loja/produtos/[slug] - dev - 3a448ad
 ## [2025-06-12] Corrigido erro de build por importacao de fs/promises no bundle de cliente - dev - 94b6508
+## [2025-06-12] Corrigido prefixo de tipo incorreto no preview do Storybook - dev - c3ffbb6
+## [2025-06-12] Ajustado preview do Storybook para aplicar AppConfigProvider e exibir cores primarias - dev - 30fade5

--- a/stories/CartButton.stories.tsx
+++ b/stories/CartButton.stories.tsx
@@ -1,0 +1,25 @@
+import type { Meta, StoryObj } from '@storybook/nextjs';
+import CartButton from '../app/components/CartButton';
+import { CartProvider } from '../lib/context/CartContext';
+import { ThemeProvider } from '../lib/context/ThemeContext';
+
+const meta = {
+  title: 'Components/CartButton',
+  component: CartButton,
+  decorators: [
+    (Story) => (
+      <ThemeProvider>
+        <CartProvider>
+          <Story />
+        </CartProvider>
+      </ThemeProvider>
+    ),
+  ],
+  tags: ['autodocs'],
+} satisfies Meta<typeof CartButton>;
+
+export default meta;
+
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {};


### PR DESCRIPTION
## Summary
- apply `AppConfigProvider` decorator globally in `.storybook/preview.ts`
- create `CartButton` story to cover missing component
- log the fix in `ERR_LOG.md`

## Testing
- `npm run lint` *(fails: sh: 1: next: not found)*
- `npm run storybook` *(fails: sh: 1: storybook: not found)*

------
https://chatgpt.com/codex/tasks/task_e_684ab75dfc94832ca5fd2b78a4d8bf73