### PR TITLE
Atualizar envio de slug e cores no cadastro de produto

### DIFF
--- a/app/admin/produtos/page.tsx
+++ b/app/admin/produtos/page.tsx
@@ -7,6 +7,16 @@ import Link from "next/link";
 import type { Produto } from "@/types";
 import { ModalProduto } from "./novo/ModalProduto";
 
+function slugify(str: string) {
+  return str
+    .normalize("NFD")
+    .replace(/[\u0300-\u036f]/g, "")
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, "-")
+    .replace(/(^-|-$)+/g, "")
+    .replace(/-+/g, "-");
+}
+
 const PRODUTOS_POR_PAGINA = 10;
 
 export default function AdminProdutosPage() {
@@ -75,6 +85,15 @@ export default function AdminProdutosPage() {
     }
     if (form.descricao) formData.set("descricao", String(form.descricao));
     if (form.detalhes) formData.set("detalhes", String(form.detalhes));
+    if (!form.slug && form.nome) {
+      form.slug = slugify(String(form.nome));
+    }
+    if (form.slug) formData.set("slug", String(form.slug));
+    if (Array.isArray(form.cores)) {
+      formData.set("cores", (form.cores as string[]).join(","));
+    } else if (form.cores) {
+      formData.set("cores", String(form.cores));
+    }
     formData.set("ativo", String(form.ativo ? "true" : "false"));
     if (form.imagens && form.imagens instanceof FileList) {
       Array.from(form.imagens).forEach((file) =>

--- a/logs/DOC_LOG.md
+++ b/logs/DOC_LOG.md
@@ -120,3 +120,4 @@
 ## [2025-06-20] BankAccountModal passa a cadastrar chaves PIX via createPixKey. README documentado.
 ## [2025-06-16] Adicionados logs nas rotas de produtos registrando host do PocketBase e usuario
 ## [2025-06-16] Removidos consoles restantes das rotas de API
+## [2025-06-21] Cadastro de produtos envia campos slug e cores


### PR DESCRIPTION
## Summary
- calcular slug e enviar campos slug/cores ao criar produto
- registrar mudança no DOC_LOG

## Testing
- `npm run lint` *(fails: Unexpected any errors in unrelated files)*
- `npm run build` *(fails: build errors in unrelated files)*

------
https://chatgpt.com/codex/tasks/task_e_685087bea0ac832c90158f1f0e261b8b