### PR TITLE
Fix modal positioning

### DIFF
--- a/app/admin/eventos/novo/ModalEvento.tsx
+++ b/app/admin/eventos/novo/ModalEvento.tsx
@@ -40,7 +40,7 @@ export function ModalEvento<T extends Record<string, unknown>>({
                 initial={{ opacity: 0 }}
                 animate={{ opacity: 1 }}
                 exit={{ opacity: 0 }}
-                className="fixed inset-0 bg-black/60 backdrop-blur-sm" />
+                className="fixed inset-0 flex items-center justify-center bg-black/60 backdrop-blur-sm" />
             </Dialog.Overlay>
             <Dialog.Content asChild>
               <motion.div

--- a/app/admin/perfil/components/ModalEditarPerfil.tsx
+++ b/app/admin/perfil/components/ModalEditarPerfil.tsx
@@ -70,7 +70,7 @@ export default function ModalEditarPerfil({
               initial={{ opacity: 0 }}
               animate={{ opacity: 1 }}
               exit={{ opacity: 0 }}
-              className="fixed inset-0 bg-black/60 dark:bg-black/80 backdrop-blur-sm"
+              className="fixed inset-0 flex items-center justify-center bg-black/60 dark:bg-black/80 backdrop-blur-sm"
             />
           </Dialog.Overlay>
           <Dialog.Content asChild>

--- a/app/admin/produtos/categorias/ModalCategoria.tsx
+++ b/app/admin/produtos/categorias/ModalCategoria.tsx
@@ -32,7 +32,7 @@ export default function ModalCategoria({
                 initial={{ opacity: 0 }}
                 animate={{ opacity: 1 }}
                 exit={{ opacity: 0 }}
-                className="fixed inset-0 bg-black/60 backdrop-blur-sm" />
+                className="fixed inset-0 flex items-center justify-center bg-black/60 backdrop-blur-sm" />
             </Dialog.Overlay>
             <Dialog.Content asChild>
               <motion.div

--- a/app/components/AuthModal.tsx
+++ b/app/components/AuthModal.tsx
@@ -27,7 +27,7 @@ export default function AuthModal({
                 initial={{ opacity: 0 }}
                 animate={{ opacity: 1 }}
                 exit={{ opacity: 0 }}
-                className="fixed inset-0 bg-black/60 backdrop-blur-sm" />
+                className="fixed inset-0 flex items-center justify-center bg-black/60 backdrop-blur-sm" />
             </Dialog.Overlay>
             <Dialog.Content asChild>
               <motion.div

--- a/components/ModalAnimated.tsx
+++ b/components/ModalAnimated.tsx
@@ -34,9 +34,7 @@ export default function ModalAnimated({
                 animate={{ opacity: 1, scale: 1 }}
                 exit={{ opacity: 0, scale: 0.95 }}
                 transition={{ type: "spring", stiffness: 300, damping: 20 }}
-                className="fixed top-1/2 left-1/2 -translate-x-1/2 -translate-y-1/2 
-               bg-white dark:bg-zinc-900 text-black dark:text-white 
-               p-6 rounded-xl z-[130]"
+                className="bg-white dark:bg-zinc-900 text-black dark:text-white p-6 rounded-xl z-[130]"
               >
                 {children}
               </motion.div>


### PR DESCRIPTION
## Summary
- remove fixed positioning classes from ModalAnimated content
- keep overlays centered with `flex items-center justify-center`

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_685029d1181c832cacb8faf69163fa88