### PR TITLE
Atualizar seção Blog e CMS

### DIFF
--- a/README.md
+++ b/README.md
@@ -276,23 +276,16 @@ Líderes veem apenas a quantidade de inscrições e pedidos do seu campo.
 
 ## Blog e CMS
 
-Os arquivos de conteúdo ficam dentro da pasta `posts/` na raiz do projeto. Cada
-arquivo `.mdx` representa um post do blog.
+Os posts agora ficam na coleção `posts` do PocketBase, em vez de arquivos `.mdx`.
 
-Para criar ou editar posts pelo painel admin:
+Para criar ou editar um post pelo painel admin:
 
 1. Acesse `/admin` e realize o login.
-2. No menu lateral, clique em **Posts** e escolha **Novo Post** ou selecione um
-   existente para editar.
-3. Preencha título, resumo, categoria, autor, data de publicação, caso seja uma edição informe: post editado por {autor}, em {data de edição}, thumbnail e o conteúdo em Markdown.
-4. Salve para publicar ou atualizar o post.
+2. No menu lateral, clique em **Posts** e escolha **Novo Post** ou selecione um existente.
+3. Preencha os campos recomendados (`title`, `slug`, `summary`, `content`, `category`, `thumbnail`, `keywords`, `date`, `cliente` etc.).
+4. Salve para publicar ou atualizar.
 
-Após salvar as alterações, execute o comando abaixo para gerar
-`/public/posts.json` com a lista de posts:
-
-```bash
-npm run generate-posts
-```
+O front-end consome os posts diretamente do banco, portanto não é mais necessário executar `generate-posts`.
 
 ## Testes
 

--- a/logs/DOC_LOG.md
+++ b/logs/DOC_LOG.md
@@ -131,3 +131,4 @@
 ## [2025-06-16] Execução de npm run lint e npm run build registrou erros de lint que impediram o build.
 
 ## [2025-06-16] Rota de inscrições agora aceita eventoId no corpo e campo evento armazena o ID. OrderFlow e testes atualizados. Lint e build executados com erros em arquivos não relacionados.
+## [2025-06-16] Atualizado Blog e CMS: posts na coleção PocketBase e retirada do generate-posts.


### PR DESCRIPTION
## Summary
- atualizar README sobre nova gestão de posts via PocketBase
- registrar alteração no DOC_LOG

## Testing
- `npm run lint` *(fails: Parsing error)*
- `npm run build` *(fails: dynamic path slug mismatch)*

------
https://chatgpt.com/codex/tasks/task_e_68509aba745c832cba56948a827817b8