### PR TITLE
Fix slug and color handling on edit product page

### DIFF
--- a/app/admin/produtos/editar/[id]/page.tsx
+++ b/app/admin/produtos/editar/[id]/page.tsx
@@ -10,6 +10,17 @@ interface Categoria {
   slug: string;
 }
 
+// Função para gerar slug automático
+function slugify(str: string) {
+  return str
+    .normalize("NFD")
+    .replace(/[\u0300-\u036f]/g, "")
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, "-")
+    .replace(/(^-|-$)+/g, "")
+    .replace(/-+/g, "-");
+}
+
 export default function EditarProdutoPage() {
   const { id } = useParams<{ id: string }>();
   const { user: ctxUser, isLoggedIn } = useAuthContext();
@@ -141,6 +152,9 @@ export default function EditarProdutoPage() {
     const formElement = e.currentTarget as HTMLFormElement;
     const formData = new FormData(formElement);
 
+    const slug = slugify(formElement.nome.value);
+    formData.set("slug", slug);
+
     // Tratamento específico para o campo de imagens
     const imagensInput = formElement.querySelector<HTMLInputElement>(
       "input[name='imagens']"
@@ -154,10 +168,7 @@ export default function EditarProdutoPage() {
     }
 
     // Trata o campo de cores: insere como string separada por vírgula
-    formData.delete("cores");
-    if (cores.length > 0) {
-      formData.append("cores", cores.join(","));
-    }
+    formData.set("cores", cores.join(","));
     // Normaliza checkboxes e arrays
     const ativoChecked = formElement.querySelector<HTMLInputElement>(
       "input[name='ativo']"

--- a/logs/DOC_LOG.md
+++ b/logs/DOC_LOG.md
@@ -120,3 +120,5 @@
 ## [2025-06-20] BankAccountModal passa a cadastrar chaves PIX via createPixKey. README documentado.
 ## [2025-06-16] Adicionados logs nas rotas de produtos registrando host do PocketBase e usuario
 ## [2025-06-16] Removidos consoles restantes das rotas de API
+
+## [2025-06-16] Corrigida atualização de slug e cores ao editar produto.


### PR DESCRIPTION
## Summary
- add slugify helper to edit product page
- store slug from name field when saving edits
- always set cores field even if empty
- document fix in DOC_LOG

## Testing
- `npm run lint` *(fails: next not found)*
- `npm run build` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_685088883588832c98e82c0c7da45b3a