### PR TITLE
Implement requireRole checks on Asaas routes

### DIFF
--- a/__tests__/admin/asaasCheckoutRoute.test.ts
+++ b/__tests__/admin/asaasCheckoutRoute.test.ts
@@ -1,0 +1,21 @@
+import { describe, it, expect, vi, afterEach } from 'vitest'
+import { POST } from '../../app/admin/api/asaas/checkout/route'
+import { NextRequest } from 'next/server'
+vi.mock('../../lib/apiAuth', () => ({ requireRole: vi.fn() }))
+import { requireRole } from '../../lib/apiAuth'
+
+describe('POST /admin/api/asaas/checkout', () => {
+  afterEach(() => {
+    vi.restoreAllMocks()
+  })
+
+  it('retorna 403 quando requireRole falha', async () => {
+    (requireRole as unknown as { mockReturnValue: (v: any) => void }).mockReturnValue({
+      error: 'Acesso negado',
+      status: 403
+    })
+    const req = new Request('http://test', { method: 'POST', body: '{}' })
+    const res = await POST(req as unknown as NextRequest)
+    expect(res.status).toBe(403)
+  })
+})

--- a/__tests__/admin/asaasRoute.test.ts
+++ b/__tests__/admin/asaasRoute.test.ts
@@ -1,7 +1,7 @@
-import { describe, it, expect, vi } from 'vitest'
+import { describe, it, expect, vi, afterEach } from 'vitest'
 import { POST } from '../../app/admin/api/asaas/route'
 import { NextRequest } from 'next/server'
-
+vi.mock('../../lib/apiAuth', () => ({ requireRole: vi.fn() }))
 vi.mock('../../lib/pocketbase', () => ({
   createPocketBase: () => ({
     authStore: { isValid: true },
@@ -9,9 +9,32 @@ vi.mock('../../lib/pocketbase', () => ({
     collection: () => ({ getFirstListItem: vi.fn() })
   })
 }))
+import { requireRole } from '../../lib/apiAuth'
 
 describe('POST /admin/api/asaas', () => {
+  afterEach(() => {
+    vi.restoreAllMocks()
+  })
+
+  it('retorna 403 quando requireRole falha', async () => {
+    (requireRole as unknown as { mockReturnValue: (v: any) => void }).mockReturnValue({
+      error: 'Acesso negado',
+      status: 403
+    })
+    const req = new Request('http://test', { method: 'POST', body: '{}' })
+    const res = await POST(req as unknown as NextRequest)
+    expect(res.status).toBe(403)
+  })
+
   it('lança erro quando ASAAS_API_KEY ausente', async () => {
+    (requireRole as unknown as { mockReturnValue: (v: any) => void }).mockReturnValue({
+      pb: {
+        authStore: { isValid: true },
+        admins: { authWithPassword: vi.fn() },
+        collection: () => ({ getFirstListItem: vi.fn() })
+      } as any,
+      user: { role: 'coordenador' }
+    })
     delete process.env.ASAAS_API_KEY
     const req = new Request('http://test', { method: 'POST', body: JSON.stringify({ pedidoId:'1', valor:1 }) })
     await expect(POST(req as unknown as NextRequest)).rejects.toThrow()

--- a/__tests__/api/produtosRoute.test.ts
+++ b/__tests__/api/produtosRoute.test.ts
@@ -13,6 +13,9 @@ vi.mock('../../lib/pocketbase', () => ({
 vi.mock('../../lib/products', () => ({
   filtrarProdutos: vi.fn((p) => p)
 }))
+vi.mock('../../lib/getTenantFromHost', () => ({
+  getTenantFromHost: vi.fn().mockResolvedValue(null)
+}))
 
 describe('GET /api/produtos', () => {
   it('retorna 500 quando pocketbase falha', async () => {

--- a/__tests__/asaasCheckout.test.ts
+++ b/__tests__/asaasCheckout.test.ts
@@ -2,6 +2,8 @@ import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { buildCheckoutUrl } from '../lib/asaas';
 import { POST } from '../app/admin/api/asaas/checkout/route';
 import { NextRequest } from 'next/server';
+vi.mock('../lib/apiAuth', () => ({ requireRole: vi.fn() }))
+import { requireRole } from '../lib/apiAuth'
 
 describe('buildCheckoutUrl', () => {
   it('normaliza barra ao final', () => {
@@ -14,6 +16,14 @@ describe('checkout route', () => {
   const originalEnv = process.env;
   beforeEach(() => {
     process.env = { ...originalEnv, ASAAS_API_URL: 'https://asaas', ASAAS_API_KEY: 'key' };
+    (requireRole as unknown as { mockReturnValue: (v: any) => void }).mockReturnValue({
+      pb: {
+        authStore: { isValid: true },
+        admins: { authWithPassword: vi.fn() },
+        collection: () => ({ getFirstListItem: vi.fn() })
+      } as any,
+      user: { role: 'coordenador' }
+    });
   });
   afterEach(() => {
     process.env = originalEnv;

--- a/app/admin/api/asaas/checkout/route.ts
+++ b/app/admin/api/asaas/checkout/route.ts
@@ -1,7 +1,7 @@
 import { NextRequest, NextResponse } from "next/server";
 import { z } from "zod";
 import { createCheckout } from "@/lib/asaas";
-import createPocketBase from "@/lib/pocketbase";
+import { requireRole } from "@/lib/apiAuth";
 
 const checkoutSchema = z.object({
   valor: z.number(),
@@ -41,6 +41,14 @@ const checkoutSchema = z.object({
 });
 
 export async function POST(req: NextRequest) {
+  const auth = requireRole(req, "coordenador");
+
+  if ("error" in auth) {
+    return NextResponse.json({ error: auth.error }, { status: auth.status });
+  }
+
+  const { pb } = auth;
+
   try {
     console.log("📥 Recebendo requisição POST em /asaas/checkout");
 
@@ -69,7 +77,6 @@ export async function POST(req: NextRequest) {
       paymentMethods,
     } = parse.data;
 
-    const pb = createPocketBase();
     if (
       process.env.PB_ADMIN_EMAIL &&
       process.env.PB_ADMIN_PASSWORD &&

--- a/app/admin/api/asaas/route.ts
+++ b/app/admin/api/asaas/route.ts
@@ -1,10 +1,16 @@
 import { NextRequest, NextResponse } from "next/server";
-import { createPocketBase } from "@/lib/pocketbase";
+import { requireRole } from "@/lib/apiAuth";
 import { logInfo } from "@/lib/logger";
 import { buildExternalReference } from "@/lib/asaas";
 
 export async function POST(req: NextRequest) {
-  const pb = createPocketBase();
+  const auth = requireRole(req, "coordenador");
+
+  if ("error" in auth) {
+    return NextResponse.json({ error: auth.error }, { status: auth.status });
+  }
+
+  const { pb } = auth;
   const baseUrl = process.env.ASAAS_API_URL;
 
   let apiKey = process.env.ASAAS_API_KEY || "";


### PR DESCRIPTION
## Summary
- check coordinator role in Asaas routes
- validate authorization in POST handlers before processing
- mock role check in Asaas route tests and create a new test for checkout
- update checkout tests with role mocks and fix produtos test

## Testing
- `npm run lint`
- `npm run build`
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_684c676e5258832ca7667ac05edd8e4d