### PR TITLE
Fix public route regex in admin layout

### DIFF
--- a/app/admin/components/LayoutWrapper.tsx
+++ b/app/admin/components/LayoutWrapper.tsx
@@ -14,7 +14,7 @@ export default function LayoutWrapper({
   children: React.ReactNode;
 }) {
   const pathname = usePathname();
-  const isInscricaoPublica = /^\/inscricoes\/[^/]+$/.test(pathname);
+  const isInscricaoPublica = /^\/inscricoes\/[^/]+\/[^/]+$/.test(pathname);
 
   const { isLoggedIn, user } = useAuthContext();
 

--- a/logs/DOC_LOG.md
+++ b/logs/DOC_LOG.md
@@ -136,3 +136,4 @@
 ## [2025-06-16] Formulário de inscrições reutilizado nos eventos. Dropdown de campos adicionado. Lint e build executados com falhas.
 ## [2025-06-16] Removida pasta app/loja/inscricoes; link de inscricao aponta para /loja/eventos e redirect corrigido. Lint e build sem erros.
 ## [2025-06-24] Removido script generatePostsJson e atualizados testes para buscar posts via PocketBase.
+## [2025-06-24] Ajustada regex no LayoutWrapper para ocultar Header em rotas de inscrições públicas. Lint e build executados com erros em app/blog/post/[slug]/page.tsx.


### PR DESCRIPTION
## Summary
- update public registration regex in LayoutWrapper
- log lint/build execution

## Testing
- `npm run lint` *(fails: PostRecord defined but never used)*
- `npm run build` *(fails to compile)*

------
https://chatgpt.com/codex/tasks/task_e_6850a1a11910832c8248fc08fbac73f0