### PR TITLE
Add CPF/CNPJ validation in BankAccountModal

### DIFF
--- a/__tests__/bankAccountModal.test.tsx
+++ b/__tests__/bankAccountModal.test.tsx
@@ -1,0 +1,48 @@
+/* @vitest-environment jsdom */
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { render, screen, fireEvent } from '@testing-library/react'
+import BankAccountModal from '@/app/admin/financeiro/transferencias/modals/BankAccountModal'
+
+vi.mock('../lib/hooks/usePocketBase', () => ({
+  default: () => ({ authStore: { model: { id: 'u1', cliente: 'cli1' } } })
+}))
+
+const createBankAccount = vi.fn()
+const createPixKey = vi.fn()
+const searchBanks = vi.fn().mockResolvedValue([])
+
+vi.mock('../lib/bankAccounts', () => ({
+  searchBanks,
+  createBankAccount,
+  createPixKey,
+}))
+
+function fillBasicFields(container: HTMLElement, cpf: string, birth: string) {
+  fireEvent.change(screen.getByPlaceholderText('Nome do titular'), { target: { value: 'Fulano' }})
+  fireEvent.change(screen.getByPlaceholderText('Nome da conta'), { target: { value: 'Conta' }})
+  fireEvent.change(screen.getByPlaceholderText('CPF/CNPJ'), { target: { value: cpf }})
+  const date = container.querySelectorAll('input[type="date"]')[0] as HTMLInputElement
+  fireEvent.change(date, { target: { value: birth }})
+}
+
+describe('BankAccountModal validations', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('mostra erro quando cpf/cnpj inválido', async () => {
+    const { container } = render(<BankAccountModal open onClose={() => {}} />)
+    fillBasicFields(container, '123', '2000-01-01')
+    fireEvent.submit(container.querySelector('form') as HTMLFormElement)
+    expect(await screen.findByText('CPF/CNPJ inválido.')).toBeInTheDocument()
+    expect(createBankAccount).not.toHaveBeenCalled()
+  })
+
+  it('mostra erro quando data inválida', async () => {
+    const { container } = render(<BankAccountModal open onClose={() => {}} />)
+    fillBasicFields(container, '93541134780', '2023-13-01')
+    fireEvent.submit(container.querySelector('form') as HTMLFormElement)
+    expect(await screen.findByText('Data de nascimento inválida.')).toBeInTheDocument()
+    expect(createBankAccount).not.toHaveBeenCalled()
+  })
+})

--- a/app/admin/financeiro/transferencias/modals/BankAccountModal.tsx
+++ b/app/admin/financeiro/transferencias/modals/BankAccountModal.tsx
@@ -12,6 +12,11 @@ import {
   createPixKey,
   Bank,
 } from "@/lib/bankAccounts";
+import {
+  isValidCPF,
+  isValidCNPJ,
+  isValidDate,
+} from "@/utils/validators";
 
 interface BankAccountModalProps {
   open: boolean;
@@ -71,6 +76,15 @@ export default function BankAccountModal({ open, onClose }: BankAccountModalProp
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
     if (!user) return;
+    setErro("");
+    if (cpfCnpj && !isValidCPF(cpfCnpj) && !isValidCNPJ(cpfCnpj)) {
+      setErro("CPF/CNPJ inválido.");
+      return;
+    }
+    if (ownerBirthDate && !isValidDate(ownerBirthDate)) {
+      setErro("Data de nascimento inválida.");
+      return;
+    }
     try {
       if (type === "pix") {
         await createPixKey(


### PR DESCRIPTION
## Summary
- validate `cpfCnpj` with CPF/CNPJ rules and `ownerBirthDate` with date rule
- show error messages when invalid
- add tests covering invalid input scenarios

## Testing
- `npm run lint`
- `npm run build`
- `npm test` *(fails: asaasCheckout, api routes and validators tests)*

------
https://chatgpt.com/codex/tasks/task_e_685070021d34832c870893edb72028e2