### PR TITLE
Fix saldo page toFixed error

### DIFF
--- a/app/admin/financeiro/saldo/page.tsx
+++ b/app/admin/financeiro/saldo/page.tsx
@@ -87,19 +87,25 @@ export default function SaldoPage() {
             <div className="card p-6 text-center">
               <h3 className="text-lg font-semibold mb-2">Saldo Disponível</h3>
               <p className="text-xl font-bold">
-                {saldo ? `R$ ${saldo.disponivel.toFixed(2)}` : "—"}
+                {typeof saldo?.disponivel === "number"
+                  ? `R$ ${saldo.disponivel.toFixed(2)}`
+                  : "—"}
               </p>
             </div>
             <div className="card p-6 text-center">
               <h3 className="text-lg font-semibold mb-2">A Liberar</h3>
               <p className="text-xl font-bold">
-                {saldo ? `R$ ${saldo.aLiberar.toFixed(2)}` : "—"}
+                {typeof saldo?.aLiberar === "number"
+                  ? `R$ ${saldo.aLiberar.toFixed(2)}`
+                  : "—"}
               </p>
             </div>
             <div className="card p-6 text-center">
               <h3 className="text-lg font-semibold mb-2">Total Recebido</h3>
               <p className="text-xl font-bold">
-                {saldo ? `R$ ${saldo.totalRecebido.toFixed(2)}` : "—"}
+                {typeof saldo?.totalRecebido === "number"
+                  ? `R$ ${saldo.totalRecebido.toFixed(2)}`
+                  : "—"}
               </p>
             </div>
           </div>
@@ -119,7 +125,9 @@ export default function SaldoPage() {
                     <tr key={t.id}>
                       <td className="px-2">{t.date}</td>
                       <td className="px-2">{t.description}</td>
-                      <td className="px-2">{t.value.toFixed(2)}</td>
+                      <td className="px-2">
+                        {typeof t.value === "number" ? t.value.toFixed(2) : "—"}
+                      </td>
                     </tr>
                   ))}
                 </tbody>

--- a/logs/ERR_LOG.md
+++ b/logs/ERR_LOG.md
@@ -56,3 +56,4 @@
 ## [2025-06-12] Ajustado carregamento de gêneros e imagens no detalhe do produto - dev - 6fd0697
 ## [2025-06-13] Implementadas rotas de saldo e transferência Asaas com verificação de permissão - dev - 7c89834
 ## [2025-06-13] Corrigido erro "saldo undefined" na página Financeiro - dev - f8df755
+## [2025-06-15] Corrigido erro "Cannot read properties of undefined (reading 'toFixed')" em SaldoPage - dev - edbc5b2


### PR DESCRIPTION
## Summary
- guard saldo values in `app/admin/financeiro/saldo/page.tsx` before calling `toFixed`
- handle invalid value in extrato table
- log the bugfix in `ERR_LOG.md`

## Testing
- `npm run lint` *(fails: next not found)*
- `npm run build` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_684ec2558bc8832c83820d5d8109e9f8