### PR TITLE
Remove redundant setters in checkout

### DIFF
--- a/app/loja/checkout/page.tsx
+++ b/app/loja/checkout/page.tsx
@@ -46,11 +46,6 @@ function CheckoutContent() {
       setCep(String(user.cep ?? ""));
       setCidade(String(user.cidade ?? ""));
       setCpf(String(user.cpf ?? ""));
-      setCpf(String(user.cpf ?? ""));
-      setNumero(String(user.numero ?? ""));
-      setEstado(String(user.estado ?? ""));
-      setCep(String(user.cep ?? ""));
-      setCidade(String(user.cidade ?? ""));
       setDataNascimento(String((user as UsuarioExtra).data_nascimento ?? ""));
     }
   }, [user]);


### PR DESCRIPTION
## Summary
- cleanup repeated `set` calls in checkout page

## Testing
- `npm run lint`
- `npm run build` *(fails: Expected 10 arguments in SignUpForm.tsx)*

------
https://chatgpt.com/codex/tasks/task_e_684af0658fac832c8e559e12a55beac9