### PR TITLE
Add formatDate tests

### DIFF
--- a/__tests__/formatDate.test.ts
+++ b/__tests__/formatDate.test.ts
@@ -1,0 +1,14 @@
+import { describe, it, expect } from 'vitest'
+import { formatDate } from '../utils/formatDate'
+
+describe('formatDate', () => {
+  it('retorna a data formatada quando valor é válido', () => {
+    const formatted = formatDate(new Date('2024-01-01'))
+    expect(formatted).toBe('01/01/2024')
+  })
+
+  it('retorna string vazia quando valor é inválido', () => {
+    const formatted = formatDate('invalid-date')
+    expect(formatted).toBe('')
+  })
+})


### PR DESCRIPTION
## Summary
- add unit tests for `formatDate` util

## Testing
- `npm run lint`
- `npm run test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_684ac830a30c832c94e12b186d3b362e