### PR TITLE
Ajuste de generos e imagens na loja

### DIFF
--- a/app/loja/produtos/[slug]/ProdutoInterativo.tsx
+++ b/app/loja/produtos/[slug]/ProdutoInterativo.tsx
@@ -135,7 +135,8 @@ export default function ProdutoInterativo({
   const pauseRef = useRef(false);
   const router = useRouter();
 
-  const imgs = imagens[genero] || imagens[generosNorm[0]];
+  const firstImgKey = Object.keys(imagens)[0];
+  const imgs = imagens[genero] || imagens["default"] || imagens[firstImgKey];
 
   useEffect(() => {
     setIndexImg(0);
@@ -276,7 +277,7 @@ export default function ProdutoInterativo({
                 ...produto,
                 imagens: Array.isArray(produto.imagens)
                   ? produto.imagens
-                  : imagens[genero] || [],
+                  : imagens[genero] || imagens["default"] || imagens[firstImgKey] || [],
                 generos: [genero],
                 tamanhos: [tamanho],
                 cores: cor ? [cor] : [],

--- a/app/loja/produtos/[slug]/page.tsx
+++ b/app/loja/produtos/[slug]/page.tsx
@@ -62,17 +62,25 @@ export default function ProdutoDetalhe() {
     );
   }
 
-  // Normaliza imagens, tamanhos, generos
+  // Normaliza imagens e gêneros
   let generos: string[] = [];
   let imagens: Record<string, string[]> = {};
+
+  // Tenta extrair lista de gêneros armazenada no produto
+  if (produto.generos) {
+    generos = Array.isArray(produto.generos)
+      ? produto.generos.map((g) => g.trim())
+      : produto.generos.split(",").map((g) => g.trim());
+  }
+
   if (typeof produto.imagens === "object" && !Array.isArray(produto.imagens)) {
     // formato: { masculino: [...], feminino: [...] }
     imagens = produto.imagens as Record<string, string[]>;
-    generos = Object.keys(imagens);
+    if (generos.length === 0) generos = Object.keys(imagens);
   } else {
     // formato: array
     imagens = { default: (produto.imagens as string[]) || [] };
-    generos = ["default"];
+    if (generos.length === 0) generos = ["default"];
   }
 
   const tamanhos = Array.isArray(produto.tamanhos)

--- a/logs/ERR_LOG.md
+++ b/logs/ERR_LOG.md
@@ -53,3 +53,4 @@
 ## [2025-06-12] Corrigido erro "Expression expected" no preview do Storybook renomeando arquivo para .tsx - dev - 25cd01a 
 ## [2025-06-12] Ajustado tipo Produto em loja/produtos/[slug] para compatibilidade com types - dev - 707ff02
 ## [2025-06-12] Corrigido erro de build em login por falta de Suspense - dev - 823ad2b
+## [2025-06-12] Ajustado carregamento de gêneros e imagens no detalhe do produto - dev - 6fd0697


### PR DESCRIPTION
## Resumo
- processar campo `generos` em produtos
- fallback de imagem por genero no componente interativo
- registrar correção no `ERR_LOG`

## Testes
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_684ac9e2c808832c9246790e1e829143