### PR TITLE
Add event title expansion in admin

### DIFF
--- a/__tests__/inscricoesPage.test.tsx
+++ b/__tests__/inscricoesPage.test.tsx
@@ -1,0 +1,57 @@
+/* @vitest-environment jsdom */
+import { render, screen } from '@testing-library/react'
+import { vi } from 'vitest'
+import ListaInscricoesPage from '@/app/admin/inscricoes/page'
+
+vi.mock('@/lib/pocketbase', () => ({
+  __esModule: true,
+  default: vi.fn(() => ({
+    autoCancellation: vi.fn(),
+    collection: () => ({
+      getFullList: vi.fn().mockResolvedValue([
+        {
+          id: '1',
+          nome: 'Fulano',
+          telefone: '999999',
+          cpf: '123',
+          evento: 'evt1',
+          status: 'pendente',
+          created: '2025-01-01',
+          expand: {
+            campo: { nome: 'Campo 1', id: 'c1' },
+            evento: { titulo: 'Congresso Teste' },
+            pedido: { id: 'p1', status: 'pago', valor: 10 },
+          },
+        },
+      ]),
+    }),
+  })),
+}))
+
+vi.mock('@/lib/context/AuthContext', () => ({
+  useAuthContext: () => ({ user: { id: 'u1', role: 'coordenador' }, tenantId: 't1' }),
+}))
+
+vi.mock('@/lib/context/ToastContext', () => ({
+  useToast: () => ({ showError: vi.fn(), showSuccess: vi.fn() }),
+}))
+
+vi.mock('@/app/admin/inscricoes/componentes/ModalEdit', () => ({
+  __esModule: true,
+  default: () => <div />,
+}))
+
+vi.mock('@/app/admin/inscricoes/componentes/ModalVisualizarPedido', () => ({
+  __esModule: true,
+  default: () => <div />,
+}))
+
+vi.mock('@/app/admin/components/TooltipIcon', () => ({
+  __esModule: true,
+  default: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+}))
+
+test('exibe titulo do evento na tabela', async () => {
+  render(<ListaInscricoesPage />)
+  expect(await screen.findByText('Congresso Teste')).toBeInTheDocument()
+})

--- a/app/admin/dashboard/page.tsx
+++ b/app/admin/dashboard/page.tsx
@@ -32,7 +32,10 @@ export default function DashboardPage() {
         const [inscricoesRes, pedidosRes] = await Promise.all([
           pb
             .collection("inscricoes")
-            .getList(page, perPage, { expand: "campo,criado_por,pedido", signal }),
+            .getList(page, perPage, {
+              expand: "campo,evento,criado_por,pedido",
+              signal,
+            }),
           pb
             .collection("pedidos")
             .getList(page, perPage, { expand: "campo,criado_por", signal }),
@@ -49,7 +52,7 @@ export default function DashboardPage() {
           id: r.id,
           nome: r.nome,
           telefone: r.telefone,
-          evento: r.evento,
+          evento: r.expand?.evento?.titulo,
           status: r.status,
           created: r.created,
           campo: r.campo,
@@ -78,7 +81,7 @@ export default function DashboardPage() {
           created: r.created,
           campo: r.campo,
           genero: r.genero,
-          evento: r.evento,
+          evento: r.expand?.evento?.titulo,
           data_nascimento: r.data_nascimento,
           responsavel: r.responsavel,
           expand: {

--- a/app/admin/inscricoes/page.tsx
+++ b/app/admin/inscricoes/page.tsx
@@ -76,13 +76,17 @@ export default function ListaInscricoesPage() {
         : `campo='${user.campo}' && ${baseFiltro}`;
 
     pb.collection("inscricoes")
-      .getFullList({ sort: "-created", filter: filtro, expand: "campo,pedido" })
+      .getFullList({
+        sort: "-created",
+        filter: filtro,
+        expand: "campo,evento,pedido",
+      })
       .then((res) => {
         const lista = res.map((r) => ({
           id: r.id,
           nome: r.nome,
           telefone: r.telefone,
-          evento: r.evento,
+          evento: r.expand?.evento?.titulo,
           cpf: r.cpf,
           status: r.status,
           created: r.created,

--- a/app/admin/lider-painel/page.tsx
+++ b/app/admin/lider-painel/page.tsx
@@ -43,7 +43,7 @@ export default function LiderDashboardPage() {
             .collection("inscricoes")
             .getList(page, perPage, {
               filter: `campo="${campoId}" && cliente='${tenantId}'`,
-              expand: "campo,criado_por,pedido",
+              expand: "campo,evento,criado_por,pedido",
               signal,
             }),
           pb
@@ -64,7 +64,7 @@ export default function LiderDashboardPage() {
           id: r.id,
           nome: r.nome,
           telefone: r.telefone,
-          evento: r.evento,
+          evento: r.expand?.evento?.titulo,
           status: r.status,
           created: r.created,
           campo: r.campo,
@@ -93,7 +93,7 @@ export default function LiderDashboardPage() {
           created: r.created,
           campo: r.campo,
           genero: r.genero,
-          evento: r.evento,
+          evento: r.expand?.evento?.titulo,
           data_nascimento: r.data_nascimento,
           responsavel: r.responsavel,
           expand: {

--- a/logs/DOC_LOG.md
+++ b/logs/DOC_LOG.md
@@ -126,3 +126,4 @@
 ## [2025-06-22] Domínios agora mapeados em `clientes_config`; credenciais Asaas mantidas em `m24_clientes`. Documentação e exemplos atualizados.
 ## [2025-06-22] Documentacao revisada para indicar que cor_primary, logo_url e font ficam em clientes_config
 ## [2025-06-20] Atualizado guia e README de transferências incluindo suporte a PIX e formato `value` do payload.
+## [2025-06-23] Inscricoes exibem titulo do evento via expand; tipos atualizados.

--- a/types/index.ts
+++ b/types/index.ts
@@ -34,6 +34,7 @@ export type Inscricao = {
       telefone?: string;
       cpf?: string;
     };
+    evento?: Evento;
   };
 };
 


### PR DESCRIPTION
## Summary
- include event in Inscricao expand type
- fetch event title when listing inscriptions
- show event title in leader panel and dashboard
- test event title in inscriptions table
- log documentation update

## Testing
- `npm run lint` *(fails: 'prefer-const', '@typescript-eslint/no-unused-vars')*
- `npm run build` *(fails: ESLint errors)*

------
https://chatgpt.com/codex/tasks/task_e_6850966972f8832c98d68eb500a9a267