### PR TITLE
Add PIX support for transfers

### DIFF
--- a/README.md
+++ b/README.md
@@ -182,17 +182,34 @@ Resposta de exemplo:
 
 Envia uma transferência do saldo do Asaas para a conta bancária cadastrada. Requisição `POST` com o seguinte payload:
 
+Para contas bancárias:
+
 ```json
 {
-  "valor": 150.75,
+  "value": 150.75,
   "bankAccountId": "acc_123",
-  "descricao": "Repasse loja junho/2025"
+  "description": "Repasse loja junho/2025"
 }
 ```
 
-- **valor** – valor a transferir em reais.
-- **bankAccountId** – código da conta bancária de destino.
-- **descricao** – texto opcional para identificar a transferência.
+Para PIX:
+
+```json
+{
+  "value": 150.75,
+  "pixAddressKey": "a@b.com",
+  "pixAddressKeyType": "email",
+  "description": "Repasse loja junho/2025",
+  "scheduleDate": "2025-08-20"
+}
+```
+
+- **value** – valor a transferir em reais.
+- **bankAccountId** – código da conta bancária de destino (quando conta bancária).
+- **pixAddressKey** – chave PIX de destino.
+- **pixAddressKeyType** – tipo da chave PIX (`cpf`, `email`, `phone` etc.).
+- **description** – texto opcional para identificar a transferência.
+- **scheduleDate** – data de agendamento (opcional e apenas para PIX).
 
 Essas rotas utilizam a chave do Asaas de cada cliente (tenant) conforme descrito em [docs/plano-negocio.md](docs/plano-negocio.md).
 

--- a/app/admin/api/asaas/transferencia/route.ts
+++ b/app/admin/api/asaas/transferencia/route.ts
@@ -1,6 +1,5 @@
 import { NextRequest, NextResponse } from "next/server";
 import { requireClienteFromHost } from "@/lib/clienteAuth";
-import { logInfo } from "@/lib/logger";
 import { logConciliacaoErro } from "@/lib/server/logger";
 
 export async function POST(req: NextRequest) {
@@ -19,8 +18,6 @@ export async function POST(req: NextRequest) {
       { status: 500 },
     );
   }
-
-  logInfo("🔑 API Key utilizada:", apiKey);
 
   const keyHeader = apiKey.startsWith("$") ? apiKey : `$${apiKey}`;
 
@@ -80,8 +77,6 @@ export async function DELETE(req: NextRequest) {
   if (!id) {
     return NextResponse.json({ error: "Id obrigatório" }, { status: 400 });
   }
-
-  logInfo("🔑 API Key utilizada:", apiKey);
 
   const keyHeader = apiKey.startsWith("$") ? apiKey : `$${apiKey}`;
 

--- a/app/admin/api/produtos/[id]/route.ts
+++ b/app/admin/api/produtos/[id]/route.ts
@@ -64,9 +64,8 @@ export async function PUT(req: NextRequest) {
     console.log("PUT /produtos - produto atualizado:", produto);
 
     return NextResponse.json(produto, { status: 200 });
-  } catch (err: any) {
-    // Para TS não reclamar:
-    const pocketError = (err as any)?.response || (err as any);
+  } catch (err: unknown) {
+    const pocketError = (err as { response?: unknown } | undefined)?.response || err;
     console.error("PUT /produtos - erro:", err);
     console.error(
       "PocketBase erro detalhado:",

--- a/app/admin/financeiro/transferencias/components/TransferenciaForm.tsx
+++ b/app/admin/financeiro/transferencias/components/TransferenciaForm.tsx
@@ -14,7 +14,9 @@ interface TransferenciaFormProps {
   onTransfer?: (
     destino: string,
     valor: number,
-    description: string
+    description: string,
+    isPix: boolean,
+    pixKey?: PixKeyRecord
   ) => Promise<void> | void;
 }
 
@@ -61,7 +63,8 @@ export default function TransferenciaForm({
     }
     setLoading(true);
     try {
-      await onTransfer?.(destino, parsed, description);
+      const pixKey = isPix ? (selected as PixKeyRecord & { kind: "pix" }) : undefined;
+      await onTransfer?.(destino, parsed, description, isPix, pixKey);
     } catch {
       setErro("Erro ao transferir.");
     } finally {

--- a/app/loja/produtos/[slug]/page.tsx
+++ b/app/loja/produtos/[slug]/page.tsx
@@ -111,15 +111,22 @@ export default function ProdutoDetalhe() {
       </Suspense>
     </main>
   );
+// O bloco abaixo era referente a uma rota de API e foi mantido comentado para
+// consulta futura, evitando erro de parsing no lint.
+/*
 } catch (err) {
   console.error("PUT /produtos - erro:", err);
-  // Mostrar resposta detalhada
   const anyErr = err as any;
   if (anyErr?.response) {
-    console.error("PocketBase erro detalhado:", JSON.stringify(anyErr.response, null, 2));
+    console.error(
+      "PocketBase erro detalhado:",
+      JSON.stringify(anyErr.response, null, 2)
+    );
   }
   await logConciliacaoErro(
     `Erro ao atualizar produto ${id}: ${String(err)} | host: ${pb.baseUrl} | user: ${user.id}`,
   );
   return NextResponse.json({ error: anyErr?.response || String(err) }, { status: 400 });
+}
+*/
 }

--- a/docs/saldo-transferencia-asaas.md
+++ b/docs/saldo-transferencia-asaas.md
@@ -37,11 +37,26 @@ Resposta:
 
 ## Transferência de Saldo
 
+
+Para contas bancárias:
+
 ```json
 {
-  "valor": 150.75,
+  "value": 150.75,
   "bankAccountId": "acc_123",
-  "descricao": "Repasse loja junho/2025"
+  "description": "Repasse loja junho/2025"
+}
+```
+
+Para chaves PIX:
+
+```json
+{
+  "value": 150.75,
+  "pixAddressKey": "a@b.com",
+  "pixAddressKeyType": "email",
+  "description": "Repasse loja junho/2025",
+  "scheduleDate": "2025-08-20" // opcional
 }
 ```
 

--- a/logs/DOC_LOG.md
+++ b/logs/DOC_LOG.md
@@ -120,3 +120,4 @@
 ## [2025-06-20] BankAccountModal passa a cadastrar chaves PIX via createPixKey. README documentado.
 ## [2025-06-16] Adicionados logs nas rotas de produtos registrando host do PocketBase e usuario
 ## [2025-06-16] Removidos consoles restantes das rotas de API
+## [2025-06-20] Atualizado guia e README de transferências incluindo suporte a PIX e formato `value` do payload.

--- a/stories/TransferenciaForm.stories.tsx
+++ b/stories/TransferenciaForm.stories.tsx
@@ -1,6 +1,7 @@
 import type { Meta, StoryObj } from '@storybook/nextjs';
 import { within, userEvent, expect } from 'storybook/test';
 import TransferenciaForm from '../app/admin/financeiro/transferencias/components/TransferenciaForm';
+import type { PixKeyRecord } from '../lib/bankAccounts';
 
 const meta = {
   title: 'Design System/TransferenciaForm',
@@ -16,13 +17,25 @@ type Story = StoryObj<typeof meta>;
 
 export const Sucesso: Story = {
   args: {
-    onTransfer: async (_d: string, _v: number, _desc: string) => {},
+    onTransfer: async (
+      _d: string,
+      _v: number,
+      _desc: string,
+      _isPix: boolean,
+      _pix?: PixKeyRecord
+    ) => {},
   },
 };
 
 export const ErroTransferencia: Story = {
   args: {
-    onTransfer: async (_d: string, _v: number, _desc: string) => {
+    onTransfer: async (
+      _d: string,
+      _v: number,
+      _desc: string,
+      _isPix: boolean,
+      _pix?: PixKeyRecord
+    ) => {
       throw new Error('fail');
     },
   },


### PR DESCRIPTION
## Summary
- expose isPix and pix data from TransferenciaForm
- build correct payload in transfer page
- document PIX payloads in README and docs
- remove API key logs from transfer route
- update docs log

## Testing
- `npm run lint`
- `npm run build`
- `npm test` *(fails: checkout route, validators, asaasRoute, estatisticasRoute, extratoRoute)*

------
https://chatgpt.com/codex/tasks/task_e_685087f2ed88832c83d521e66e7847e6