### PR TITLE
Rename collection to clientes_config

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -2,7 +2,7 @@
 NEXT_PUBLIC_PB_URL=
 PB_ADMIN_EMAIL=
 PB_ADMIN_PASSWORD=
-# Opcional. O backend procura primeiro `asaas_api_key` em `m24_clientes`.
+# Opcional. O backend procura primeiro `asaas_api_key` em `clientes_config`.
 ASAAS_API_KEY=
 ASAAS_WEBHOOK_SECRET=
 NEXT_PUBLIC_SITE_URL=

--- a/README.md
+++ b/README.md
@@ -88,7 +88,7 @@ Crie um arquivo `.env.local` na raiz e defina as seguintes variáveis:
 
 Os servidores identificam automaticamente o tenant pelo domínio de cada requisição usando `getTenantFromHost`.
 
-Cada registro em `m24_clientes` contém o campo `asaas_api_key`. A aplicação busca a chave correta deste cliente antes de criar cobranças ou checkouts, garantindo que cada subconta do Asaas seja utilizada separadamente.
+Cada registro em `clientes_config` contém o campo `asaas_api_key`. A aplicação busca a chave correta deste cliente antes de criar cobranças ou checkouts, garantindo que cada subconta do Asaas seja utilizada separadamente.
 
 Esta integração realiza chamadas HTTP diretamente na API do Asaas, sem utilizar o SDK oficial.
 

--- a/app/admin/api/configuracoes/route.ts
+++ b/app/admin/api/configuracoes/route.ts
@@ -10,7 +10,7 @@ export async function GET(req: NextRequest) {
   const { pb, user } = auth;
   try {
     const cliente = await pb
-      .collection("m24_clientes")
+      .collection("clientes_config")
       .getOne(user.cliente);
     return NextResponse.json(
       {
@@ -34,7 +34,7 @@ export async function PUT(req: NextRequest) {
   const { pb, user } = auth;
   try {
     const { cor_primary, logo_url, font } = await req.json();
-    const cliente = await pb.collection("m24_clientes").update(user.cliente, {
+    const cliente = await pb.collection("clientes_config").update(user.cliente, {
       cor_primary,
       logo_url,
       font,

--- a/app/api/asaas/webhook/route.ts
+++ b/app/api/asaas/webhook/route.ts
@@ -69,7 +69,7 @@ export async function POST(req: NextRequest) {
   if (accountId) {
     try {
       const c = await pb
-        .collection("m24_clientes")
+        .collection("clientes_config")
         .getFirstListItem(`asaas_account_id = "${accountId}"`);
       clienteApiKey = c?.asaas_api_key ?? null;
       clienteId = c?.id ?? null;
@@ -93,7 +93,7 @@ export async function POST(req: NextRequest) {
 
   if (!clienteApiKey && clienteId) {
     try {
-      const c = await pb.collection("m24_clientes").getOne(clienteId);
+      const c = await pb.collection("clientes_config").getOne(clienteId);
       clienteApiKey = c?.asaas_api_key ?? null;
       clienteNome = c?.nome ?? null;
     } catch {

--- a/app/api/register/route.ts
+++ b/app/api/register/route.ts
@@ -11,7 +11,7 @@ export async function POST(req: NextRequest) {
       return NextResponse.json({ error: "Dados inv\u00E1lidos" }, { status: 400 });
     }
     try {
-      await pb.collection("m24_clientes").getOne(String(cliente));
+      await pb.collection("clientes_config").getOne(String(cliente));
     } catch {
       return NextResponse.json({ error: "Cliente não encontrado" }, { status: 404 });
     }

--- a/app/blog/BlogClient.tsx
+++ b/app/blog/BlogClient.tsx
@@ -30,14 +30,14 @@ export default function BlogClient() {
         const tenantId = localStorage.getItem("tenant_id");
         if (tenantId) {
           const c = await pb
-            .collection("m24_clientes")
+            .collection("clientes_config")
             .getOne<Cliente>(tenantId);
           setNomeCliente(c.nome ?? "");
           return;
         }
         const dominio = window.location.hostname;
         const c = await pb
-          .collection("m24_clientes")
+          .collection("clientes_config")
           .getFirstListItem<Cliente>(`dominio='${dominio}'`);
         localStorage.setItem("tenant_id", c.id);
         setNomeCliente(c.nome ?? "");

--- a/app/components/SignUpForm.tsx
+++ b/app/components/SignUpForm.tsx
@@ -41,7 +41,7 @@ export default function SignUpForm({
         let tenantId = localStorage.getItem("tenant_id");
         if (!tenantId) {
           const cliente = await pb
-            .collection("m24_clientes")
+            .collection("clientes_config")
             .getFirstListItem(`dominio='${window.location.hostname}'`);
           tenantId = cliente?.id;
           if (tenantId) {

--- a/app/loja/page.tsx
+++ b/app/loja/page.tsx
@@ -27,7 +27,7 @@ export default function Home() {
           const host = window.location.hostname;
           try {
             const cliente = await pb
-              .collection("m24_clientes")
+              .collection("clientes_config")
               .getFirstListItem(`dominio='${host}'`);
             tenantId = cliente.id;
             localStorage.setItem("tenant_id", tenantId);

--- a/docs/design-system.md
+++ b/docs/design-system.md
@@ -190,6 +190,6 @@ O portal permite ajustar fonte, cor primária e logotipo dinamicamente. As confi
 Ao montar, o provedor busca as preferências em `/admin/api/configuracoes` e, caso a requisição falhe, utiliza o valor salvo no `localStorage`.
 Quando `updateConfig` é chamado, os dados são enviados para essa mesma rota e gravados no `localStorage`, mantendo navegador e PocketBase sincronizados.
 
-As personalizações agora também são persistidas na coleção `m24_clientes.cor_primaria`, evitando perda de dados entre dispositivos.
+As personalizações agora também são persistidas na coleção `clientes_config.cor_primaria`, evitando perda de dados entre dispositivos.
 
 Além de definir `--accent`, o provedor gera uma paleta HSL e expõe as variáveis `--primary-50` … `--primary-900`. Essas variáveis são mapeadas para classes Tailwind (`bg-primary-*`, `text-primary-*`), eliminando a necessidade de usar `bg-[var(--primary-600)]` ou `text-[var(--primary-500)]`.

--- a/docs/plano-negocio.md
+++ b/docs/plano-negocio.md
@@ -4,7 +4,7 @@ Implementamos a base multi-tenant do sistema no banco usando PocketBase, já pre
 
 ## Estrutura das Coleções
 
-### 1. m24_clientes
+### 1. clientes_config
 - Cadastro central de cada cliente (tenant).
 - Campo `documento` (CPF ou CNPJ) obrigatório e único, para identificação fiscal e integrações.
 
@@ -64,7 +64,7 @@ As rotas de servidor (`/api`) chamam `getTenantFromHost` para identificar o clie
 ## 1. Uso de Subcontas e API Key do Asaas
 
 * **Cada cliente (tenant) possui sua própria subconta no Asaas.**
-* Para cada subconta, armazene com segurança a respectiva **API Key** (ex: campo `asaas_api_key` na coleção `m24_clientes`).
+* Para cada subconta, armazene com segurança a respectiva **API Key** (ex: campo `asaas_api_key` na coleção `clientes_config`).
 * Toda operação de cobrança, consulta ou emissão de pagamento deve sempre utilizar a **API Key da subconta do cliente envolvido**.
 * **Nunca exponha a API Key de nenhuma subconta no frontend.** Toda requisição ao Asaas deve ser feita via backend, buscando a chave correta do cliente antes de qualquer chamada.
 
@@ -78,7 +78,7 @@ As rotas de servidor (`/api`) chamam `getTenantFromHost` para identificar o clie
 * Ao receber uma notificação:
 
   1. **Identifique a subconta do evento** (usando `accountId` do payload ou relacionando pelo `id_pagamento` ao pedido/inscrição).
-  2. Busque no banco o cliente dono da subconta (`m24_clientes.asaas_api_key` ou `m24_clientes.asaas_account_id`).
+  2. Busque no banco o cliente dono da subconta (`clientes_config.asaas_api_key` ou `clientes_config.asaas_account_id`).
   3. Atualize registros apenas desse cliente.
   4. Registre/logue o evento para conciliação.
 
@@ -88,7 +88,7 @@ As rotas de servidor (`/api`) chamam `getTenantFromHost` para identificar o clie
 
   ```js
   // Exemplo: buscar chave da subconta
-  const cliente = await pb.collection('m24_clientes').getOne(CLIENTE_ID)
+  const cliente = await pb.collection('clientes_config').getOne(CLIENTE_ID)
   const apiKey = cliente.asaas_api_key
   // Usar apiKey na autenticação das chamadas
   ```

--- a/lib/clienteAuth.ts
+++ b/lib/clienteAuth.ts
@@ -31,7 +31,7 @@ export async function requireClienteFromHost(
 
   try {
     const cliente = await pb
-      .collection("m24_clientes")
+      .collection("clientes_config")
       .getFirstListItem(`dominio = \"${host}\"`);
     if (!cliente) {
       return { error: "Cliente n\u00e3o encontrado", status: 404 };

--- a/lib/context/AppConfigContext.tsx
+++ b/lib/context/AppConfigContext.tsx
@@ -37,7 +37,7 @@ export function AppConfigProvider({ children }: { children: React.ReactNode }) {
         const pb = createPocketBase();
         const dominio = window.location.hostname;
         const cliente = await pb
-          .collection("m24_clientes")
+          .collection("clientes_config")
           .getFirstListItem(`dominio='${dominio}'`);
         const cfg: AppConfig = {
           font: cliente.font || defaultConfig.font,

--- a/lib/context/AuthContext.tsx
+++ b/lib/context/AuthContext.tsx
@@ -104,7 +104,7 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
     const dominio = window.location.hostname;
     try {
       const cliente = await pb
-        .collection("m24_clientes")
+        .collection("clientes_config")
         .getFirstListItem(`dominio='${dominio}'`);
       localStorage.setItem("tenant_id", cliente.id);
       setTenantId(cliente.id);
@@ -137,7 +137,7 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
     let clienteId: string | null = null;
     try {
       const cliente = await pb
-        .collection("m24_clientes")
+        .collection("clientes_config")
         .getFirstListItem(`dominio='${dominio}'`);
       clienteId = cliente.id;
       localStorage.setItem("tenant_id", clienteId);

--- a/lib/getTenantFromHost.ts
+++ b/lib/getTenantFromHost.ts
@@ -9,7 +9,7 @@ export async function getTenantFromHost(): Promise<string | null> {
   const pb = createPocketBase();
   try {
     const cliente = await pb
-      .collection("m24_clientes")
+      .collection("clientes_config")
       .getFirstListItem(`dominio='${host}'`);
     return cliente?.id ?? null;
   } catch {

--- a/logs/DOC_LOG.md
+++ b/logs/DOC_LOG.md
@@ -120,3 +120,4 @@
 ## [2025-06-20] BankAccountModal passa a cadastrar chaves PIX via createPixKey. README documentado.
 ## [2025-06-16] Adicionados logs nas rotas de produtos registrando host do PocketBase e usuario
 ## [2025-06-16] Removidos consoles restantes das rotas de API
+## [2025-06-20] Coleção m24_clientes renomeada para clientes_config em códigos e docs.


### PR DESCRIPTION
## Summary
- use `clientes_config` collection name across TS/JS files
- update environment example and documentation
- log change in DOC_LOG

## Testing
- `npx next lint` *(fails: Unexpected any, parsing error)*
- `npx next build` *(fails: syntax errors in existing code)*

------
https://chatgpt.com/codex/tasks/task_e_685086fcc634832cb0103d7daea8ee2d