### PR TITLE
Update post editor to output HTML

### DIFF
--- a/app/admin/posts/components/PostContentEditor.tsx
+++ b/app/admin/posts/components/PostContentEditor.tsx
@@ -5,27 +5,18 @@ import Image from "@tiptap/extension-image";
 import Link from "@tiptap/extension-link";
 import EditorToolbar from "./EditorToolbar";
 import { useEffect } from "react";
-// @ts-expect-error: turndown não possui tipos TypeScript oficiais
-import TurndownService from "turndown";
-import { marked } from "marked";
-
-// Função para converter markdown em HTML para o editor
-function markdownToHtml(md: string) {
-  return marked.parse(md || "");
-}
-
-// Função para converter HTML do editor em markdown ao salvar
-const turndownService = new TurndownService();
 
 type Props = {
-  value: string; // markdown inicial
-  onChange: (markdown: string) => void;
+  /** HTML inicial do editor */
+  value: string;
+  /** Dispara sempre que o HTML é atualizado */
+  onChange: (html: string) => void;
 };
 
 export default function PostMarkdownEditor({ value, onChange }: Props) {
   const editor = useEditor({
     extensions: [StarterKit, Image, Link],
-    content: markdownToHtml(value),
+    content: value,
     editorProps: {
       attributes: {
         class:
@@ -33,19 +24,17 @@ export default function PostMarkdownEditor({ value, onChange }: Props) {
       },
     },
     onUpdate: ({ editor }) => {
-      // Obtém HTML do editor e converte para Markdown
+      // Retorna o HTML do editor sempre que atualizado
       const html = editor.getHTML();
-      const markdown = turndownService.turndown(html);
-      onChange(markdown);
+      onChange(html);
     },
   });
 
   // Atualiza quando o valor externo ou o editor mudam
   useEffect(() => {
     if (editor && value) {
-      const html = markdownToHtml(value);
-      if (html !== editor.getHTML()) {
-        editor.commands.setContent(html, false);
+      if (value !== editor.getHTML()) {
+        editor.commands.setContent(value, false);
       }
     }
   }, [value, editor]);

--- a/app/admin/posts/editar/[slug]/page.tsx
+++ b/app/admin/posts/editar/[slug]/page.tsx
@@ -3,7 +3,6 @@
 import { useEffect, useState } from "react";
 import { useRouter, useParams } from "next/navigation";
 import { useAuthContext } from "@/lib/context/AuthContext";
-import { marked } from "marked";
 import PostContentEditor from "../../components/PostContentEditor";
 import Header from "@/app/components/Header";
 import Footer from "@/app/components/Footer";
@@ -135,7 +134,7 @@ export default function EditarPostPage() {
 
           <article
             className="prose prose-neutral max-w-none"
-            dangerouslySetInnerHTML={{ __html: marked.parse(conteudo) }}
+            dangerouslySetInnerHTML={{ __html: conteudo }}
           />
         </main>
         <Footer />

--- a/app/admin/posts/novo/page.tsx
+++ b/app/admin/posts/novo/page.tsx
@@ -3,7 +3,6 @@
 import { useEffect, useState } from "react";
 import { useRouter } from "next/navigation";
 import { useAuthContext } from "@/lib/context/AuthContext";
-import { marked } from "marked";
 import PostContentEditor from "../components/PostContentEditor";
 
 export default function NovoPostPage() {
@@ -31,7 +30,7 @@ export default function NovoPostPage() {
         </button>
         <article
           className="prose prose-neutral max-w-none"
-          dangerouslySetInnerHTML={{ __html: marked.parse(conteudo) }}
+          dangerouslySetInnerHTML={{ __html: conteudo }}
         />
       </main>
     );

--- a/app/blog/post/[slug]/page.tsx
+++ b/app/blog/post/[slug]/page.tsx
@@ -2,8 +2,6 @@ import fs from "fs";
 import path from "path";
 import matter from "gray-matter";
 import { notFound } from "next/navigation";
-import { evaluate } from "xdm";
-import * as runtime from "react/jsx-runtime";
 import Footer from "@/app/components/Footer";
 import Image from "next/image";
 import { Share2, Clock } from "lucide-react";
@@ -66,10 +64,9 @@ export default async function BlogPostPage({
   const raw = fs.readFileSync(filePath, "utf8");
   const { content, data } = matter(raw);
   const { nextPost, suggestions } = getRelatedPosts(slug, data.category);
-  const evaluated = await evaluate(content, { ...runtime });
-  const Content = evaluated.default;
 
-  const words = content.split(/\s+/).length;
+  const plainText = content.replace(/<[^>]+>/g, "");
+  const words = plainText.split(/\s+/).length;
   const readingTime = Math.ceil(words / 200);
 
   const siteUrl = process.env.NEXT_PUBLIC_SITE_URL || "https://m24saude.com.br";
@@ -176,10 +173,11 @@ export default async function BlogPostPage({
           <p className="mb-8 text-[1.125rem] text-neutral-700">{data.summary}</p>
         )}
 
-        <article className="prose prose-neutral max-w-none">
-          <Content />
-          {nextPost && <NextPostButton slug={nextPost.slug} />}
-        </article>
+        <article
+          className="prose prose-neutral max-w-none"
+          dangerouslySetInnerHTML={{ __html: content }}
+        />
+        {nextPost && <NextPostButton slug={nextPost.slug} />}
       </main>
 
       <PostSuggestions posts={suggestions} />

--- a/stories/PostContentEditor.stories.tsx
+++ b/stories/PostContentEditor.stories.tsx
@@ -11,7 +11,7 @@ const meta = {
     onChange: { action: 'changed' },
   },
   args: {
-    value: '# Post de Exemplo\n\nEdite o conte\u00fado...',
+    value: '<h1>Post de Exemplo</h1>\n<p>Edite o conteúdo...</p>',
     onChange: fn(),
   },
 } satisfies Meta<typeof PostContentEditor>;

--- a/stories/PostPreviewToggle.stories.tsx
+++ b/stories/PostPreviewToggle.stories.tsx
@@ -1,11 +1,10 @@
 import type { Meta, StoryObj } from '@storybook/nextjs';
 import { userEvent, within, expect } from 'storybook/test';
 import { useState } from 'react';
-import { marked } from 'marked';
 import PostContentEditor from '../app/admin/posts/components/PostContentEditor';
 
 function Demo() {
-  const [content, setContent] = useState('# Título');
+  const [content, setContent] = useState('<h1>Título</h1>');
   const [preview, setPreview] = useState(false);
 
   return preview ? (
@@ -13,7 +12,7 @@ function Demo() {
       <button onClick={() => setPreview(false)}>Editar</button>
       <article
         className="prose prose-neutral max-w-none"
-        dangerouslySetInnerHTML={{ __html: marked.parse(content) }}
+        dangerouslySetInnerHTML={{ __html: content }}
       />
     </div>
   ) : (


### PR DESCRIPTION
## Summary
- update PostContentEditor to output HTML on change
- change admin post pages to handle HTML previews
- render blog posts using stored HTML
- update storybook examples for PostContentEditor

## Testing
- `npm run lint` *(fails: Parsing error in inscricoes pages)*
- `npm run build` *(fails: dynamic path slug conflict)*

------
https://chatgpt.com/codex/tasks/task_e_68509c5135cc832cb5d659b121074654