### PR TITLE
Add Asaas balance and transfer API routes

### DIFF
--- a/app/admin/api/asaas/saldo/route.ts
+++ b/app/admin/api/asaas/saldo/route.ts
@@ -1,0 +1,70 @@
+import { NextRequest, NextResponse } from "next/server";
+import { requireRole } from "@/lib/apiAuth";
+
+export async function GET(req: NextRequest) {
+  const auth = requireRole(req, "coordenador");
+  if ("error" in auth) {
+    return NextResponse.json({ error: auth.error }, { status: auth.status });
+  }
+
+  const { pb } = auth;
+  const baseUrl = process.env.ASAAS_API_URL;
+  let apiKey = process.env.ASAAS_API_KEY || "";
+
+  try {
+    const host = req.headers.get("host")?.split(":" )[0] ?? "";
+    if (!pb.authStore.isValid) {
+      await pb.admins.authWithPassword(
+        process.env.PB_ADMIN_EMAIL!,
+        process.env.PB_ADMIN_PASSWORD!
+      );
+    }
+    if (host) {
+      const clienteRecord = await pb
+        .collection("m24_clientes")
+        .getFirstListItem(`dominio = "${host}"`);
+      if (clienteRecord?.asaas_api_key) {
+        apiKey = clienteRecord.asaas_api_key;
+      }
+    }
+  } catch {
+    /* ignore */
+  }
+
+  if (!baseUrl || !apiKey) {
+    return NextResponse.json(
+      { error: "Asaas não configurado" },
+      { status: 500 }
+    );
+  }
+
+  const keyHeader = apiKey.startsWith("$") ? apiKey : `$${apiKey}`;
+
+  try {
+    const res = await fetch(`${baseUrl}/account/balance`, {
+      headers: {
+        accept: "application/json",
+        "access-token": keyHeader,
+        "User-Agent": "qg3",
+      },
+    });
+
+    if (!res.ok) {
+      const errorBody = await res.text();
+      console.error("Erro ao consultar saldo Asaas:", errorBody);
+      return NextResponse.json(
+        { error: "Falha ao consultar saldo" },
+        { status: 500 }
+      );
+    }
+
+    const data = await res.json();
+    return NextResponse.json(data);
+  } catch (err) {
+    console.error("Erro inesperado ao consultar saldo:", err);
+    return NextResponse.json(
+      { error: "Erro ao consultar saldo" },
+      { status: 500 }
+    );
+  }
+}

--- a/app/admin/api/asaas/transferencia/route.ts
+++ b/app/admin/api/asaas/transferencia/route.ts
@@ -1,0 +1,130 @@
+import { NextRequest, NextResponse } from "next/server";
+import { requireRole } from "@/lib/apiAuth";
+import createPocketBase from "@/lib/pocketbase";
+
+async function getApiKey(req: NextRequest, pb: ReturnType<typeof createPocketBase>) {
+  let apiKey = process.env.ASAAS_API_KEY || "";
+  try {
+    const host = req.headers.get("host")?.split(":" )[0] ?? "";
+    if (!pb.authStore.isValid) {
+      await pb.admins.authWithPassword(
+        process.env.PB_ADMIN_EMAIL!,
+        process.env.PB_ADMIN_PASSWORD!
+      );
+    }
+    if (host) {
+      const clienteRecord = await pb
+        .collection("m24_clientes")
+        .getFirstListItem(`dominio = "${host}"`);
+      if (clienteRecord?.asaas_api_key) {
+        apiKey = clienteRecord.asaas_api_key;
+      }
+    }
+  } catch {
+    /* ignore */
+  }
+  return apiKey;
+}
+
+export async function POST(req: NextRequest) {
+  const auth = requireRole(req, "coordenador");
+  if ("error" in auth) {
+    return NextResponse.json({ error: auth.error }, { status: auth.status });
+  }
+  const { pb } = auth;
+  const baseUrl = process.env.ASAAS_API_URL;
+  const apiKey = await getApiKey(req, pb);
+
+  if (!baseUrl || !apiKey) {
+    return NextResponse.json(
+      { error: "Asaas não configurado" },
+      { status: 500 }
+    );
+  }
+
+  const keyHeader = apiKey.startsWith("$") ? apiKey : `$${apiKey}`;
+
+  try {
+    const body = await req.json();
+    const res = await fetch(`${baseUrl}/transfers`, {
+      method: "POST",
+      headers: {
+        accept: "application/json",
+        "Content-Type": "application/json",
+        "access-token": keyHeader,
+        "User-Agent": "qg3",
+      },
+      body: JSON.stringify(body),
+    });
+
+    if (!res.ok) {
+      const errorBody = await res.text();
+      console.error("Erro ao criar transferência:", errorBody);
+      return NextResponse.json(
+        { error: "Falha ao criar transferência" },
+        { status: 500 }
+      );
+    }
+
+    const data = await res.json();
+    return NextResponse.json(data, { status: 201 });
+  } catch (err) {
+    console.error("Erro inesperado ao criar transferência:", err);
+    return NextResponse.json(
+      { error: "Erro ao criar transferência" },
+      { status: 500 }
+    );
+  }
+}
+
+export async function DELETE(req: NextRequest) {
+  const auth = requireRole(req, "coordenador");
+  if ("error" in auth) {
+    return NextResponse.json({ error: auth.error }, { status: auth.status });
+  }
+  const { pb } = auth;
+  const baseUrl = process.env.ASAAS_API_URL;
+  const apiKey = await getApiKey(req, pb);
+
+  if (!baseUrl || !apiKey) {
+    return NextResponse.json(
+      { error: "Asaas não configurado" },
+      { status: 500 }
+    );
+  }
+
+  const id = req.nextUrl.searchParams.get("id");
+  if (!id) {
+    return NextResponse.json({ error: "Id obrigatório" }, { status: 400 });
+  }
+
+  const keyHeader = apiKey.startsWith("$") ? apiKey : `$${apiKey}`;
+
+  try {
+    const res = await fetch(`${baseUrl}/transfers/${id}`, {
+      method: "DELETE",
+      headers: {
+        accept: "application/json",
+        "access-token": keyHeader,
+        "User-Agent": "qg3",
+      },
+    });
+
+    if (!res.ok) {
+      const errorBody = await res.text();
+      console.error("Erro ao cancelar transferência:", errorBody);
+      return NextResponse.json(
+        { error: "Falha ao cancelar transferência" },
+        { status: 500 }
+      );
+    }
+
+    return NextResponse.json({ status: "cancelado" });
+  } catch (err) {
+    console.error("Erro inesperado ao cancelar transferência:", err);
+    return NextResponse.json(
+      { error: "Erro ao cancelar transferência" },
+      { status: 500 }
+    );
+  }
+}

--- a/logs/ERR_LOG.md
+++ b/logs/ERR_LOG.md
@@ -54,3 +54,4 @@
 ## [2025-06-12] Ajustado tipo Produto em loja/produtos/[slug] para compatibilidade com types - dev - 707ff02
 ## [2025-06-12] Corrigido erro de build em login por falta de Suspense - dev - 823ad2b
 ## [2025-06-12] Ajustado carregamento de gêneros e imagens no detalhe do produto - dev - 6fd0697
+## [2025-06-13] Implementadas rotas de saldo e transferência Asaas com verificação de permissão - dev - 7c89834


### PR DESCRIPTION
## Summary
- add Asaas balance route to query `/v3/account/balance`
- add transfer route with create and cancel endpoints
- log missing permissions fix
- remove unused import

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_684c6026dd20832cbce97dbbe6fd4774