### PR TITLE
Add API key logging per cliente

### DIFF
--- a/app/admin/api/asaas/checkout/route.ts
+++ b/app/admin/api/asaas/checkout/route.ts
@@ -90,6 +90,7 @@ export async function POST(req: NextRequest) {
 
     const host = req.headers.get("host")?.split(":" )[0] ?? "";
     let apiKey = process.env.ASAAS_API_KEY || "";
+    let userAgent = "qg3";
     try {
       if (host) {
         const clienteRecord = await pb
@@ -97,6 +98,7 @@ export async function POST(req: NextRequest) {
           .getFirstListItem(`dominio = "${host}"`);
         if (clienteRecord?.asaas_api_key) {
           apiKey = clienteRecord.asaas_api_key;
+          userAgent = clienteRecord?.nome || userAgent;
         }
       }
     } catch {
@@ -116,6 +118,8 @@ export async function POST(req: NextRequest) {
       paymentMethods,
     });
 
+    console.log("🔑 API Key utilizada:", apiKey);
+
     const checkoutUrl = await createCheckout(
       {
         valor,
@@ -130,6 +134,7 @@ export async function POST(req: NextRequest) {
         paymentMethods,
       },
       apiKey,
+      userAgent,
     );
 
     console.log("✅ Checkout criado com sucesso:", checkoutUrl);

--- a/app/admin/api/asaas/route.ts
+++ b/app/admin/api/asaas/route.ts
@@ -14,6 +14,7 @@ export async function POST(req: NextRequest) {
   const baseUrl = process.env.ASAAS_API_URL;
 
   let apiKey = process.env.ASAAS_API_KEY || "";
+  let userAgent = "qg3";
   try {
     const host = req.headers.get("host")?.split(":" )[0] ?? "";
     if (!pb.authStore.isValid) {
@@ -28,6 +29,7 @@ export async function POST(req: NextRequest) {
         .getFirstListItem(`dominio = "${host}"`);
       if (clienteRecord?.asaas_api_key) {
         apiKey = clienteRecord.asaas_api_key;
+        userAgent = clienteRecord?.nome || userAgent;
       }
     }
   } catch {
@@ -39,6 +41,8 @@ export async function POST(req: NextRequest) {
       "❌ ASAAS_API_KEY não definida! Confira seu .env ou painel de variáveis."
     );
   }
+  console.log("🔑 API Key utilizada:", apiKey);
+
   const keyHeader = apiKey.startsWith("$") ? apiKey : "$" + apiKey;
 
   if (!keyHeader || !baseUrl) {
@@ -104,7 +108,7 @@ export async function POST(req: NextRequest) {
         headers: {
           accept: "application/json",
           "access-token": keyHeader,
-          "User-Agent": "qg3",
+          "User-Agent": userAgent,
         },
       }
     );
@@ -138,7 +142,7 @@ export async function POST(req: NextRequest) {
           accept: "application/json",
           "Content-Type": "application/json",
           "access-token": keyHeader,
-          "User-Agent": "qg3",
+          "User-Agent": userAgent,
         },
         body: JSON.stringify(clientePayload),
       });
@@ -181,7 +185,7 @@ export async function POST(req: NextRequest) {
       headers: {
         "Content-Type": "application/json",
         "access-token": keyHeader,
-        "User-Agent": "qg3",
+        "User-Agent": userAgent,
       },
       body: JSON.stringify({
         customer: clienteId,

--- a/app/admin/api/asaas/saldo/route.ts
+++ b/app/admin/api/asaas/saldo/route.ts
@@ -10,6 +10,7 @@ export async function GET(req: NextRequest) {
   const { pb } = auth;
   const baseUrl = process.env.ASAAS_API_URL;
   let apiKey = process.env.ASAAS_API_KEY || "";
+  let userAgent = "qg3";
 
   try {
     const host = req.headers.get("host")?.split(":" )[0] ?? "";
@@ -25,6 +26,7 @@ export async function GET(req: NextRequest) {
         .getFirstListItem(`dominio = "${host}"`);
       if (clienteRecord?.asaas_api_key) {
         apiKey = clienteRecord.asaas_api_key;
+        userAgent = clienteRecord?.nome || userAgent;
       }
     }
   } catch {
@@ -38,6 +40,8 @@ export async function GET(req: NextRequest) {
     );
   }
 
+  console.log("🔑 API Key utilizada:", apiKey);
+
   const keyHeader = apiKey.startsWith("$") ? apiKey : `$${apiKey}`;
 
   try {
@@ -45,7 +49,7 @@ export async function GET(req: NextRequest) {
       headers: {
         accept: "application/json",
         "access-token": keyHeader,
-        "User-Agent": "qg3",
+        "User-Agent": userAgent,
       },
     });
 

--- a/app/api/asaas/webhook/route.ts
+++ b/app/api/asaas/webhook/route.ts
@@ -62,6 +62,7 @@ export async function POST(req: NextRequest) {
 
   let clienteApiKey: string | null = null;
   let clienteId: string | null = null;
+  let clienteNome: string | null = null;
   let usuarioId: string | null = null;
   let inscricaoId: string | null = null;
   const accountId = payment?.accountId || body.accountId;
@@ -72,6 +73,7 @@ export async function POST(req: NextRequest) {
         .getFirstListItem(`asaas_account_id = "${accountId}"`);
       clienteApiKey = c?.asaas_api_key ?? null;
       clienteId = c?.id ?? null;
+      clienteNome = c?.nome ?? null;
     } catch {
       /* ignore */
     }
@@ -93,6 +95,7 @@ export async function POST(req: NextRequest) {
     try {
       const c = await pb.collection("m24_clientes").getOne(clienteId);
       clienteApiKey = c?.asaas_api_key ?? null;
+      clienteNome = c?.nome ?? null;
     } catch {
       /* ignore */
     }
@@ -102,6 +105,8 @@ export async function POST(req: NextRequest) {
     return NextResponse.json({ error: "Cliente não encontrado" }, { status: 404 });
   }
 
+  console.log("🔑 API Key utilizada:", clienteApiKey);
+
   const keyHeader = clienteApiKey.startsWith("$")
     ? clienteApiKey
     : `$${clienteApiKey}`;
@@ -110,7 +115,7 @@ export async function POST(req: NextRequest) {
     headers: {
       accept: "application/json",
       "access-token": keyHeader,
-      "User-Agent": "qg3",
+      "User-Agent": clienteNome ?? "qg3",
     },
   });
 

--- a/lib/asaas.ts
+++ b/lib/asaas.ts
@@ -46,12 +46,14 @@ export type CreateCheckoutParams = {
 export async function createCheckout(
   params: CreateCheckoutParams,
   apiKey: string,
+  agentUser = "qg3",
   baseUrl = process.env.ASAAS_API_URL
 ): Promise<string> {
   const rawKey = apiKey;
 
   console.log("🔑 ASAAS_API_URL:", baseUrl);
   console.log("🔑 ASAAS_API_KEY:", rawKey);
+  console.log("👤 User-Agent:", agentUser);
 
   if (!baseUrl || !rawKey) {
     throw new Error("Asaas não configurado");
@@ -110,7 +112,7 @@ export async function createCheckout(
       accept: "application/json",
       "Content-Type": "application/json",
       "access-token": finalKey,
-      "User-Agent": "qg3",
+      "User-Agent": agentUser,
     },
     body: JSON.stringify(payload),
   });


### PR DESCRIPTION
## Summary
- log Asaas API key after reading from `m24_clientes`
- propagate cliente name as User-Agent header
- show key when creating checkout and transfers

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_684c7ecd4cf8832cb8086f6e29658dbf