### PR TITLE
Improve CEP lookup error handling

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -7,3 +7,4 @@ ASAAS_API_KEY=
 ASAAS_WEBHOOK_SECRET=
 NEXT_PUBLIC_SITE_URL=
 ASAAS_API_URL=https://sandbox.asaas.com/api/v3/
+NEXT_PUBLIC_VIA_CEP_URL=https://viacep.com.br/ws


### PR DESCRIPTION
## Summary
- check response status before reading CEP data
- clear address fields when the lookup fails
- expose VIA CEP API URL in `.env.example`

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_684af0a65628832c8deecf7a4042d872