### PR TITLE
Adicionar NEXT_PUBLIC_TENANT_ID ao exemplo e lidar com tenant ausente

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,5 +1,6 @@
 
 NEXT_PUBLIC_PB_URL=
+NEXT_PUBLIC_TENANT_ID=
 PB_ADMIN_EMAIL=
 PB_ADMIN_PASSWORD=
 # Opcional. O backend procura primeiro `asaas_api_key` em `m24_clientes`.

--- a/README.md
+++ b/README.md
@@ -80,12 +80,16 @@ Esses documentos também trazem exemplos das classes globais `btn` e
 Crie um arquivo `.env.local` na raiz e defina as seguintes variáveis:
 
 - `NEXT_PUBLIC_PB_URL` - URL do PocketBase
+- `NEXT_PUBLIC_TENANT_ID` - ID do cliente (tenant) usado para filtrar produtos na loja
 - `PB_ADMIN_EMAIL` - e-mail do administrador do PocketBase
 - `PB_ADMIN_PASSWORD` - senha do administrador
 - `ASAAS_API_KEY` - (opcional) chave padrão da API do Asaas
 - `ASAAS_WEBHOOK_SECRET` - segredo para validar webhooks do Asaas
 - `ASAAS_API_URL` - URL base da API do Asaas (ex.: `https://api-sandbox.asaas.com/api/v3/`)
 - `NEXT_PUBLIC_SITE_URL` - endereço do site (opcional)
+
+`NEXT_PUBLIC_TENANT_ID` define qual cliente (tenant) deve ter seus produtos
+listados na loja. Se não for informado, todos os produtos serão exibidos.
 
 Cada registro em `m24_clientes` contém o campo `asaas_api_key`. A aplicação busca a chave correta deste cliente antes de criar cobranças ou checkouts, garantindo que cada subconta do Asaas seja utilizada separadamente.
 

--- a/app/loja/produtos/page.tsx
+++ b/app/loja/produtos/page.tsx
@@ -14,8 +14,12 @@ interface Produto {
 export default async function ProdutosPage() {
   const pb = createPocketBase();
   const tenantId = process.env.NEXT_PUBLIC_TENANT_ID;
+  const baseFilter = tenantId
+    ? `ativo = true && cliente='${tenantId}'`
+    : "ativo = true";
+
   const list = await pb.collection("produtos").getList<Produto>(1, 50, {
-    filter: `ativo = true && cliente='${tenantId}'`,
+    filter: baseFilter,
     sort: "-created",
   });
   const produtosPB: Produto[] = list.items;
@@ -28,6 +32,11 @@ export default async function ProdutosPage() {
   return (
     <main className="max-w-7xl mx-auto px-2 md:px-6 py-8 font-sans text-[var(--text-primary)]">
       <h1 className="text-2xl md:text-3xl font-bold mb-8">Produtos</h1>
+      {!tenantId && (
+        <p className="mb-4 text-sm">
+          Variável NEXT_PUBLIC_TENANT_ID não definida. Exibindo todos os produtos.
+        </p>
+      )}
       <ProdutosFiltrados produtos={produtos} />
     </main>
   );

--- a/logs/DOC_LOG.md
+++ b/logs/DOC_LOG.md
@@ -88,3 +88,4 @@
 
 ## [2025-06-12] Adicionadas propriedades tipo_dominio, verificado e modo_validacao ao tipo Cliente.
 ## [2025-06-12] Adicionada tabela de campos em docs/plano-negocio.md incluindo tipo_dominio, verificado e modo_validacao
+## [2025-06-12] Adicionada variavel NEXT_PUBLIC_TENANT_ID em .env.example e explicacao no README


### PR DESCRIPTION
## Summary
- acrescentar `NEXT_PUBLIC_TENANT_ID` no `.env.example`
- documentar variável no README com orientação de uso
- tratar ausência do tenant em `app/loja/produtos/page.tsx`
- registrar alteração no `DOC_LOG.md`

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_684ad49b388c832c8eb663fcb890d0d6