### PR TITLE
Add bank account modal

### DIFF
--- a/README.md
+++ b/README.md
@@ -198,6 +198,13 @@ e consulta `${ASAAS_API_URL}/financialTransactions` com os parâmetros padrão
 `offset=0`, `limit=10` e `order=asc`, enviando os mesmos cabeçalhos utilizados
 em `/admin/api/asaas/saldo`.
 
+### Cadastro de Contas Bancárias
+
+O painel possui o modal `BankAccountModal` para registrar contas bancárias do cliente. O campo **Banco** utiliza busca na BrasilAPI (`NEXT_PUBLIC_BRASILAPI_URL`) e preenche automaticamente `bankCode` e `ispb`. Ao enviar o formulário os dados são salvos na coleção `clientes_contas_bancarias` relacionados ao usuário autenticado e ao tenant.
+Na página **Transferências**, um botão **Nova conta** abre este modal para facilitar o cadastro durante o fluxo de transferências.
+O `ModalAnimated` recebeu um `z-index` superior para evitar que elementos fixos como a navbar sobreponham o conteúdo do modal.
+
+
 ### Coleção `compras`
 
 Registra as compras feitas na loja. Campos principais:

--- a/__tests__/bankAccounts.test.ts
+++ b/__tests__/bankAccounts.test.ts
@@ -1,0 +1,53 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { searchBanks, createBankAccount } from '../lib/bankAccounts';
+import type PocketBase from 'pocketbase';
+
+describe('searchBanks', () => {
+  const env = process.env;
+  beforeEach(() => {
+    process.env = { ...env, NEXT_PUBLIC_BRASILAPI_URL: 'https://brasil' } as NodeJS.ProcessEnv;
+  });
+  afterEach(() => {
+    process.env = env;
+    vi.restoreAllMocks();
+  });
+  it('monta url e retorna lista', async () => {
+    const fetchMock = vi.fn().mockResolvedValue({
+      ok: true,
+      json: () => Promise.resolve([{ ispb: '1', name: 'Bank', code: 10 }]),
+    });
+    const banks = await searchBanks('Bank', fetchMock);
+    expect(fetchMock).toHaveBeenCalledWith('https://brasil/api/banks/v1?search=Bank');
+    expect(banks[0].code).toBe(10);
+  });
+});
+
+describe('createBankAccount', () => {
+  it('envia dados para pocketbase', async () => {
+    const createMock = vi.fn().mockResolvedValue({ id: '1' });
+    const pb = {
+      collection: vi.fn(() => ({ create: createMock })),
+    } as unknown as PocketBase;
+    await createBankAccount(
+      pb,
+      {
+        ownerName: 'a',
+        cpfCnpj: 'b',
+        ownerBirthDate: 'c',
+        bankName: 'd',
+        bankCode: '1',
+        ispb: '2',
+        agency: '3',
+        account: '4',
+        accountDigit: '5',
+        bankAccountType: 'corrente',
+      },
+      'u1',
+      'cli1'
+    );
+    expect(pb.collection).toHaveBeenCalledWith('clientes_contas_bancarias');
+    expect(createMock).toHaveBeenCalledWith(
+      expect.objectContaining({ usuario: 'u1', cliente: 'cli1' })
+    );
+  });
+});

--- a/app/admin/financeiro/transferencias/page.tsx
+++ b/app/admin/financeiro/transferencias/page.tsx
@@ -4,11 +4,13 @@ import { useRouter } from "next/navigation";
 import { useAuthContext } from "@/lib/context/AuthContext";
 import { useState } from "react";
 import TransferenciaForm from "@/components/TransferenciaForm";
+import BankAccountModal from "@/components/modals/BankAccountModal";
 
 export default function TransferenciasPage() {
   const { isLoggedIn } = useAuthContext();
   const router = useRouter();
   const [mensagem, setMensagem] = useState("");
+  const [openAccountModal, setOpenAccountModal] = useState(false);
 
   async function handleTransfer(destino: string, valor: number) {
     const res = await fetch("/admin/api/asaas/transferencia", {
@@ -32,7 +34,18 @@ export default function TransferenciasPage() {
     <main className="max-w-lg mx-auto px-4 py-8">
       <h2 className="heading mb-6">Transferências</h2>
       {mensagem && <p className="mb-4">{mensagem}</p>}
+      <button
+        type="button"
+        className="btn btn-secondary mb-4"
+        onClick={() => setOpenAccountModal(true)}
+      >
+        Nova conta
+      </button>
       <TransferenciaForm onTransfer={handleTransfer} />
+      <BankAccountModal
+        open={openAccountModal}
+        onClose={() => setOpenAccountModal(false)}
+      />
     </main>
   );
 }

--- a/components/ModalAnimated.tsx
+++ b/components/ModalAnimated.tsx
@@ -25,7 +25,7 @@ export default function ModalAnimated({
                 animate={{ opacity: 1 }}
                 exit={{ opacity: 0 }}
                 transition={{ duration: 0.2 }}
-                className="fixed inset-0 bg-black/60 backdrop-blur-sm z-40"
+                className="fixed inset-0 bg-black/60 backdrop-blur-sm z-[120]"
               />
             </Dialog.Overlay>
             <Dialog.Content asChild>
@@ -34,7 +34,7 @@ export default function ModalAnimated({
                 animate={{ opacity: 1, scale: 1 }}
                 exit={{ opacity: 0, scale: 0.95 }}
                 transition={{ type: "spring", stiffness: 300, damping: 20 }}
-                className="fixed top-1/2 left-1/2 -translate-x-1/2 -translate-y-1/2 bg-white dark:bg-zinc-900 text-black dark:text-white p-6 rounded-xl z-50"
+                className="fixed top-1/2 left-1/2 -translate-x-1/2 -translate-y-1/2 bg-white dark:bg-zinc-900 text-black dark:text-white p-6 rounded-xl z-[130]"
               >
                 {children}
               </motion.div>

--- a/components/modals/BankAccountModal.tsx
+++ b/components/modals/BankAccountModal.tsx
@@ -1,0 +1,177 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import ModalAnimated from "../ModalAnimated";
+import usePocketBase from "@/lib/hooks/usePocketBase";
+import type { UserModel } from "@/types/UserModel";
+import { searchBanks, createBankAccount, Bank } from "@/lib/bankAccounts";
+
+interface BankAccountModalProps {
+  open: boolean;
+  onClose: () => void;
+}
+
+export default function BankAccountModal({ open, onClose }: BankAccountModalProps) {
+  const pb = usePocketBase();
+  const user = pb.authStore.model as unknown as UserModel | null;
+
+  const [ownerName, setOwnerName] = useState("");
+  const [cpfCnpj, setCpfCnpj] = useState("");
+  const [ownerBirthDate, setOwnerBirthDate] = useState("");
+  const [bankName, setBankName] = useState("");
+  const [bankCode, setBankCode] = useState("");
+  const [ispb, setIspb] = useState("");
+  const [agency, setAgency] = useState("");
+  const [account, setAccount] = useState("");
+  const [accountDigit, setAccountDigit] = useState("");
+  const [bankAccountType, setBankAccountType] = useState("conta_corrente");
+  const [banks, setBanks] = useState<Bank[]>([]);
+  const [erro, setErro] = useState("");
+
+  useEffect(() => {
+    if (!bankName) {
+      setBanks([]);
+      return;
+    }
+    const timeout = setTimeout(() => {
+      searchBanks(bankName)
+        .then(setBanks)
+        .catch(() => setBanks([]));
+    }, 300);
+    return () => clearTimeout(timeout);
+  }, [bankName]);
+
+  const handleBankChange = (value: string) => {
+    setBankName(value);
+    const found = banks.find((b) => b.name === value);
+    if (found) {
+      setBankCode(String(found.code));
+      setIspb(found.ispb);
+    }
+  };
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    if (!user) return;
+    try {
+      await createBankAccount(
+        pb,
+        {
+          ownerName,
+          cpfCnpj,
+          ownerBirthDate,
+          bankName,
+          bankCode,
+          ispb,
+          agency,
+          account,
+          accountDigit,
+          bankAccountType,
+        },
+        user.id,
+        (user as UserModel & { cliente?: string }).cliente || user.id
+      );
+      onClose();
+    } catch (err) {
+      console.error(err);
+      setErro("Erro ao salvar.");
+    }
+  };
+
+  return (
+    <ModalAnimated open={open} onOpenChange={(v) => !v && onClose()}>
+      <form onSubmit={handleSubmit} className="space-y-3 w-80">
+        <h3 className="text-lg font-semibold text-center">Adicionar Conta</h3>
+        <input
+          className="input-base"
+          placeholder="Nome do titular"
+          value={ownerName}
+          onChange={(e) => setOwnerName(e.target.value)}
+          required
+        />
+        <input
+          className="input-base"
+          placeholder="CPF/CNPJ"
+          value={cpfCnpj}
+          onChange={(e) => setCpfCnpj(e.target.value)}
+          required
+        />
+        <input
+          className="input-base"
+          type="date"
+          value={ownerBirthDate}
+          onChange={(e) => setOwnerBirthDate(e.target.value)}
+          required
+        />
+        <div>
+          <input
+            list="bank-list"
+            className="input-base"
+            placeholder="Banco"
+            value={bankName}
+            onChange={(e) => handleBankChange(e.target.value)}
+            required
+          />
+          <datalist id="bank-list">
+            {banks.map((b) => (
+              <option key={b.ispb} value={b.name} />
+            ))}
+          </datalist>
+        </div>
+        <input
+          className="input-base"
+          placeholder="Código do banco"
+          value={bankCode}
+          readOnly
+          required
+        />
+        <input
+          className="input-base"
+          placeholder="ISPB"
+          value={ispb}
+          readOnly
+          required
+        />
+        <input
+          className="input-base"
+          placeholder="Agência"
+          value={agency}
+          onChange={(e) => setAgency(e.target.value)}
+          required
+        />
+        <input
+          className="input-base"
+          placeholder="Conta"
+          value={account}
+          onChange={(e) => setAccount(e.target.value)}
+          required
+        />
+        <input
+          className="input-base"
+          placeholder="Dígito"
+          value={accountDigit}
+          onChange={(e) => setAccountDigit(e.target.value)}
+          required
+        />
+        <select
+          className="input-base"
+          value={bankAccountType}
+          onChange={(e) => setBankAccountType(e.target.value)}
+          required
+        >
+          <option value="conta_corrente">Conta Corrente</option>
+          <option value="conta_poupanca">Conta Poupança</option>
+        </select>
+        {erro && <p className="text-error-600 text-sm">{erro}</p>}
+        <div className="flex justify-end gap-2 pt-2">
+          <button type="button" className="btn btn-secondary" onClick={onClose}>
+            Cancelar
+          </button>
+          <button type="submit" className="btn btn-primary">
+            Salvar
+          </button>
+        </div>
+      </form>
+    </ModalAnimated>
+  );
+}

--- a/lib/bankAccounts.ts
+++ b/lib/bankAccounts.ts
@@ -1,0 +1,46 @@
+export interface Bank {
+  ispb: string;
+  name: string;
+  code: number;
+  fullName?: string;
+}
+
+export async function searchBanks(query: string, fetchFn: typeof fetch = fetch): Promise<Bank[]> {
+  if (!query) return [];
+  const base = process.env.NEXT_PUBLIC_BRASILAPI_URL || '';
+  const url = `${base}/api/banks/v1?search=${encodeURIComponent(query)}`;
+  const res = await fetchFn(url);
+  if (!res.ok) {
+    throw new Error('Erro ao consultar bancos');
+  }
+  return (await res.json()) as Bank[];
+}
+
+import type PocketBase from 'pocketbase';
+
+export interface BankAccount {
+  ownerName: string;
+  cpfCnpj: string;
+  ownerBirthDate: string;
+  bankName: string;
+  bankCode: string;
+  ispb: string;
+  agency: string;
+  account: string;
+  accountDigit: string;
+  bankAccountType: string;
+}
+
+export async function createBankAccount(
+  pb: PocketBase,
+  account: BankAccount,
+  userId: string,
+  clienteId: string
+) {
+  const data = {
+    ...account,
+    usuario: userId,
+    cliente: clienteId,
+  };
+  return pb.collection('clientes_contas_bancarias').create(data);
+}

--- a/logs/DOC_LOG.md
+++ b/logs/DOC_LOG.md
@@ -104,3 +104,7 @@
 ## [2025-06-16] Rota /admin/api/asaas/extrato atualizada para requireClienteFromHost e docs revisados.
 ## [2025-06-16] README e guia atualizados mencionando uso de /finance/transactions no extrato com mesmo cabeçalho de saldo.
 ## [2025-06-16] Extrato agora usa /financialTransactions e define offset, limit e order=asc.
+
+## [2025-06-17] BankAccountModal criado com busca BrasilAPI e registro em clientes_contas_bancarias. Documentação e testes adicionados.
+## [2025-06-16] Botão Nova conta integrado à página de Transferências com o BankAccountModal.
+## [2025-06-17] Ajustado z-index do ModalAnimated para sobrepor a navbar e documentado no README.

--- a/stories/BankAccountModal.stories.tsx
+++ b/stories/BankAccountModal.stories.tsx
@@ -1,0 +1,35 @@
+import type { Meta, StoryObj } from '@storybook/nextjs';
+import { within, expect, fn } from 'storybook/test';
+import BankAccountModal from '../components/modals/BankAccountModal';
+import { AuthProvider } from '../lib/context/AuthContext';
+import { ThemeProvider } from '../lib/context/ThemeContext';
+
+const meta = {
+  title: 'Design System/BankAccountModal',
+  component: BankAccountModal,
+  decorators: [
+    (Story) => (
+      <ThemeProvider>
+        <AuthProvider>
+          <Story />
+        </AuthProvider>
+      </ThemeProvider>
+    ),
+  ],
+  args: {
+    open: true,
+    onClose: fn(),
+  },
+  tags: ['autodocs'],
+} satisfies Meta<typeof BankAccountModal>;
+
+export default meta;
+
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    await expect(canvas.getByText(/Adicionar Conta/i)).toBeInTheDocument();
+  },
+};


### PR DESCRIPTION
## Summary
- add BankAccountModal component using ModalAnimated
- search banks on BrasilAPI with debounce
- create PocketBase helpers for bank accounts
- document bank account flow
- log doc changes
- add Storybook story and tests
- add button on Transferências page to open the modal
- bump z-index of ModalAnimated so it appears above fixed navbars

## Testing
- `npm run lint`
- `npm run test` *(fails: multiple assertions fail)*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_684ec9bf0698832cb6158c37ca4039e3