### PR TITLE
Create finance page

### DIFF
--- a/app/admin/financeiro/page.tsx
+++ b/app/admin/financeiro/page.tsx
@@ -1,0 +1,76 @@
+"use client";
+
+import { useAuthContext } from "@/lib/context/AuthContext";
+import { useEffect, useState } from "react";
+import { useRouter } from "next/navigation";
+
+interface Saldo {
+  disponivel: number;
+  aLiberar: number;
+  totalRecebido: number;
+}
+
+export default function FinanceiroPage() {
+  const { tenantId, isLoggedIn } = useAuthContext();
+  const router = useRouter();
+  const [saldo, setSaldo] = useState<Saldo | null>(null);
+  const [loading, setLoading] = useState(false);
+
+  useEffect(() => {
+    if (!isLoggedIn) {
+      router.replace("/login");
+      return;
+    }
+    if (!tenantId) return;
+    const fetchSaldo = async () => {
+      try {
+        setLoading(true);
+        const res = await fetch(`/admin/api/financeiro/saldo?tenantId=${tenantId}`);
+        if (res.ok) {
+          const data = await res.json();
+          setSaldo(data);
+        }
+      } catch (err) {
+        console.error("Erro ao obter saldo:", err);
+      } finally {
+        setLoading(false);
+      }
+    };
+    fetchSaldo();
+  }, [tenantId, isLoggedIn, router]);
+
+  return (
+    <main className="max-w-4xl mx-auto px-4 py-8">
+      <h2 className="heading mb-6">Financeiro</h2>
+      {loading ? (
+        <p className="text-center">Carregando...</p>
+      ) : (
+        <>
+          <div className="grid gap-6 md:grid-cols-3 mb-8">
+            <div className="card p-6 text-center">
+              <h3 className="text-lg font-semibold mb-2">Saldo Disponível</h3>
+              <p className="text-xl font-bold">
+                {saldo ? `R$ ${saldo.disponivel.toFixed(2)}` : "—"}
+              </p>
+            </div>
+            <div className="card p-6 text-center">
+              <h3 className="text-lg font-semibold mb-2">A Liberar</h3>
+              <p className="text-xl font-bold">
+                {saldo ? `R$ ${saldo.aLiberar.toFixed(2)}` : "—"}
+              </p>
+            </div>
+            <div className="card p-6 text-center">
+              <h3 className="text-lg font-semibold mb-2">Total Recebido</h3>
+              <p className="text-xl font-bold">
+                {saldo ? `R$ ${saldo.totalRecebido.toFixed(2)}` : "—"}
+              </p>
+            </div>
+          </div>
+          <div className="flex justify-end">
+            <button className="btn btn-primary">Transferir Saldo</button>
+          </div>
+        </>
+      )}
+    </main>
+  );
+}


### PR DESCRIPTION
## Summary
- add Admin Financeiro page with saldo cards

## Testing
- `npm run lint` *(fails: next not found)*
- `npm run build` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_684c6025548c832ca332942d703239ef