### PR TITLE
Adjust thumbnail key and unique color list

### DIFF
--- a/app/loja/produtos/[slug]/ProdutoInterativo.tsx
+++ b/app/loja/produtos/[slug]/ProdutoInterativo.tsx
@@ -125,11 +125,15 @@ export default function ProdutoInterativo({
   );
   const [genero, setGenero] = useState(generosNorm[0]);
   const [tamanho, setTamanho] = useState(tamanhos[0]);
-  const coresList = Array.isArray(produto.cores)
-    ? produto.cores
-    : typeof produto.cores === "string"
-    ? produto.cores.split(",").map((c: string) => c.trim())
-    : [];
+  const coresList = Array.from(
+    new Set(
+      Array.isArray(produto.cores)
+        ? produto.cores
+        : typeof produto.cores === "string"
+        ? produto.cores.split(",").map((c: string) => c.trim())
+        : []
+    )
+  );
   const [cor, setCor] = useState(coresList[0] || "");
   const [indexImg, setIndexImg] = useState(0);
   const pauseRef = useRef(false);
@@ -172,7 +176,7 @@ export default function ProdutoInterativo({
         <div className="flex gap-3 mt-4">
           {imgs.map((src, i) => (
             <Image
-              key={i}
+              key={src}
               src={src}
               alt={`Miniatura ${i + 1}`}
               width={64}


### PR DESCRIPTION
## Summary
- ensure `coresList` has no duplicates before rendering
- use image src as key for product thumbnails

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_685024bec1fc832c9e20e412c3290349