### PR TITLE
Implement tenant resolution by host

### DIFF
--- a/app/api/campos/route.ts
+++ b/app/api/campos/route.ts
@@ -1,6 +1,7 @@
 import { NextRequest, NextResponse } from "next/server";
 import { getUserFromHeaders } from "@/lib/getUserFromHeaders";
 import { logInfo } from "@/lib/logger";
+import { getTenantFromHost } from "@/lib/getTenantFromHost";
 
 export async function GET(req: NextRequest) {
   const auth = await getUserFromHeaders(req);
@@ -13,7 +14,7 @@ export async function GET(req: NextRequest) {
 
   const tenantId =
     (user && (user as { cliente?: string }).cliente) ||
-    process.env.NEXT_PUBLIC_TENANT_ID;
+    (await getTenantFromHost());
 
   if (user.role !== "coordenador") {
     return NextResponse.json({ error: "Acesso negado" }, { status: 403 });
@@ -55,7 +56,7 @@ export async function POST(req: NextRequest) {
 
   const tenantId =
     (user && (user as { cliente?: string }).cliente) ||
-    process.env.NEXT_PUBLIC_TENANT_ID;
+    (await getTenantFromHost());
 
   try {
     const { nome } = await req.json();

--- a/app/api/produtos/route.ts
+++ b/app/api/produtos/route.ts
@@ -1,12 +1,13 @@
 import { NextRequest, NextResponse } from "next/server";
 import createPocketBase from "@/lib/pocketbase";
 import { filtrarProdutos, ProdutoRecord } from "@/lib/products";
+import { getTenantFromHost } from "@/lib/getTenantFromHost";
 
 export async function GET(req: NextRequest) {
 
   const pb = createPocketBase();
   const categoria = req.nextUrl.searchParams.get("categoria") || undefined;
-  const tenantId = process.env.NEXT_PUBLIC_TENANT_ID;
+  const tenantId = await getTenantFromHost();
 
   try {
     const baseFilter = tenantId ? `ativo = true && cliente='${tenantId}'` : "ativo = true";

--- a/app/loja/categorias/[slug]/page.tsx
+++ b/app/loja/categorias/[slug]/page.tsx
@@ -1,6 +1,7 @@
 // app/loja/categorias/[slug]/page.tsx
 import createPocketBase from "@/lib/pocketbase";
 import ProdutosFiltrados from "./ProdutosFiltrados";
+import { getTenantFromHost } from "@/lib/getTenantFromHost";
 
 interface Produto {
   id: string;
@@ -22,7 +23,7 @@ export default async function CategoriaDetalhe({
 }) {
   const { slug } = await params;
   const pb = createPocketBase();
-  const tenantId = process.env.NEXT_PUBLIC_TENANT_ID;
+  const tenantId = await getTenantFromHost();
 
   const produtosPB: Produto[] = await pb.collection("produtos").getFullList({
     filter: `ativo = true && categoria = '${slug}' && cliente='${tenantId}'`,

--- a/app/loja/categorias/page.tsx
+++ b/app/loja/categorias/page.tsx
@@ -1,4 +1,5 @@
 import createPocketBase from "@/lib/pocketbase";
+import { getTenantFromHost } from "@/lib/getTenantFromHost";
 
 export const dynamic = "force-dynamic";
 
@@ -10,7 +11,7 @@ interface Categoria {
 
 export default async function CategoriasPage() {
   const pb = createPocketBase();
-  const tenantId = process.env.NEXT_PUBLIC_TENANT_ID;
+  const tenantId = await getTenantFromHost();
   const categorias: Categoria[] = await pb
     .collection("categorias")
     .getFullList({ sort: "nome", filter: `cliente='${tenantId}'` });

--- a/app/loja/produtos/page.tsx
+++ b/app/loja/produtos/page.tsx
@@ -1,5 +1,6 @@
 import createPocketBase from "@/lib/pocketbase";
 import ProdutosFiltrados from "./ProdutosFiltrados";
+import { getTenantFromHost } from "@/lib/getTenantFromHost";
 
 export const dynamic = "force-dynamic";
 
@@ -13,7 +14,7 @@ interface Produto {
 
 export default async function ProdutosPage() {
   const pb = createPocketBase();
-  const tenantId = process.env.NEXT_PUBLIC_TENANT_ID;
+  const tenantId = await getTenantFromHost();
   const list = await pb.collection("produtos").getList<Produto>(1, 50, {
     filter: `ativo = true && cliente='${tenantId}'`,
     sort: "-created",

--- a/lib/getTenantFromHost.ts
+++ b/lib/getTenantFromHost.ts
@@ -1,0 +1,17 @@
+import { headers } from "next/headers";
+import createPocketBase from "@/lib/pocketbase";
+
+export async function getTenantFromHost(): Promise<string | null> {
+  const host = (await headers()).get("host")?.split(":")[0] ?? "";
+  if (!host) return null;
+
+  const pb = createPocketBase();
+  try {
+    const cliente = await pb
+      .collection("m24_clientes")
+      .getFirstListItem(`dominio='${host}'`);
+    return cliente?.id ?? null;
+  } catch {
+    return null;
+  }
+}

--- a/logs/DOC_LOG.md
+++ b/logs/DOC_LOG.md
@@ -88,3 +88,5 @@
 
 ## [2025-06-12] Adicionadas propriedades tipo_dominio, verificado e modo_validacao ao tipo Cliente.
 ## [2025-06-12] Adicionada tabela de campos em docs/plano-negocio.md incluindo tipo_dominio, verificado e modo_validacao
+
+## [2025-06-12] Removida variavel NEXT_PUBLIC_TENANT_ID e implementada logica para obter tenant pelo host.


### PR DESCRIPTION
## Summary
- add util `getTenantFromHost` to look up the tenant by request host
- use new util in product and category pages and related API routes
- record removal of `NEXT_PUBLIC_TENANT_ID` env var in DOC_LOG

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_684ae5899744832c98ee126c202ea184