### PR TITLE
Fix key collisions in pagination and gallery

### DIFF
--- a/app/blog/BlogClient.tsx
+++ b/app/blog/BlogClient.tsx
@@ -176,7 +176,7 @@ export default function BlogClient() {
 
                   {[...Array(totalPages)].map((_, i) => (
                     <button
-                      key={i}
+                      key={`page-${i + 1}`}
                       onClick={() => handlePageChange(i + 1)}
                       className={`px-3 py-2 text-sm rounded ${
                         currentPage === i + 1

--- a/app/loja/produtos/[slug]/ProdutoInterativo.tsx
+++ b/app/loja/produtos/[slug]/ProdutoInterativo.tsx
@@ -172,7 +172,7 @@ export default function ProdutoInterativo({
         <div className="flex gap-3 mt-4">
           {imgs.map((src, i) => (
             <Image
-              key={i}
+              key={i + 1}
               src={src}
               alt={`Miniatura ${i + 1}`}
               width={64}


### PR DESCRIPTION
## Summary
- avoid React key collisions on pagination buttons
- update gallery thumbnails to use incremental key

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_685024c65e98832c834f65e2360c8ab0