### PR TITLE
Add estatisticas endpoint and balance fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -159,7 +159,23 @@ GET /admin/api/asaas/saldo
 Resposta de exemplo:
 
 ```json
-{ "saldo": 1234.56 }
+{ "balance": 1234.56 }
+```
+
+### Endpoint `/admin/api/asaas/estatisticas`
+
+Consulta estatísticas de cobranças através de `/finance/payment/statistics`.
+Todos os parâmetros da requisição são repassados ao Asaas, permitindo filtros
+como `status`, `billingType` e datas.
+
+```bash
+GET /admin/api/asaas/estatisticas?status=PENDING
+```
+
+Resposta de exemplo:
+
+```json
+{ "quantity": 1, "value": 50, "netValue": 48.01 }
 ```
 
 ### Endpoint `/admin/api/asaas/transferencia`

--- a/__tests__/api/estatisticasRoute.test.ts
+++ b/__tests__/api/estatisticasRoute.test.ts
@@ -1,0 +1,45 @@
+import { describe, it, expect, vi } from 'vitest';
+import { GET } from '../../app/admin/api/asaas/estatisticas/route';
+import { NextRequest } from 'next/server';
+
+vi.mock('../../lib/apiAuth', () => ({ requireRole: vi.fn() }));
+import { requireRole } from '../../lib/apiAuth';
+
+describe('GET /admin/api/asaas/estatisticas', () => {
+  it('retorna 403 quando requireRole falha', async () => {
+    (requireRole as unknown as { mockReturnValue: (v: any) => void }).mockReturnValue({
+      error: 'forbidden',
+      status: 403,
+    });
+    const req = new Request('http://test');
+    (req as any).nextUrl = new URL('http://test');
+    const res = await GET(req as unknown as NextRequest);
+    expect(res.status).toBe(403);
+  });
+
+  it('retorna json quando sucesso', async () => {
+    (requireRole as unknown as { mockReturnValue: (v: any) => void }).mockReturnValue({
+      pb: {
+        authStore: { isValid: true },
+        admins: { authWithPassword: vi.fn() },
+        collection: () => ({ getFirstListItem: vi.fn() }),
+      } as any,
+      user: { role: 'coordenador' },
+    });
+
+    global.fetch = vi.fn().mockResolvedValue({
+      ok: true,
+      json: () => Promise.resolve({ netValue: 10 }),
+    }) as unknown as typeof fetch;
+
+    process.env.ASAAS_API_URL = 'https://asaas';
+    process.env.ASAAS_API_KEY = 'key';
+
+    const req = new Request('http://test');
+    (req as any).nextUrl = new URL('http://test');
+    const res = await GET(req as unknown as NextRequest);
+    const body = await res.json();
+    expect(res.status).toBe(200);
+    expect(body).toEqual({ netValue: 10 });
+  });
+});

--- a/app/admin/api/asaas/estatisticas/route.ts
+++ b/app/admin/api/asaas/estatisticas/route.ts
@@ -1,0 +1,55 @@
+import { NextRequest, NextResponse } from "next/server";
+import { requireClienteFromHost } from "@/lib/clienteAuth";
+
+export async function GET(req: NextRequest) {
+  const auth = await requireClienteFromHost(req);
+  if ("error" in auth) {
+    return NextResponse.json({ error: auth.error }, { status: auth.status });
+  }
+
+  const { cliente } = auth;
+  const baseUrl = process.env.ASAAS_API_URL;
+  const apiKey = cliente.asaas_api_key || process.env.ASAAS_API_KEY || "";
+  const userAgent = cliente.nome || "qg3";
+
+  if (!baseUrl || !apiKey) {
+    return NextResponse.json(
+      { error: "Asaas não configurado" },
+      { status: 500 },
+    );
+  }
+
+  const keyHeader = apiKey.startsWith("$") ? apiKey : `$${apiKey}`;
+  const url = new URL(`${baseUrl}/finance/payment/statistics`);
+  req.nextUrl.searchParams.forEach((value, name) => {
+    url.searchParams.set(name, value);
+  });
+
+  try {
+    const res = await fetch(url.toString(), {
+      headers: {
+        accept: "application/json",
+        "access-token": keyHeader,
+        "User-Agent": userAgent,
+      },
+    });
+
+    if (!res.ok) {
+      const errorBody = await res.text();
+      console.error("Erro ao consultar estatísticas:", errorBody);
+      return NextResponse.json(
+        { error: "Falha ao consultar estatísticas" },
+        { status: 500 },
+      );
+    }
+
+    const data = await res.json();
+    return NextResponse.json(data);
+  } catch (err) {
+    console.error("Erro inesperado ao consultar estatísticas:", err);
+    return NextResponse.json(
+      { error: "Erro ao consultar estatísticas" },
+      { status: 500 },
+    );
+  }
+}

--- a/app/admin/financeiro/page.tsx
+++ b/app/admin/financeiro/page.tsx
@@ -4,16 +4,15 @@ import { useRouter } from "next/navigation";
 import { useEffect, useState } from "react";
 import { useAuthContext } from "@/lib/context/AuthContext";
 
-interface Saldo {
-  disponivel: number;
-  aLiberar: number;
-  totalRecebido: number;
+interface Statistics {
+  netValue: number;
 }
 
 export default function FinanceiroPage() {
   const { tenantId, isLoggedIn } = useAuthContext();
   const router = useRouter();
-  const [saldo, setSaldo] = useState<Saldo | null>(null);
+  const [saldoDisponivel, setSaldoDisponivel] = useState<number | null>(null);
+  const [aLiberar, setALiberar] = useState<number | null>(null);
   const [loading, setLoading] = useState(false);
 
   useEffect(() => {
@@ -25,10 +24,17 @@ export default function FinanceiroPage() {
     const fetchSaldo = async () => {
       try {
         setLoading(true);
-        const res = await fetch(`/admin/api/asaas/saldo`);
-        if (res.ok) {
-          const data = await res.json();
-          setSaldo(data);
+        const saldoRes = await fetch(`/admin/api/asaas/saldo`);
+        if (saldoRes.ok) {
+          const data: { balance: number } = await saldoRes.json();
+          setSaldoDisponivel(data.balance);
+        }
+        const statsRes = await fetch(
+          `/admin/api/asaas/estatisticas?status=PENDING`,
+        );
+        if (statsRes.ok) {
+          const stats: Statistics = await statsRes.json();
+          setALiberar(stats.netValue);
         }
       } catch (err) {
         console.error("Erro ao obter saldo:", err);
@@ -50,25 +56,15 @@ export default function FinanceiroPage() {
             <div className="card p-6 text-center">
               <h3 className="text-lg font-semibold mb-2">Saldo Disponível</h3>
               <p className="text-xl font-bold">
-                {typeof saldo?.disponivel === "number"
-                  ? `R$ ${saldo.disponivel.toFixed(2)}`
+                {typeof saldoDisponivel === "number"
+                  ? `R$ ${saldoDisponivel.toFixed(2)}`
                   : "—"}
               </p>
             </div>
             <div className="card p-6 text-center">
               <h3 className="text-lg font-semibold mb-2">A Liberar</h3>
               <p className="text-xl font-bold">
-                {typeof saldo?.aLiberar === "number"
-                  ? `R$ ${saldo.aLiberar.toFixed(2)}`
-                  : "—"}
-              </p>
-            </div>
-            <div className="card p-6 text-center">
-              <h3 className="text-lg font-semibold mb-2">Total Recebido</h3>
-              <p className="text-xl font-bold">
-                {typeof saldo?.totalRecebido === "number"
-                  ? `R$ ${saldo.totalRecebido.toFixed(2)}`
-                  : "—"}
+                {typeof aLiberar === "number" ? `R$ ${aLiberar.toFixed(2)}` : "—"}
               </p>
             </div>
           </div>

--- a/app/admin/financeiro/saldo/page.tsx
+++ b/app/admin/financeiro/saldo/page.tsx
@@ -7,10 +7,8 @@ import { saveAs } from "file-saver";
 import * as XLSX from "xlsx";
 import jsPDF from "jspdf";
 
-interface Saldo {
-  disponivel: number;
-  aLiberar: number;
-  totalRecebido: number;
+interface Statistics {
+  netValue: number;
 }
 
 interface ExtratoItem {
@@ -24,7 +22,8 @@ interface ExtratoItem {
 export default function SaldoPage() {
   const { isLoggedIn } = useAuthContext();
   const router = useRouter();
-  const [saldo, setSaldo] = useState<Saldo | null>(null);
+  const [saldoDisponivel, setSaldoDisponivel] = useState<number | null>(null);
+  const [aLiberar, setALiberar] = useState<number | null>(null);
   const [extrato, setExtrato] = useState<ExtratoItem[]>([]);
   const [loading, setLoading] = useState(false);
 
@@ -38,7 +37,15 @@ export default function SaldoPage() {
         setLoading(true);
         const saldoRes = await fetch("/admin/api/asaas/saldo");
         if (saldoRes.ok) {
-          setSaldo(await saldoRes.json());
+          const data: { balance: number } = await saldoRes.json();
+          setSaldoDisponivel(data.balance);
+        }
+        const statsRes = await fetch(
+          "/admin/api/asaas/estatisticas?status=PENDING",
+        );
+        if (statsRes.ok) {
+          const stats: Statistics = await statsRes.json();
+          setALiberar(stats.netValue);
         }
         const extratoRes = await fetch("/admin/api/asaas/extrato");
         if (extratoRes.ok) {
@@ -87,25 +94,15 @@ export default function SaldoPage() {
             <div className="card p-6 text-center">
               <h3 className="text-lg font-semibold mb-2">Saldo Disponível</h3>
               <p className="text-xl font-bold">
-                {typeof saldo?.disponivel === "number"
-                  ? `R$ ${saldo.disponivel.toFixed(2)}`
+                {typeof saldoDisponivel === "number"
+                  ? `R$ ${saldoDisponivel.toFixed(2)}`
                   : "—"}
               </p>
             </div>
             <div className="card p-6 text-center">
               <h3 className="text-lg font-semibold mb-2">A Liberar</h3>
               <p className="text-xl font-bold">
-                {typeof saldo?.aLiberar === "number"
-                  ? `R$ ${saldo.aLiberar.toFixed(2)}`
-                  : "—"}
-              </p>
-            </div>
-            <div className="card p-6 text-center">
-              <h3 className="text-lg font-semibold mb-2">Total Recebido</h3>
-              <p className="text-xl font-bold">
-                {typeof saldo?.totalRecebido === "number"
-                  ? `R$ ${saldo.totalRecebido.toFixed(2)}`
-                  : "—"}
+                {typeof aLiberar === "number" ? `R$ ${aLiberar.toFixed(2)}` : "—"}
               </p>
             </div>
           </div>

--- a/docs/saldo-transferencia-asaas.md
+++ b/docs/saldo-transferencia-asaas.md
@@ -17,7 +17,22 @@ GET /admin/api/asaas/saldo
 Resposta:
 
 ```json
-{ "saldo": 1234.56 }
+{ "balance": 1234.56 }
+```
+
+## Estatísticas de Cobranças
+
+Utilize esta rota para obter valores agregados das cobranças no Asaas. Todos os
+parâmetros enviados são repassados para `/finance/payment/statistics`.
+
+```bash
+GET /admin/api/asaas/estatisticas?status=PENDING
+```
+
+Resposta:
+
+```json
+{ "quantity": 1, "value": 50, "netValue": 48.01 }
 ```
 
 ## Transferência de Saldo

--- a/logs/DOC_LOG.md
+++ b/logs/DOC_LOG.md
@@ -112,3 +112,4 @@
 ## [2025-06-17] BankAccountModal criado com busca BrasilAPI e registro em clientes_contas_bancarias. Documentação e testes adicionados.
 ## [2025-06-16] Botão Nova conta integrado à página de Transferências com o BankAccountModal.
 ## [2025-06-17] Ajustado z-index do ModalAnimated para sobrepor a navbar e documentado no README.
+## [2025-06-16] Adicionada rota /admin/api/asaas/estatisticas e exemplos de uso no README e guia de saldo.


### PR DESCRIPTION
## Summary
- implement `/admin/api/asaas/estatisticas` route
- fetch balance and pending statistics on financeiro pages
- document estatisticas endpoint in README and guide
- log new documentation update

## Testing
- `npm run lint`
- `npm run build`
- `npm test` *(fails: 5 failed, 25 passed)*

------
https://chatgpt.com/codex/tasks/task_e_68502c0b7b54832c8afcaab9b74c3c1c