### PR TITLE
Add finance components with stories

### DIFF
--- a/components/SaldoCard.tsx
+++ b/components/SaldoCard.tsx
@@ -1,0 +1,23 @@
+"use client";
+
+interface SaldoCardProps {
+  saldo: number;
+  className?: string;
+}
+
+function cn(...classes: Array<string | undefined>) {
+  return classes.filter(Boolean).join(" ");
+}
+
+export default function SaldoCard({ saldo, className }: SaldoCardProps) {
+  return (
+    <div className={cn("card text-center", className)}>
+      <h3 className="text-sm font-semibold text-neutral-500 dark:text-neutral-300">
+        Saldo Disponível
+      </h3>
+      <p className="text-3xl font-bold text-neutral-800 dark:text-neutral-100">
+        R$ {saldo.toFixed(2)}
+      </p>
+    </div>
+  );
+}

--- a/components/TransferenciaForm.tsx
+++ b/components/TransferenciaForm.tsx
@@ -1,0 +1,57 @@
+"use client";
+
+import { useState } from "react";
+
+interface TransferenciaFormProps {
+  onTransfer?: (destino: string, valor: number) => Promise<void> | void;
+}
+
+export default function TransferenciaForm({
+  onTransfer,
+}: TransferenciaFormProps) {
+  const [destino, setDestino] = useState("");
+  const [valor, setValor] = useState("");
+  const [erro, setErro] = useState("");
+  const [loading, setLoading] = useState(false);
+
+  async function handleSubmit(e: React.FormEvent) {
+    e.preventDefault();
+    setErro("");
+    const parsed = Number(valor);
+    if (!destino || isNaN(parsed) || parsed <= 0) {
+      setErro("Dados inv\u00e1lidos.");
+      return;
+    }
+    setLoading(true);
+    try {
+      await onTransfer?.(destino, parsed);
+    } catch {
+      setErro("Erro ao transferir.");
+    } finally {
+      setLoading(false);
+    }
+  }
+
+  return (
+    <form onSubmit={handleSubmit} className="space-y-4 max-w-sm">
+      {erro && <p className="text-sm text-error-600">{erro}</p>}
+      <input
+        type="text"
+        className="input-base"
+        placeholder="Destinat\u00e1rio"
+        value={destino}
+        onChange={(e) => setDestino(e.target.value)}
+      />
+      <input
+        type="number"
+        className="input-base"
+        placeholder="Valor (R$)"
+        value={valor}
+        onChange={(e) => setValor(e.target.value)}
+      />
+      <button type="submit" className="btn btn-primary" disabled={loading}>
+        {loading ? "Enviando..." : "Transferir"}
+      </button>
+    </form>
+  );
+}

--- a/stories/SaldoCard.stories.tsx
+++ b/stories/SaldoCard.stories.tsx
@@ -1,0 +1,18 @@
+import type { Meta, StoryObj } from '@storybook/nextjs';
+import SaldoCard from '../components/SaldoCard';
+
+const meta = {
+  title: 'Design System/SaldoCard',
+  component: SaldoCard,
+  tags: ['autodocs'],
+  args: { saldo: 1200.5 },
+} satisfies Meta<typeof SaldoCard>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const ComSaldo: Story = {};
+
+export const SemSaldo: Story = {
+  args: { saldo: 0 },
+};

--- a/stories/TransferenciaForm.stories.tsx
+++ b/stories/TransferenciaForm.stories.tsx
@@ -1,0 +1,36 @@
+import type { Meta, StoryObj } from '@storybook/nextjs';
+import { within, userEvent, expect } from 'storybook/test';
+import TransferenciaForm from '../components/TransferenciaForm';
+
+const meta = {
+  title: 'Design System/TransferenciaForm',
+  component: TransferenciaForm,
+  tags: ['autodocs'],
+  argTypes: {
+    onTransfer: { action: 'onTransfer' },
+  },
+} satisfies Meta<typeof TransferenciaForm>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Sucesso: Story = {
+  args: {
+    onTransfer: async () => {},
+  },
+};
+
+export const ErroTransferencia: Story = {
+  args: {
+    onTransfer: async () => {
+      throw new Error('fail');
+    },
+  },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    await userEvent.type(canvas.getByPlaceholderText(/destinat\u00e1rio/i), 'user');
+    await userEvent.type(canvas.getByPlaceholderText(/valor/i), '10');
+    await userEvent.click(canvas.getByRole('button', { name: /transferir/i }));
+    await expect(canvas.getByText(/erro ao transferir/i)).toBeInTheDocument();
+  },
+};


### PR DESCRIPTION
## Summary
- add `SaldoCard` component
- add `TransferenciaForm` component
- document components in Storybook

## Testing
- `npm run lint`
- `npm run build`
- `npm test` *(fails: 1 failed, 25 passed)*

------
https://chatgpt.com/codex/tasks/task_e_684c60385d64832c8092dc88bb7257c1