### PR TITLE
Implement CEP autofill for signup

### DIFF
--- a/app/components/SignUpForm.tsx
+++ b/app/components/SignUpForm.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState } from "react";
+import { useState, useEffect } from "react";
 import { useAuthContext } from "@/lib/context/AuthContext";
 
 export default function SignUpForm({
@@ -24,6 +24,24 @@ export default function SignUpForm({
   const [senhaConfirm, setSenhaConfirm] = useState("");
   const [erro, setErro] = useState("");
   const [loading, setLoading] = useState(false);
+
+  useEffect(() => {
+    async function fetchEndereco() {
+      const cleanCep = cep.replace(/\D/g, "");
+      if (cleanCep.length !== 8) return;
+      try {
+        const res = await fetch(`https://viacep.com.br/ws/${cleanCep}/json/`);
+        const data = await res.json();
+        if (data.erro) return;
+        setEndereco(data.logradouro || "");
+        setCidade(data.localidade || "");
+        setEstado(data.uf || "");
+      } catch {
+        /* ignore */
+      }
+    }
+    fetchEndereco();
+  }, [cep]);
 
   async function handleSubmit(e: React.FormEvent) {
     e.preventDefault();

--- a/lib/getTenantFromHost.ts
+++ b/lib/getTenantFromHost.ts
@@ -2,7 +2,8 @@ import { headers } from "next/headers";
 import createPocketBase from "@/lib/pocketbase";
 
 export async function getTenantFromHost(): Promise<string | null> {
-  const host = headers().get("host")?.split(":")[0] ?? "";
+  const headersList = await headers();
+  const host = headersList.get("host")?.split(":")[0] ?? "";
   if (!host) return null;
 
   const pb = createPocketBase();


### PR DESCRIPTION
## Summary
- allow looking up CEP on signup form to fill address fields
- fix header retrieval on tenant identification

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_684aebd4d954832c98bd16a604bad4ce