### PR TITLE
Add Pix key tests

### DIFF
--- a/__tests__/bankAccounts.test.ts
+++ b/__tests__/bankAccounts.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach, afterEach, expectTypeOf } from 'vitest';
-import { searchBanks, createBankAccount, getBankAccountsByTenant, type ClienteContaBancariaRecord } from '../lib/bankAccounts';
+import { searchBanks, createBankAccount, createPixKey, getBankAccountsByTenant, type ClienteContaBancariaRecord } from '../lib/bankAccounts';
 import type PocketBase from 'pocketbase';
 
 describe('searchBanks', () => {
@@ -92,6 +92,48 @@ describe('createBankAccount', () => {
     );
     expect(createMock).toHaveBeenCalledWith(
       expect.objectContaining({ ownerName: 'Titular', accountName: 'Conta Salario', bankAccountType: 'conta_salario' })
+    );
+  });
+});
+
+describe('createPixKey', () => {
+  it('chama a coleção clientes_pix', async () => {
+    const createMock = vi.fn().mockResolvedValue({ id: '1' });
+    const pb = {
+      collection: vi.fn(() => ({ create: createMock })),
+    } as unknown as PocketBase;
+    await createPixKey(
+      pb,
+      {
+        pixAddressKey: 'chave@pix.com',
+        pixAddressKeyType: 'email',
+        description: 'Test',
+        scheduleDate: '2024-01-01',
+      },
+      'u1',
+      'cli1'
+    );
+    expect(pb.collection).toHaveBeenCalledWith('clientes_pix');
+  });
+
+  it('inclui usuario e cliente no payload', async () => {
+    const createMock = vi.fn().mockResolvedValue({ id: '1' });
+    const pb = {
+      collection: vi.fn(() => ({ create: createMock })),
+    } as unknown as PocketBase;
+    await createPixKey(
+      pb,
+      {
+        pixAddressKey: 'a1',
+        pixAddressKeyType: 'cpf',
+        description: 'Desc',
+        scheduleDate: '2024-02-02',
+      },
+      'user2',
+      'client2'
+    );
+    expect(createMock).toHaveBeenCalledWith(
+      expect.objectContaining({ usuario: 'user2', cliente: 'client2' })
     );
   });
 });


### PR DESCRIPTION
## Summary
- add missing createPixKey tests in bankAccounts test suite
- run lint, build and tests

## Testing
- `npm run lint`
- `npm run build`
- `npx vitest run` *(fails: 6 failed, 25 passed)*

------
https://chatgpt.com/codex/tasks/task_e_68507015bdcc832ca65a836fa30ae65a