### PR TITLE
refactor: use slug as map key

### DIFF
--- a/app/blog/components/BlogHeroCarousel.tsx
+++ b/app/blog/components/BlogHeroCarousel.tsx
@@ -91,9 +91,9 @@ export default function BlogHeroCarousel() {
 
         {/* Dots */}
         <div className="mt-4 flex gap-2 justify-center">
-          {posts.map((_, index) => (
+          {posts.map((post, index) => (
             <span
-              key={index}
+              key={post.slug}
               className={`w-2.5 h-2.5 rounded-full ${
                 index === currentIndex ? "bg-primary-600" : "bg-white/50"
               }`}

--- a/app/components/Hero.tsx
+++ b/app/components/Hero.tsx
@@ -89,9 +89,9 @@ export default function BlogHeroCarousel() {
         </div>
         {/* Dots */}
         <div className="mt-4 flex gap-2 justify-center">
-          {posts.map((_, index) => (
+          {posts.map((post, index) => (
             <span
-              key={index}
+              key={post.slug}
               className={`w-2.5 h-2.5 rounded-full ${
                 index === currentIndex ? "bg-blue-600" : "bg-white/50"
               }`}


### PR DESCRIPTION
## Summary
- use `post.slug` in Hero dot map
- use `post.slug` in blog hero carousel dot map

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_685024b258c4832ca9042f4b6c458d90