### PR TITLE
Add basic API route tests

### DIFF
--- a/__tests__/admin/asaasRoute.test.ts
+++ b/__tests__/admin/asaasRoute.test.ts
@@ -1,0 +1,19 @@
+import { describe, it, expect, vi } from 'vitest'
+import { POST } from '../../app/admin/api/asaas/route'
+import { NextRequest } from 'next/server'
+
+vi.mock('../../lib/pocketbase', () => ({
+  createPocketBase: () => ({
+    authStore: { isValid: true },
+    admins: { authWithPassword: vi.fn() },
+    collection: () => ({ getFirstListItem: vi.fn() })
+  })
+}))
+
+describe('POST /admin/api/asaas', () => {
+  it('lança erro quando ASAAS_API_KEY ausente', async () => {
+    delete process.env.ASAAS_API_KEY
+    const req = new Request('http://test', { method: 'POST', body: JSON.stringify({ pedidoId:'1', valor:1 }) })
+    await expect(POST(req as unknown as NextRequest)).rejects.toThrow()
+  })
+})

--- a/__tests__/admin/camposRoute.test.ts
+++ b/__tests__/admin/camposRoute.test.ts
@@ -1,0 +1,15 @@
+import { describe, it, expect, vi } from 'vitest'
+import { GET } from '../../app/admin/api/campos/route'
+import { NextRequest } from 'next/server'
+
+vi.mock('../../lib/apiAuth', () => ({
+  requireRole: vi.fn(() => ({ error: 'Acesso negado', status: 403 }))
+}))
+
+describe('GET /admin/api/campos', () => {
+  it('retorna codigo da autenticacao quando requireRole falha', async () => {
+    const req = new Request('http://test')
+    const res = await GET(req as unknown as NextRequest)
+    expect(res.status).toBe(403)
+  })
+})

--- a/__tests__/admin/pedidosRoute.test.ts
+++ b/__tests__/admin/pedidosRoute.test.ts
@@ -1,0 +1,11 @@
+import { describe, it, expect } from 'vitest'
+import { POST } from '../../app/admin/api/pedidos/route'
+import { NextRequest } from 'next/server'
+
+describe('POST /admin/api/pedidos', () => {
+  it('retorna 400 quando inscricaoId ausente', async () => {
+    const req = new Request('http://test', { method: 'POST', body: JSON.stringify({}) })
+    const res = await POST(req as unknown as NextRequest)
+    expect(res.status).toBe(400)
+  })
+})

--- a/__tests__/api/camposRoute.test.ts
+++ b/__tests__/api/camposRoute.test.ts
@@ -1,0 +1,15 @@
+import { describe, it, expect, vi } from 'vitest'
+import { GET } from '../../app/api/campos/route'
+import { NextRequest } from 'next/server'
+
+vi.mock('../../lib/getUserFromHeaders', () => ({
+  getUserFromHeaders: vi.fn(() => ({ error: 'Token invalido' }))
+}))
+
+describe('GET /api/campos', () => {
+  it('retorna 401 quando nao autenticado', async () => {
+    const req = new Request('http://test')
+    const res = await GET(req as unknown as NextRequest)
+    expect(res.status).toBe(401)
+  })
+})

--- a/__tests__/api/checkoutLinkRoute.test.ts
+++ b/__tests__/api/checkoutLinkRoute.test.ts
@@ -1,0 +1,12 @@
+import { describe, it, expect } from 'vitest'
+import { GET } from '../../app/api/checkout-link/route'
+
+describe('GET /api/checkout-link', () => {
+  it('retorna 500 quando variavel de ambiente ausente', async () => {
+    delete process.env.CAMISETA_CHECKOUT_URL
+    const res = await GET()
+    expect(res.status).toBe(500)
+    const body = await res.json()
+    expect(body.error).toBe('Checkout URL not configured')
+  })
+})

--- a/__tests__/api/produtosRoute.test.ts
+++ b/__tests__/api/produtosRoute.test.ts
@@ -1,0 +1,26 @@
+import { describe, it, expect, vi } from 'vitest'
+import { GET } from '../../app/api/produtos/route'
+import { NextRequest } from 'next/server'
+
+vi.mock('../../lib/pocketbase', () => ({
+  default: vi.fn(() => ({
+    collection: () => ({
+      getFullList: vi.fn().mockRejectedValue(new Error('fail'))
+    })
+  }))
+}))
+
+vi.mock('../../lib/products', () => ({
+  filtrarProdutos: vi.fn((p) => p)
+}))
+
+describe('GET /api/produtos', () => {
+  it('retorna 500 quando pocketbase falha', async () => {
+    const req = new Request('http://test')
+    ;(req as any).nextUrl = new URL('http://test')
+    const res = await GET(req as unknown as NextRequest)
+    expect(res.status).toBe(500)
+    const body = await res.json()
+    expect(body).toEqual([])
+  })
+})

--- a/__tests__/api/registerRoute.test.ts
+++ b/__tests__/api/registerRoute.test.ts
@@ -1,0 +1,22 @@
+import { describe, it, expect, vi } from 'vitest'
+import { POST } from '../../app/api/register/route'
+import { NextRequest } from 'next/server'
+
+const getOneMock = vi.fn().mockRejectedValue(new Error('not found'))
+const createMock = vi.fn()
+
+vi.mock('../../lib/pocketbase', () => ({
+  default: vi.fn(() => ({
+    collection: () => ({ getOne: getOneMock, create: createMock })
+  }))
+}))
+
+describe('POST /api/register', () => {
+  it('retorna 404 se cliente nao encontrado', async () => {
+    const req = new Request('http://test', { method: 'POST', body: JSON.stringify({ nome:'n', email:'e', telefone:'t', password:'p', cliente:'1' }) })
+    const res = await POST(req as unknown as NextRequest)
+    expect(res.status).toBe(404)
+    const body = await res.json()
+    expect(body.error).toBe('Cliente não encontrado')
+  })
+})


### PR DESCRIPTION
## Summary
- add sample tests covering some public and admin API routes
- check error handling using mocked PocketBase

## Testing
- `npm run lint`
- `npm exec vitest run`
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_684ac87d051c832ca33cd8d7529d840f