### PR TITLE
Add getUserFromHeaders tests

### DIFF
--- a/__tests__/getUserFromHeaders.test.ts
+++ b/__tests__/getUserFromHeaders.test.ts
@@ -1,0 +1,49 @@
+import { describe, it, expect, vi, afterEach } from 'vitest'
+import { NextRequest } from 'next/server'
+
+vi.mock('../lib/pocketbase', () => {
+  const pbMock = {
+    authStore: { save: vi.fn() },
+    autoCancellation: vi.fn(),
+  }
+  return { __esModule: true, default: vi.fn(() => pbMock) }
+})
+
+import { getUserFromHeaders } from '../lib/getUserFromHeaders'
+import createPocketBase from '../lib/pocketbase'
+
+describe('getUserFromHeaders', () => {
+  afterEach(() => {
+    vi.restoreAllMocks()
+  })
+
+  it('retorna erro quando cabeçalhos faltam', () => {
+    const req = new Request('http://test')
+    const result = getUserFromHeaders(req as unknown as NextRequest)
+    expect(result).toEqual({ error: 'Token ou usuário ausente.' })
+  })
+
+  it('retorna erro quando usuário é inválido', () => {
+    const headers = new Headers({
+      Authorization: 'Bearer token',
+      'X-PB-User': 'invalid-json',
+    })
+    const req = new Request('http://test', { headers })
+    const result = getUserFromHeaders(req as unknown as NextRequest)
+    expect(result).toEqual({ error: 'Usuário inválido.' })
+  })
+
+  it('retorna usuário e pocketbase quando sucesso', () => {
+    const user = { id: '1', role: 'admin' }
+    const headers = new Headers({
+      Authorization: 'Bearer token123',
+      'X-PB-User': JSON.stringify(user),
+    })
+    const req = new Request('http://test', { headers })
+    const result = getUserFromHeaders(req as unknown as NextRequest)
+    const pb = (createPocketBase as unknown as vi.Mock).mock.results[0].value
+    expect(result).toEqual({ user, pbSafe: pb })
+    expect(pb.authStore.save).toHaveBeenCalledWith('token123', user)
+    expect(pb.autoCancellation).toHaveBeenCalledWith(false)
+  })
+})


### PR DESCRIPTION
## Summary
- add unit tests for `getUserFromHeaders`

## Testing
- `npm run lint`
- `npm run test -- --run`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_684ac844b930832cb617fc3519371616