### PR TITLE
Map tenants via clientes_config

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -2,7 +2,8 @@
 NEXT_PUBLIC_PB_URL=
 PB_ADMIN_EMAIL=
 PB_ADMIN_PASSWORD=
-# Opcional. O backend procura primeiro `asaas_api_key` em `m24_clientes`.
+# Opcional. O backend procura primeiro `asaas_api_key` em `m24_clientes`,
+# associado ao domínio via `clientes_config`.
 ASAAS_API_KEY=
 ASAAS_WEBHOOK_SECRET=
 NEXT_PUBLIC_SITE_URL=

--- a/README.md
+++ b/README.md
@@ -86,9 +86,9 @@ Crie um arquivo `.env.local` na raiz e defina as seguintes variáveis:
 - `NEXT_PUBLIC_SITE_URL` - endereço do site do cliente
 - `NEXT_PUBLIC_BRASILAPI_URL` - base para chamadas à BrasilAPI
 
-Os servidores identificam automaticamente o tenant pelo domínio de cada requisição usando `getTenantFromHost`.
+Os servidores identificam automaticamente o tenant pelo domínio de cada requisição usando `getTenantFromHost`, que consulta a coleção `clientes_config` para descobrir o ID do cliente.
 
-Cada registro em `m24_clientes` contém o campo `asaas_api_key`. A aplicação busca a chave correta deste cliente antes de criar cobranças ou checkouts, garantindo que cada subconta do Asaas seja utilizada separadamente.
+Com esse ID, o backend acessa `m24_clientes` e obtém as credenciais `asaas_api_key` e `asaas_account_id` da subconta correspondente, garantindo que cada domínio utilize sua própria chave Asaas.
 
 Esta integração realiza chamadas HTTP diretamente na API do Asaas, sem utilizar o SDK oficial.
 

--- a/docs/plano-negocio.md
+++ b/docs/plano-negocio.md
@@ -25,7 +25,12 @@ Implementamos a base multi-tenant do sistema no banco usando PocketBase, já pre
 | `responsavel_email` | E-mail de contato do responsável. |
 | `ativo` | Indica se o cliente está ativo no sistema. |
 | `created` | Data de criação do cadastro. |
-### 2. Coleções filhas (usuarios, produtos, pedidos, inscricoes)
+
+### 2. clientes_config
+- Mapeia cada domínio para o ID do cliente correspondente (`cliente`).
+- Serve de ponte para que funções como `getTenantFromHost` identifiquem o tenant a partir do hostname.
+
+### 3. Coleções filhas (usuarios, produtos, pedidos, inscricoes)
 - Todas possuem campo de relação obrigatória `cliente` (referência à coleção `clientes`).
 - Isso garante que todo registro esteja sempre vinculado a um cliente.
 
@@ -46,7 +51,7 @@ Implementamos a base multi-tenant do sistema no banco usando PocketBase, já pre
 
 - O escopo do usuário (coordenador, lider, usuario) deve ser respeitado dentro do tenant.
 
-As rotas de servidor (`/api`) chamam `getTenantFromHost` para identificar o cliente pelo domínio da requisição, garantindo o isolamento automático entre tenants.
+As rotas de servidor (`/api`) chamam `getTenantFromHost` para identificar o cliente pelo domínio. Essa função consulta `clientes_config` e retorna o ID que será usado para buscar as credenciais em `m24_clientes`.
 
 ## Benefícios
 

--- a/docs/saldo-transferencia-asaas.md
+++ b/docs/saldo-transferencia-asaas.md
@@ -6,7 +6,7 @@ Este guia explica como consultar o saldo e realizar transferências usando as ro
 
 1. **Permissões** – apenas coordenadores autenticados podem acessar essas rotas.
 2. **externalReference** – todas as transações devem incluir um `externalReference` no formato `cliente_<idCliente>_usuario_<idUsuario>[_inscricao_<id>]`, conforme [docs/plano-negocio.md](./plano-negocio.md).
-3. **Chave API** – a aplicação busca a `asaas_api_key` da subconta do cliente (tenant) antes de contatar o Asaas, garantindo o isolamento multi-tenant.
+3. **Chave API** – a aplicação identifica o cliente pelo domínio em `clientes_config` e busca `asaas_api_key` e `asaas_account_id` em `m24_clientes` antes de contatar o Asaas, garantindo o isolamento multi-tenant.
 
 ## Consulta de Saldo
 

--- a/lib/clienteAuth.ts
+++ b/lib/clienteAuth.ts
@@ -30,12 +30,13 @@ export async function requireClienteFromHost(
   }
 
   try {
-    const cliente = await pb
-      .collection("m24_clientes")
+    const cfg = await pb
+      .collection("clientes_config")
       .getFirstListItem(`dominio = \"${host}\"`);
-    if (!cliente) {
+    if (!cfg) {
       return { error: "Cliente n\u00e3o encontrado", status: 404 };
     }
+    const cliente = await pb.collection("m24_clientes").getOne(cfg.cliente);
     return { pb, cliente };
   } catch {
     return { error: "Cliente n\u00e3o encontrado", status: 404 };

--- a/lib/getTenantFromHost.ts
+++ b/lib/getTenantFromHost.ts
@@ -8,10 +8,10 @@ export async function getTenantFromHost(): Promise<string | null> {
 
   const pb = createPocketBase();
   try {
-    const cliente = await pb
-      .collection("m24_clientes")
+    const cfg = await pb
+      .collection("clientes_config")
       .getFirstListItem(`dominio='${host}'`);
-    return cliente?.id ?? null;
+    return cfg?.cliente ?? null;
   } catch {
     return null;
   }

--- a/logs/DOC_LOG.md
+++ b/logs/DOC_LOG.md
@@ -123,3 +123,4 @@
 ## [2025-06-21] Cadastro de produtos envia campos slug e cores
 
 ## [2025-06-16] Corrigida atualização de slug e cores ao editar produto.
+## [2025-06-22] Domínios agora mapeados em `clientes_config`; credenciais Asaas mantidas em `m24_clientes`. Documentação e exemplos atualizados.


### PR DESCRIPTION
## Summary
- map host to tenant in `requireClienteFromHost`
- fetch tenant id from `clientes_config` in `getTenantFromHost`
- document new tenant lookup in README and business docs
- note Asaas keys remain in `m24_clientes`
- update env example and DOC_LOG

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68508b78d290832cb4092036df86c648