### PR TITLE
Update docs for tenant resolution

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,6 +87,8 @@ Crie um arquivo `.env.local` na raiz e defina as seguintes variáveis:
 - `ASAAS_API_URL` - URL base da API do Asaas (ex.: `https://api-sandbox.asaas.com/api/v3/`)
 - `NEXT_PUBLIC_SITE_URL` - endereço do site (opcional)
 
+Os servidores identificam automaticamente o tenant pelo domínio de cada requisição usando `getTenantFromHost`. A variável `NEXT_PUBLIC_TENANT_ID` foi removida.
+
 Cada registro em `m24_clientes` contém o campo `asaas_api_key`. A aplicação busca a chave correta deste cliente antes de criar cobranças ou checkouts, garantindo que cada subconta do Asaas seja utilizada separadamente.
 
 Esta integração realiza chamadas HTTP diretamente na API do Asaas, sem utilizar o SDK oficial.

--- a/docs/plano-negocio.md
+++ b/docs/plano-negocio.md
@@ -46,6 +46,8 @@ Implementamos a base multi-tenant do sistema no banco usando PocketBase, já pre
 
 - O escopo do usuário (coordenador, lider, usuario) deve ser respeitado dentro do tenant.
 
+As rotas de servidor (`/api`) chamam `getTenantFromHost` para identificar o cliente pelo domínio da requisição, garantindo o isolamento automático entre tenants.
+
 ## Benefícios
 
 - Estrutura pronta para SaaS: escalável, segura, pronta para deploy em nuvem.

--- a/logs/DOC_LOG.md
+++ b/logs/DOC_LOG.md
@@ -90,3 +90,5 @@
 ## [2025-06-12] Adicionada tabela de campos em docs/plano-negocio.md incluindo tipo_dominio, verificado e modo_validacao
 
 ## [2025-06-12] Removida variavel NEXT_PUBLIC_TENANT_ID e implementada logica para obter tenant pelo host.
+
+## [2025-06-12] Atualizados README e plano-negocio sobre getTenantFromHost e remoção do NEXT_PUBLIC_TENANT_ID.


### PR DESCRIPTION
## Summary
- document automatic tenant resolution by domain in README
- clarify server routes use `getTenantFromHost` in business plan
- log documentation updates

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_684ae9910168832cb6be91bf154e6362