### PR TITLE
Add domain-based auth to Asaas API

### DIFF
--- a/app/admin/api/asaas/saldo/route.ts
+++ b/app/admin/api/asaas/saldo/route.ts
@@ -1,42 +1,25 @@
 import { NextRequest, NextResponse } from "next/server";
-import { requireRole } from "@/lib/apiAuth";
+import { requireClienteFromHost } from "@/lib/clienteAuth";
 
 export async function GET(req: NextRequest) {
-  const auth = requireRole(req, "coordenador");
+  const auth = await requireClienteFromHost(req);
   if ("error" in auth) {
     return NextResponse.json({ error: auth.error }, { status: auth.status });
   }
 
-  const { pb } = auth;
+  const { cliente } = auth;
   const baseUrl = process.env.ASAAS_API_URL;
-  let apiKey = process.env.ASAAS_API_KEY || "";
-
-  try {
-    const host = req.headers.get("host")?.split(":" )[0] ?? "";
-    if (!pb.authStore.isValid) {
-      await pb.admins.authWithPassword(
-        process.env.PB_ADMIN_EMAIL!,
-        process.env.PB_ADMIN_PASSWORD!
-      );
-    }
-    if (host) {
-      const clienteRecord = await pb
-        .collection("m24_clientes")
-        .getFirstListItem(`dominio = "${host}"`);
-      if (clienteRecord?.asaas_api_key) {
-        apiKey = clienteRecord.asaas_api_key;
-      }
-    }
-  } catch {
-    /* ignore */
-  }
+  const apiKey = cliente.asaas_api_key || process.env.ASAAS_API_KEY || "";
+  const userAgent = cliente.nome || "qg3";
 
   if (!baseUrl || !apiKey) {
     return NextResponse.json(
       { error: "Asaas não configurado" },
-      { status: 500 }
+      { status: 500 },
     );
   }
+
+  console.log("🔑 API Key utilizada:", apiKey);
 
   const keyHeader = apiKey.startsWith("$") ? apiKey : `$${apiKey}`;
 
@@ -45,7 +28,7 @@ export async function GET(req: NextRequest) {
       headers: {
         accept: "application/json",
         "access-token": keyHeader,
-        "User-Agent": "qg3",
+        "User-Agent": userAgent,
       },
     });
 
@@ -54,7 +37,7 @@ export async function GET(req: NextRequest) {
       console.error("Erro ao consultar saldo Asaas:", errorBody);
       return NextResponse.json(
         { error: "Falha ao consultar saldo" },
-        { status: 500 }
+        { status: 500 },
       );
     }
 
@@ -64,7 +47,7 @@ export async function GET(req: NextRequest) {
     console.error("Erro inesperado ao consultar saldo:", err);
     return NextResponse.json(
       { error: "Erro ao consultar saldo" },
-      { status: 500 }
+      { status: 500 },
     );
   }
 }

--- a/app/admin/api/asaas/transferencia/route.ts
+++ b/app/admin/api/asaas/transferencia/route.ts
@@ -1,46 +1,24 @@
 import { NextRequest, NextResponse } from "next/server";
-import { requireRole } from "@/lib/apiAuth";
-import createPocketBase from "@/lib/pocketbase";
-
-async function getApiKey(req: NextRequest, pb: ReturnType<typeof createPocketBase>) {
-  let apiKey = process.env.ASAAS_API_KEY || "";
-  try {
-    const host = req.headers.get("host")?.split(":" )[0] ?? "";
-    if (!pb.authStore.isValid) {
-      await pb.admins.authWithPassword(
-        process.env.PB_ADMIN_EMAIL!,
-        process.env.PB_ADMIN_PASSWORD!
-      );
-    }
-    if (host) {
-      const clienteRecord = await pb
-        .collection("m24_clientes")
-        .getFirstListItem(`dominio = "${host}"`);
-      if (clienteRecord?.asaas_api_key) {
-        apiKey = clienteRecord.asaas_api_key;
-      }
-    }
-  } catch {
-    /* ignore */
-  }
-  return apiKey;
-}
+import { requireClienteFromHost } from "@/lib/clienteAuth";
 
 export async function POST(req: NextRequest) {
-  const auth = requireRole(req, "coordenador");
+  const auth = await requireClienteFromHost(req);
   if ("error" in auth) {
     return NextResponse.json({ error: auth.error }, { status: auth.status });
   }
-  const { pb } = auth;
+  const { cliente } = auth;
   const baseUrl = process.env.ASAAS_API_URL;
-  const apiKey = await getApiKey(req, pb);
+  const apiKey = cliente.asaas_api_key || process.env.ASAAS_API_KEY || "";
+  const userAgent = cliente.nome || "qg3";
 
   if (!baseUrl || !apiKey) {
     return NextResponse.json(
       { error: "Asaas não configurado" },
-      { status: 500 }
+      { status: 500 },
     );
   }
+
+  console.log("🔑 API Key utilizada:", apiKey);
 
   const keyHeader = apiKey.startsWith("$") ? apiKey : `$${apiKey}`;
 
@@ -52,7 +30,7 @@ export async function POST(req: NextRequest) {
         accept: "application/json",
         "Content-Type": "application/json",
         "access-token": keyHeader,
-        "User-Agent": "qg3",
+        "User-Agent": userAgent,
       },
       body: JSON.stringify(body),
     });
@@ -62,7 +40,7 @@ export async function POST(req: NextRequest) {
       console.error("Erro ao criar transferência:", errorBody);
       return NextResponse.json(
         { error: "Falha ao criar transferência" },
-        { status: 500 }
+        { status: 500 },
       );
     }
 
@@ -72,24 +50,25 @@ export async function POST(req: NextRequest) {
     console.error("Erro inesperado ao criar transferência:", err);
     return NextResponse.json(
       { error: "Erro ao criar transferência" },
-      { status: 500 }
+      { status: 500 },
     );
   }
 }
 
 export async function DELETE(req: NextRequest) {
-  const auth = requireRole(req, "coordenador");
+  const auth = await requireClienteFromHost(req);
   if ("error" in auth) {
     return NextResponse.json({ error: auth.error }, { status: auth.status });
   }
-  const { pb } = auth;
+  const { cliente } = auth;
   const baseUrl = process.env.ASAAS_API_URL;
-  const apiKey = await getApiKey(req, pb);
+  const apiKey = cliente.asaas_api_key || process.env.ASAAS_API_KEY || "";
+  const userAgent = cliente.nome || "qg3";
 
   if (!baseUrl || !apiKey) {
     return NextResponse.json(
       { error: "Asaas não configurado" },
-      { status: 500 }
+      { status: 500 },
     );
   }
 
@@ -97,6 +76,8 @@ export async function DELETE(req: NextRequest) {
   if (!id) {
     return NextResponse.json({ error: "Id obrigatório" }, { status: 400 });
   }
+
+  console.log("🔑 API Key utilizada:", apiKey);
 
   const keyHeader = apiKey.startsWith("$") ? apiKey : `$${apiKey}`;
 
@@ -106,7 +87,7 @@ export async function DELETE(req: NextRequest) {
       headers: {
         accept: "application/json",
         "access-token": keyHeader,
-        "User-Agent": "qg3",
+        "User-Agent": userAgent,
       },
     });
 
@@ -115,7 +96,7 @@ export async function DELETE(req: NextRequest) {
       console.error("Erro ao cancelar transferência:", errorBody);
       return NextResponse.json(
         { error: "Falha ao cancelar transferência" },
-        { status: 500 }
+        { status: 500 },
       );
     }
 
@@ -124,7 +105,7 @@ export async function DELETE(req: NextRequest) {
     console.error("Erro inesperado ao cancelar transferência:", err);
     return NextResponse.json(
       { error: "Erro ao cancelar transferência" },
-      { status: 500 }
+      { status: 500 },
     );
   }
 }

--- a/app/admin/financeiro/page.tsx
+++ b/app/admin/financeiro/page.tsx
@@ -25,7 +25,7 @@ export default function FinanceiroPage() {
     const fetchSaldo = async () => {
       try {
         setLoading(true);
-        const res = await fetch(`/admin/api/financeiro/saldo?tenantId=${tenantId}`);
+        const res = await fetch(`/admin/api/asaas/saldo`);
         if (res.ok) {
           const data = await res.json();
           setSaldo(data);
@@ -50,19 +50,25 @@ export default function FinanceiroPage() {
             <div className="card p-6 text-center">
               <h3 className="text-lg font-semibold mb-2">Saldo Disponível</h3>
               <p className="text-xl font-bold">
-                {saldo ? `R$ ${saldo.disponivel.toFixed(2)}` : "—"}
+                {typeof saldo?.disponivel === "number"
+                  ? `R$ ${saldo.disponivel.toFixed(2)}`
+                  : "—"}
               </p>
             </div>
             <div className="card p-6 text-center">
               <h3 className="text-lg font-semibold mb-2">A Liberar</h3>
               <p className="text-xl font-bold">
-                {saldo ? `R$ ${saldo.aLiberar.toFixed(2)}` : "—"}
+                {typeof saldo?.aLiberar === "number"
+                  ? `R$ ${saldo.aLiberar.toFixed(2)}`
+                  : "—"}
               </p>
             </div>
             <div className="card p-6 text-center">
               <h3 className="text-lg font-semibold mb-2">Total Recebido</h3>
               <p className="text-xl font-bold">
-                {saldo ? `R$ ${saldo.totalRecebido.toFixed(2)}` : "—"}
+                {typeof saldo?.totalRecebido === "number"
+                  ? `R$ ${saldo.totalRecebido.toFixed(2)}`
+                  : "—"}
               </p>
             </div>
           </div>

--- a/app/api/asaas/webhook/route.ts
+++ b/app/api/asaas/webhook/route.ts
@@ -62,6 +62,7 @@ export async function POST(req: NextRequest) {
 
   let clienteApiKey: string | null = null;
   let clienteId: string | null = null;
+  let clienteNome: string | null = null;
   let usuarioId: string | null = null;
   let inscricaoId: string | null = null;
   const accountId = payment?.accountId || body.accountId;
@@ -72,6 +73,7 @@ export async function POST(req: NextRequest) {
         .getFirstListItem(`asaas_account_id = "${accountId}"`);
       clienteApiKey = c?.asaas_api_key ?? null;
       clienteId = c?.id ?? null;
+      clienteNome = c?.nome ?? null;
     } catch {
       /* ignore */
     }
@@ -93,6 +95,7 @@ export async function POST(req: NextRequest) {
     try {
       const c = await pb.collection("m24_clientes").getOne(clienteId);
       clienteApiKey = c?.asaas_api_key ?? null;
+      clienteNome = c?.nome ?? null;
     } catch {
       /* ignore */
     }
@@ -102,6 +105,8 @@ export async function POST(req: NextRequest) {
     return NextResponse.json({ error: "Cliente não encontrado" }, { status: 404 });
   }
 
+  console.log("🔑 API Key utilizada:", clienteApiKey);
+
   const keyHeader = clienteApiKey.startsWith("$")
     ? clienteApiKey
     : `$${clienteApiKey}`;
@@ -110,7 +115,7 @@ export async function POST(req: NextRequest) {
     headers: {
       accept: "application/json",
       "access-token": keyHeader,
-      "User-Agent": "qg3",
+      "User-Agent": clienteNome ?? "qg3",
     },
   });
 

--- a/lib/asaas.ts
+++ b/lib/asaas.ts
@@ -46,12 +46,14 @@ export type CreateCheckoutParams = {
 export async function createCheckout(
   params: CreateCheckoutParams,
   apiKey: string,
+  agentUser = "qg3",
   baseUrl = process.env.ASAAS_API_URL
 ): Promise<string> {
   const rawKey = apiKey;
 
   console.log("🔑 ASAAS_API_URL:", baseUrl);
   console.log("🔑 ASAAS_API_KEY:", rawKey);
+  console.log("👤 User-Agent:", agentUser);
 
   if (!baseUrl || !rawKey) {
     throw new Error("Asaas não configurado");
@@ -110,7 +112,7 @@ export async function createCheckout(
       accept: "application/json",
       "Content-Type": "application/json",
       "access-token": finalKey,
-      "User-Agent": "qg3",
+      "User-Agent": agentUser,
     },
     body: JSON.stringify(payload),
   });

--- a/lib/clienteAuth.ts
+++ b/lib/clienteAuth.ts
@@ -1,0 +1,43 @@
+import type { NextRequest } from "next/server";
+import type { RecordModel } from "pocketbase";
+import createPocketBase from "@/lib/pocketbase";
+
+export type ClienteAuthOk = {
+  pb: ReturnType<typeof createPocketBase>;
+  cliente: RecordModel;
+};
+
+export type ClienteAuthError = {
+  error: string;
+  status: number;
+};
+
+export async function requireClienteFromHost(
+  req: NextRequest,
+): Promise<ClienteAuthOk | ClienteAuthError> {
+  const host = req.headers.get("host")?.split(":" )[0] ?? "";
+  if (!host) {
+    return { error: "Dom\u00ednio ausente", status: 400 };
+  }
+
+  const pb = createPocketBase();
+
+  if (!pb.authStore.isValid) {
+    await pb.admins.authWithPassword(
+      process.env.PB_ADMIN_EMAIL!,
+      process.env.PB_ADMIN_PASSWORD!,
+    );
+  }
+
+  try {
+    const cliente = await pb
+      .collection("m24_clientes")
+      .getFirstListItem(`dominio = \"${host}\"`);
+    if (!cliente) {
+      return { error: "Cliente n\u00e3o encontrado", status: 404 };
+    }
+    return { pb, cliente };
+  } catch {
+    return { error: "Cliente n\u00e3o encontrado", status: 404 };
+  }
+}

--- a/logs/ERR_LOG.md
+++ b/logs/ERR_LOG.md
@@ -55,3 +55,4 @@
 ## [2025-06-12] Corrigido erro de build em login por falta de Suspense - dev - 823ad2b
 ## [2025-06-12] Ajustado carregamento de gêneros e imagens no detalhe do produto - dev - 6fd0697
 ## [2025-06-13] Implementadas rotas de saldo e transferência Asaas com verificação de permissão - dev - 7c89834
+## [2025-06-13] Corrigido erro "saldo undefined" na página Financeiro - dev - f8df755


### PR DESCRIPTION
## Summary
- authenticate Asaas API routes using cliente domain
- look up cliente data with `requireClienteFromHost`
- simplify API key and User-Agent handling
- prevent undefined fields in Financeiro page
- log fix for saldo runtime error

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_684c7ecd4cf8832cb8086f6e29658dbf