### PR TITLE
Add ClienteContaBancariaRecord type

### DIFF
--- a/__tests__/TransferenciaForm.test.tsx
+++ b/__tests__/TransferenciaForm.test.tsx
@@ -1,6 +1,7 @@
 /* @vitest-environment jsdom */
-import { describe, it, expect, vi } from 'vitest';
+import { describe, it, expect, vi, expectTypeOf } from 'vitest';
 import { render, screen } from '@testing-library/react';
+import type { ClienteContaBancariaRecord } from '../lib/bankAccounts';
 import TransferenciaForm from '@/app/admin/financeiro/transferencias/components/TransferenciaForm';
 
 vi.mock('../lib/hooks/usePocketBase', () => ({
@@ -11,11 +12,12 @@ vi.mock('../lib/context/AuthContext', () => ({
   useAuthContext: () => ({ tenantId: 'cli1' })
 }));
 
+const contasMock: ClienteContaBancariaRecord[] = [
+  { id: '1', accountName: 'Conta 1', ownerName: 'Fulano' },
+  { id: '2', accountName: 'Conta 2', ownerName: 'Beltrano' },
+];
 vi.mock('../lib/bankAccounts', () => ({
-  getBankAccountsByTenant: vi.fn().mockResolvedValue([
-    { id: '1', accountName: 'Conta 1', ownerName: 'Fulano' },
-    { id: '2', accountName: 'Conta 2', ownerName: 'Beltrano' },
-  ]),
+  getBankAccountsByTenant: vi.fn().mockResolvedValue(contasMock),
 }));
 
 describe('TransferenciaForm', () => {
@@ -25,5 +27,6 @@ describe('TransferenciaForm', () => {
     expect(options).toHaveLength(3);
     expect(options[1].textContent).toContain('Conta 1');
     expect(options[2].textContent).toContain('Conta 2');
+    expectTypeOf(contasMock).toEqualTypeOf<ClienteContaBancariaRecord[]>();
   });
 });

--- a/__tests__/bankAccounts.test.ts
+++ b/__tests__/bankAccounts.test.ts
@@ -1,5 +1,5 @@
-import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
-import { searchBanks, createBankAccount, getBankAccountsByTenant } from '../lib/bankAccounts';
+import { describe, it, expect, vi, beforeEach, afterEach, expectTypeOf } from 'vitest';
+import { searchBanks, createBankAccount, getBankAccountsByTenant, type ClienteContaBancariaRecord } from '../lib/bankAccounts';
 import type PocketBase from 'pocketbase';
 
 describe('searchBanks', () => {
@@ -106,5 +106,17 @@ describe('getBankAccountsByTenant', () => {
     expect(pb.collection).toHaveBeenCalledWith('clientes_contas_bancarias');
     expect(listMock).toHaveBeenCalledWith({ filter: "cliente='cli1'" });
     expect(contas[0].id).toBe('1');
+  });
+
+  it('retorna lista tipada', async () => {
+    const listMock = vi
+      .fn()
+      .mockResolvedValue([{ id: '1', accountName: 'Conta', ownerName: 'Fulano' }]);
+    const pb = {
+      collection: vi.fn(() => ({ getFullList: listMock })),
+    } as unknown as PocketBase;
+    const contas = await getBankAccountsByTenant(pb, 'cli1');
+    expectTypeOf(contas).toEqualTypeOf<ClienteContaBancariaRecord[]>();
+    expect(contas[0].accountName).toBe('Conta');
   });
 });

--- a/lib/bankAccounts.ts
+++ b/lib/bankAccounts.ts
@@ -34,6 +34,13 @@ export interface BankAccount {
   bankAccountType: string;
 }
 
+export interface ClienteContaBancariaRecord {
+  id: string;
+  accountName: string;
+  ownerName: string;
+  [key: string]: unknown;
+}
+
 export async function createBankAccount(
   pb: PocketBase,
   account: BankAccount,
@@ -51,8 +58,10 @@ export async function createBankAccount(
 export async function getBankAccountsByTenant(
   pb: PocketBase,
   tenantId: string
-) {
+): Promise<ClienteContaBancariaRecord[]> {
   return pb
     .collection('clientes_contas_bancarias')
-    .getFullList({ filter: `cliente='${tenantId}'` });
+    .getFullList({ filter: `cliente='${tenantId}'` }) as Promise<
+    ClienteContaBancariaRecord[]
+  >;
 }


### PR DESCRIPTION
## Summary
- add ClienteContaBancariaRecord interface for tenant bank accounts
- use new type in TransferenciaForm tests
- test typed return in bankAccounts

## Testing
- `npm run lint`
- `npm run build`
- `npx vitest run __tests__/bankAccounts.test.ts __tests__/TransferenciaForm.test.tsx` *(fails: No test files found)*
- `npm test` *(fails: several tests failing)*

------
https://chatgpt.com/codex/tasks/task_e_685069a5fb24832cbab2b6b593b5b38c