### PR TITLE
feat: integrate asaas extrato

### DIFF
--- a/README.md
+++ b/README.md
@@ -192,6 +192,8 @@ Resposta de exemplo:
 ```json
 { "data": [] }
 ```
+Use `start` e `end` (AAAA-MM-DD) para filtrar o período. A rota usa
+`requireClienteFromHost` para obter a chave do cliente e definir o `User-Agent`.
 
 ### Coleção `compras`
 

--- a/app/admin/api/asaas/extrato/route.ts
+++ b/app/admin/api/asaas/extrato/route.ts
@@ -1,44 +1,20 @@
 import { NextRequest, NextResponse } from "next/server";
-import { requireRole } from "@/lib/apiAuth";
-import createPocketBase from "@/lib/pocketbase";
-
-async function getApiKey(req: NextRequest, pb: ReturnType<typeof createPocketBase>) {
-  let apiKey = process.env.ASAAS_API_KEY || "";
-  try {
-    const host = req.headers.get("host")?.split(":" )[0] ?? "";
-    if (!pb.authStore.isValid) {
-      await pb.admins.authWithPassword(
-        process.env.PB_ADMIN_EMAIL!,
-        process.env.PB_ADMIN_PASSWORD!
-      );
-    }
-    if (host) {
-      const clienteRecord = await pb
-        .collection("m24_clientes")
-        .getFirstListItem(`dominio = "${host}"`);
-      if (clienteRecord?.asaas_api_key) {
-        apiKey = clienteRecord.asaas_api_key;
-      }
-    }
-  } catch {
-    /* ignore */
-  }
-  return apiKey;
-}
+import { requireClienteFromHost } from "@/lib/clienteAuth";
 
 export async function GET(req: NextRequest) {
-  const auth = requireRole(req, "coordenador");
+  const auth = await requireClienteFromHost(req);
   if ("error" in auth) {
     return NextResponse.json({ error: auth.error }, { status: auth.status });
   }
-  const { pb } = auth;
+  const { cliente } = auth;
   const baseUrl = process.env.ASAAS_API_URL;
-  const apiKey = await getApiKey(req, pb);
+  const apiKey = cliente.asaas_api_key || process.env.ASAAS_API_KEY || "";
+  const userAgent = cliente.nome || "qg3";
 
   if (!baseUrl || !apiKey) {
     return NextResponse.json(
       { error: "Asaas não configurado" },
-      { status: 500 }
+      { status: 500 },
     );
   }
 
@@ -55,7 +31,7 @@ export async function GET(req: NextRequest) {
       headers: {
         accept: "application/json",
         "access-token": keyHeader,
-        "User-Agent": "qg3",
+        "User-Agent": userAgent,
       },
     });
 
@@ -64,7 +40,7 @@ export async function GET(req: NextRequest) {
       console.error("Erro ao consultar extrato:", errorBody);
       return NextResponse.json(
         { error: "Falha ao consultar extrato" },
-        { status: 500 }
+        { status: 500 },
       );
     }
 
@@ -74,7 +50,7 @@ export async function GET(req: NextRequest) {
     console.error("Erro inesperado ao consultar extrato:", err);
     return NextResponse.json(
       { error: "Erro ao consultar extrato" },
-      { status: 500 }
+      { status: 500 },
     );
   }
 }

--- a/app/admin/financeiro/page.tsx
+++ b/app/admin/financeiro/page.tsx
@@ -1,4 +1,14 @@
-import { redirect } from "next/navigation";
+"use client";
+
+import { useRouter } from "next/navigation";
+import { useEffect, useState } from "react";
+import { useAuthContext } from "@/lib/context/AuthContext";
+
+interface Saldo {
+  disponivel: number;
+  aLiberar: number;
+  totalRecebido: number;
+}
 
 export default function FinanceiroPage() {
   const { tenantId, isLoggedIn } = useAuthContext();

--- a/docs/saldo-transferencia-asaas.md
+++ b/docs/saldo-transferencia-asaas.md
@@ -35,3 +35,8 @@ A rota retorna o objeto da transferência criado pelo Asaas.
 ## Extrato de Movimentações
 
 Na página **Saldo** é possível listar o extrato financeiro usando o endpoint `/admin/api/asaas/extrato`. Utilize os botões **Exportar PDF** ou **Exportar XLSM** para salvar os dados.
+Para filtrar, informe `start` e `end` (AAAA-MM-DD):
+
+```bash
+GET /admin/api/asaas/extrato?start=2025-01-01&end=2025-01-31
+```

--- a/logs/DOC_LOG.md
+++ b/logs/DOC_LOG.md
@@ -101,3 +101,4 @@
 ## [2025-06-13] Especificado no README que apenas coordenadores visualizam métricas financeiras; líderes veem somente contagens de inscrições e pedidos.
 ## [2025-06-13] DashboardAnalytics agora aceita mostrarFinanceiro para ocultar seções com valores
 ## [2025-06-16] Páginas Saldo e Transferências criadas com extrato exportável em PDF/XLSM. README e guia atualizados.
+## [2025-06-16] Rota /admin/api/asaas/extrato atualizada para requireClienteFromHost e docs revisados.


### PR DESCRIPTION
## Summary
- get tenant info using `requireClienteFromHost` in extrato API
- document extrato usage and parameters
- fix lint by removing unused redirect import and making `FinanceiroPage` client component

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_684cb55ea404832c88083bf15cd9621a