### PR TITLE
Adicionar controle financeiro no dashboard

### DIFF
--- a/app/admin/components/DashboardAnalytics.tsx
+++ b/app/admin/components/DashboardAnalytics.tsx
@@ -18,6 +18,7 @@ const BarChart = dynamic(() => import("react-chartjs-2").then((m) => m.Bar), {
 interface DashboardAnalyticsProps {
   inscricoes: Inscricao[];
   pedidos: Pedido[];
+  mostrarFinanceiro?: boolean;
 }
 
 function groupByDate(
@@ -41,7 +42,11 @@ function groupByDate(
   return { labels: dates, data: dates.map((d) => counts[d]) };
 }
 
-export default function DashboardAnalytics({ inscricoes, pedidos }: DashboardAnalyticsProps) {
+export default function DashboardAnalytics({
+  inscricoes,
+  pedidos,
+  mostrarFinanceiro = true,
+}: DashboardAnalyticsProps) {
   const [startDate, setStartDate] = useState<string>("");
   const [endDate, setEndDate] = useState<string>("");
 
@@ -144,7 +149,9 @@ export default function DashboardAnalytics({ inscricoes, pedidos }: DashboardAna
 
   return (
     <div className="card mb-8">
-      <h3 className="text-lg font-semibold mb-4 dark:text-gray-100">Análises Temporais e Financeiras</h3>
+      <h3 className="text-lg font-semibold mb-4 dark:text-gray-100">
+        Análises Temporais{mostrarFinanceiro ? ' e Financeiras' : ''}
+      </h3>
       <div className="flex flex-wrap gap-4 items-center mb-6">
         <div className="flex items-center gap-2">
           <label className="text-sm dark:text-gray-100" htmlFor="inicio">Início:</label>
@@ -193,18 +200,20 @@ export default function DashboardAnalytics({ inscricoes, pedidos }: DashboardAna
           </div>
         </div>
       </div>
-      <div className="grid md:grid-cols-2 gap-6">
-        <div className="card p-4 flex flex-col justify-center items-center">
-          <p className="text-sm dark:text-gray-100">Média de Valor por Pedido</p>
-          <p className="text-2xl font-bold dark:text-gray-100">R$ {mediaValor.toFixed(2).replace(".", ",")}</p>
-        </div>
-        <div className="card p-4">
-          <h4 className="font-medium mb-2 dark:text-gray-100">Arrecadação por Campo</h4>
-          <div className="aspect-video">
-            <BarChart data={arrecadacaoChart} options={{ responsive: true, maintainAspectRatio: false }} />
+      {mostrarFinanceiro && (
+        <div className="grid md:grid-cols-2 gap-6">
+          <div className="card p-4 flex flex-col justify-center items-center">
+            <p className="text-sm dark:text-gray-100">Média de Valor por Pedido</p>
+            <p className="text-2xl font-bold dark:text-gray-100">R$ {mediaValor.toFixed(2).replace(".", ",")}</p>
+          </div>
+          <div className="card p-4">
+            <h4 className="font-medium mb-2 dark:text-gray-100">Arrecadação por Campo</h4>
+            <div className="aspect-video">
+              <BarChart data={arrecadacaoChart} options={{ responsive: true, maintainAspectRatio: false }} />
+            </div>
           </div>
         </div>
-      </div>
+      )}
     </div>
   );
 }

--- a/app/admin/lider-painel/page.tsx
+++ b/app/admin/lider-painel/page.tsx
@@ -159,14 +159,13 @@ export default function LiderDashboardPage() {
           <p>Cancelados: {totais.pedidos.cancelado}</p>
         </div>
 
-        <div className="card p-6 text-center">
-          <h3 className="text-lg font-semibold mb-2">Total Arrecadado</h3>
-          <p className="text-xl font-bold text-green-700">
-            R$ {totais.pedidos.valorTotal.toFixed(2).replace(".", ",")}
-          </p>
-        </div>
+        {/* Removido card de Total Arrecadado */}
       </div>
-      <DashboardAnalytics inscricoes={inscricoes} pedidos={pedidos} />
+      <DashboardAnalytics
+        inscricoes={inscricoes}
+        pedidos={pedidos}
+        mostrarFinanceiro={false}
+      />
       <div className="flex justify-center items-center gap-4 mt-4">
         <button
           className="btn btn-primary px-3 py-1"

--- a/logs/DOC_LOG.md
+++ b/logs/DOC_LOG.md
@@ -97,3 +97,4 @@
 ## [2025-06-14] Removidas entradas duplicadas de dependências e atualizado package-lock.json.
 ## [2025-06-14] Personalizacao salva em m24_clientes.cor_primaria
 ## [2025-06-13] Documentada persistência das configurações no design system.
+## [2025-06-13] DashboardAnalytics agora aceita mostrarFinanceiro para ocultar seções com valores

--- a/stories/DashboardAnalytics.stories.tsx
+++ b/stories/DashboardAnalytics.stories.tsx
@@ -17,6 +17,7 @@ const meta = {
   argTypes: {
     inscricoes: { control: 'object' },
     pedidos: { control: 'object' },
+    mostrarFinanceiro: { control: 'boolean' },
   },
   tags: ['autodocs'],
 } satisfies Meta<typeof DashboardAnalytics>;
@@ -56,9 +57,28 @@ export const Default: Story = {
         // Adicione outros campos obrigatórios do tipo Pedido aqui se necessário
       } as unknown as Pedido,
     ],
+    mostrarFinanceiro: true,
   },
   play: async ({ canvasElement }) => {
     const canvas = within(canvasElement);
     await expect(canvas.getByRole('button', { name: /exportar csv/i })).toBeInTheDocument();
+  },
+};
+
+export const SemFinanceiro: Story = {
+  args: {
+    inscricoes: [
+      { id: '1', created: '2024-01-01', nome: 'João', telefone: '11999999999' },
+    ],
+    pedidos: [
+      {
+        id: '1',
+        created: '2024-01-01',
+        valor: '100',
+        status: 'pago',
+        expand: { campo: { id: '1', nome: 'Campo 1' } },
+      } as unknown as Pedido,
+    ],
+    mostrarFinanceiro: false,
   },
 };


### PR DESCRIPTION
## Summary
- permitir esconder partes financeiras do `DashboardAnalytics`
- remover card de total arrecadado em `/admin/lider-painel`
- documentar novo comportamento no Storybook
- atualizar log de documentação

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_684c675d1fb4832c9ae6629be36ea7cd