### PR TITLE
Atualiza rota inscricoes para usar eventoId

### DIFF
--- a/__tests__/orderFlow.test.ts
+++ b/__tests__/orderFlow.test.ts
@@ -8,6 +8,7 @@ const dadosValidos = {
   cpf: '12345678900',
   data_nascimento: '2000-01-01',
   genero: 'masculino',
+  evento: 'evt1',
   liderId: 'lider1',
   produto: 'Somente Pulseira',
   tamanho: 'M'
@@ -23,6 +24,9 @@ describe('Fluxo de inscrição e pedido', () => {
   it('falha quando campos obrigatórios estão vazios', () => {
     expect(() =>
       criarInscricao({ ...dadosValidos, nome: '' })
+    ).toThrow()
+    expect(() =>
+      criarInscricao({ ...dadosValidos, evento: '' })
     ).toThrow()
   })
 

--- a/app/admin/api/inscricoes/route.ts
+++ b/app/admin/api/inscricoes/route.ts
@@ -9,6 +9,7 @@ interface DadosInscricao {
   cpf: string;
   data_nascimento: string;
   genero: string;
+  /** ID do evento */
   evento: string;
   campo: string;
   criado_por: string;
@@ -33,6 +34,8 @@ export async function POST(req: NextRequest) {
       produto,
       genero,
       liderId,
+      eventoId,
+      evento: eventoBody,
     } = body;
 
     // Limpa CPF e telefone
@@ -40,6 +43,8 @@ export async function POST(req: NextRequest) {
     const telefoneNumerico = telefone.replace(/\D/g, "");
 
     // Validação de campos obrigatórios
+    const eventoIdFinal: string | undefined = eventoId || eventoBody;
+
     const camposObrigatorios = [
       nome,
       email,
@@ -48,6 +53,7 @@ export async function POST(req: NextRequest) {
       data_nascimento,
       genero,
       liderId,
+      eventoIdFinal,
     ];
 
     if (camposObrigatorios.some((campo) => !campo || campo.trim() === "")) {
@@ -100,7 +106,7 @@ export async function POST(req: NextRequest) {
       cpf: cpfNumerico,
       data_nascimento,
       genero,
-      evento: "Congresso UMADEUS 2K25",
+      evento: eventoIdFinal!,
       campo: campoId,
       criado_por: liderId,
       status: "pendente",

--- a/lib/flows/orderFlow.ts
+++ b/lib/flows/orderFlow.ts
@@ -7,6 +7,7 @@ export type DadosInscricao = {
   cpf: string
   data_nascimento: string
   genero: string
+  evento: string
   liderId: string
   produto: string
   tamanho?: string
@@ -22,7 +23,8 @@ export function criarInscricao(dados: DadosInscricao): Inscricao {
     dados.cpf,
     dados.data_nascimento,
     dados.genero,
-    dados.liderId
+    dados.liderId,
+    dados.evento
   ]
 
   if (obrigatorios.some(v => !v || v.trim() === '')) {
@@ -34,7 +36,7 @@ export function criarInscricao(dados: DadosInscricao): Inscricao {
     nome: dados.nome,
     telefone: dados.telefone,
     cpf: dados.cpf,
-    evento: 'Congresso UMADEUS 2K25',
+    evento: dados.evento,
     tamanho: dados.tamanho,
     produto: dados.produto,
     genero: dados.genero,

--- a/logs/DOC_LOG.md
+++ b/logs/DOC_LOG.md
@@ -126,3 +126,5 @@
 ## [2025-06-22] Domínios agora mapeados em `clientes_config`; credenciais Asaas mantidas em `m24_clientes`. Documentação e exemplos atualizados.
 ## [2025-06-22] Documentacao revisada para indicar que cor_primary, logo_url e font ficam em clientes_config
 ## [2025-06-20] Atualizado guia e README de transferências incluindo suporte a PIX e formato `value` do payload.
+
+## [2025-06-16] Rota de inscrições agora aceita eventoId no corpo e campo evento armazena o ID. OrderFlow e testes atualizados. Lint e build executados com erros em arquivos não relacionados.


### PR DESCRIPTION
## Summary
- ler `eventoId` no corpo do POST de inscricoes
- repassar id para `dadosInscricao.evento`
- aceitar evento no tipo do fluxo de pedidos
- atualizar testes de `orderFlow`
- registrar mudança em `DOC_LOG.md`

## Testing
- `npm run lint` *(fails: prefer-const, no-unused-vars)*
- `npm run build` *(fails at lint step)*
- `npm test` *(fails: multiple failing tests)*

------
https://chatgpt.com/codex/tasks/task_e_6850966426d4832ca7c09fde06ebcb31