### PR TITLE
Add event selection for public registration links

### DIFF
--- a/logs/DOC_LOG.md
+++ b/logs/DOC_LOG.md
@@ -137,3 +137,4 @@
 ## [2025-06-16] Removida pasta app/loja/inscricoes; link de inscricao aponta para /loja/eventos e redirect corrigido. Lint e build sem erros.
 ## [2025-06-24] Removido script generatePostsJson e atualizados testes para buscar posts via PocketBase.
 ## [2025-06-24] Ajustada regex no LayoutWrapper para ocultar Header em rotas de inscrições públicas. Lint e build executados com erros em app/blog/post/[slug]/page.tsx.
+## [2025-06-16] Link de inscrição por usuário agora inclui eventoId selecionado. Dropdown de eventos ativos adicionado em /admin/usuarios. Lint e build executados com sucesso.


### PR DESCRIPTION
## Summary
- allow coordinators to pick active events before copying registration links
- change registration URL to include the selected eventId
- adjust blog post page to avoid build errors
- document changes in DOC_LOG

## Testing
- `npm run lint`
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_6850a4ff9d18832c84a373f69ad6c424