### PR TITLE
Update theme collection docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,7 @@ Este repositório reúne portal institucional, blog, loja virtual e painel admin
 Visitantes navegam pelo portal e pelo blog, realizam compras na loja e os coordenadores gerenciam tudo pelo admin.
 Consulte [arquitetura.md](arquitetura.md) para entender a divisão de pastas e responsabilidades.
 Para personalizar a interface utilize as orientações de [docs/design-system.md](docs/design-system.md).
+As preferências de fonte, cor e logotipo ficam nos campos `font`, `cor_primaria` e `logo_url` da coleção `m24_clientes`.
 Para um passo a passo inicial do sistema consulte [docs/iniciar-tour.md](docs/iniciar-tour.md).
 Coordenadores podem iniciar o tour clicando no ícone de mapa ao lado do sino de notificações no painel admin ou acessando `/iniciar-tour` diretamente.
 

--- a/docs/design-system.md
+++ b/docs/design-system.md
@@ -190,6 +190,6 @@ O portal permite ajustar fonte, cor primária e logotipo dinamicamente. As confi
 Ao montar, o provedor busca as preferências em `/admin/api/configuracoes` e, caso a requisição falhe, utiliza o valor salvo no `localStorage`.
 Quando `updateConfig` é chamado, os dados são enviados para essa mesma rota e gravados no `localStorage`, mantendo navegador e PocketBase sincronizados.
 
-As personalizações agora também são persistidas na coleção `m24_clientes.cor_primaria`, evitando perda de dados entre dispositivos.
+As personalizações agora também são persistidas nos campos `logo_url`, `cor_primaria` e `font` da coleção `m24_clientes`, evitando perda de dados entre dispositivos.
 
 Além de definir `--accent`, o provedor gera uma paleta HSL e expõe as variáveis `--primary-50` … `--primary-900`. Essas variáveis são mapeadas para classes Tailwind (`bg-primary-*`, `text-primary-*`), eliminando a necessidade de usar `bg-[var(--primary-600)]` ou `text-[var(--primary-500)]`.

--- a/logs/DOC_LOG.md
+++ b/logs/DOC_LOG.md
@@ -95,7 +95,7 @@
 ## [2025-06-13] Documentadas seções de LoadingOverlay, SmoothTabs e ModalAnimated no design system.
 ## [2025-06-12] Corrigido uso da variável PB_URL na rota de recuperação de link. Agora utiliza NEXT_PUBLIC_PB_URL e README/.env.example atualizados. Impacto: padronização das variáveis de ambiente.
 ## [2025-06-14] Removidas entradas duplicadas de dependências e atualizado package-lock.json.
-## [2025-06-14] Personalizacao salva em m24_clientes.cor_primaria
+## [2025-06-14] Personalizacao salva nos campos cor_primaria, logo_url e font da colecao m24_clientes
 ## [2025-06-13] Documentada persistência das configurações no design system.
 ## [2025-06-15] Documentadas rotas de saldo e transferencia do Asaas no README e novo guia saldo-transferencia-asaas.md.
 ## [2025-06-13] Especificado no README que apenas coordenadores visualizam métricas financeiras; líderes veem somente contagens de inscrições e pedidos.
@@ -123,3 +123,4 @@
 ## [2025-06-21] Cadastro de produtos envia campos slug e cores
 
 ## [2025-06-16] Corrigida atualização de slug e cores ao editar produto.
+## [2025-06-22] Documentacao revisada para indicar que cor_primaria, logo_url e font ficam em m24_clientes


### PR DESCRIPTION
## Summary
- document that theme settings are stored in `m24_clientes`
- mention fields in README
- clarify historical log entry about theme persistence

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68508b95d2f4832c875585ae8ed965f1