### PR TITLE
Add primary shades tests

### DIFF
--- a/__tests__/primaryShades.test.ts
+++ b/__tests__/primaryShades.test.ts
@@ -1,0 +1,25 @@
+import { describe, it, expect } from 'vitest'
+import { hexToHsl, generatePrimaryShades } from '../utils/primaryShades'
+
+describe('primaryShades utilities', () => {
+  it('converts hex to hsl correctly', () => {
+    expect(hexToHsl('#ff0000')).toEqual([0, 100, 50])
+    expect(hexToHsl('#fff')).toEqual([0, 0, 100])
+  })
+
+  it('generates primary shades based on color', () => {
+    const shades = generatePrimaryShades('#ff0000')
+    expect(shades).toEqual({
+      '50': '0 100% 92%',
+      '100': '0 100% 82%',
+      '200': '0 100% 74%',
+      '300': '0 100% 66%',
+      '400': '0 100% 58%',
+      '500': '0 100% 54%',
+      '600': '0 100% 50%',
+      '700': '0 100% 42%',
+      '800': '0 100% 34%',
+      '900': '0 100% 26%',
+    })
+  })
+})


### PR DESCRIPTION
## Summary
- add unit tests for primaryShades utilities
- verify hex to HSL conversion for short and long hex
- check generated shades from 50-900

## Testing
- `npm run lint`
- `npm run test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_684ac8366734832cbf82b48d9284c508