### PR TITLE
Add n8n webhook env variable

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -10,3 +10,4 @@ NEXT_PUBLIC_SITE_URL=
 NEXT_PUBLIC_BRASILAPI_URL=https://brasilapi.com.br/api
 ASAAS_API_URL=https://sandbox.asaas.com/api/v3/
 NEXT_PUBLIC_VIA_CEP_URL=https://viacep.com.br/ws
+NEXT_PUBLIC_N8N_WEBHOOK_URL=

--- a/README.md
+++ b/README.md
@@ -86,6 +86,7 @@ Crie um arquivo `.env.local` na raiz e defina as seguintes variáveis:
 - `ASAAS_API_URL` - URL base da API do Asaas (ex.: `https://api-sandbox.asaas.com/api/v3/`)
 - `NEXT_PUBLIC_SITE_URL` - endereço do site do cliente
 - `NEXT_PUBLIC_BRASILAPI_URL` - base para chamadas à BrasilAPI
+- `NEXT_PUBLIC_N8N_WEBHOOK_URL` - URL do webhook do n8n para receber inscrições
 
 Os servidores identificam automaticamente o tenant pelo domínio de cada requisição usando `getTenantFromHost`, que consulta a coleção `clientes_config` para descobrir o ID do cliente.
 

--- a/app/loja/components/InscricaoForm.tsx
+++ b/app/loja/components/InscricaoForm.tsx
@@ -2,6 +2,9 @@
 
 import { useState, useEffect } from "react";
 
+const N8N_WEBHOOK_URL =
+  process.env.NEXT_PUBLIC_N8N_WEBHOOK_URL || "https://SEU_WEBHOOK_DO_N8N";
+
 interface Campo {
   id: string;
   nome: string;
@@ -32,7 +35,7 @@ export default function InscricaoForm({ eventoId }: InscricaoFormProps) {
     const data = new FormData(form);
 
     try {
-      const response = await fetch("https://SEU_WEBHOOK_DO_N8N", {
+      const response = await fetch(N8N_WEBHOOK_URL, {
         method: "POST",
         body: JSON.stringify(Object.fromEntries(data)),
         headers: { "Content-Type": "application/json" },

--- a/logs/DOC_LOG.md
+++ b/logs/DOC_LOG.md
@@ -138,3 +138,4 @@
 ## [2025-06-24] Removido script generatePostsJson e atualizados testes para buscar posts via PocketBase.
 ## [2025-06-24] Ajustada regex no LayoutWrapper para ocultar Header em rotas de inscrições públicas. Lint e build executados com erros em app/blog/post/[slug]/page.tsx.
 ## [2025-06-16] Link de inscrição por usuário agora inclui eventoId selecionado. Dropdown de eventos ativos adicionado em /admin/usuarios. Lint e build executados com sucesso.
+## [2025-06-16] Documentada variavel NEXT_PUBLIC_N8N_WEBHOOK_URL e InscricaoForm usa URL do env. Impacto: integração n8n configurável.


### PR DESCRIPTION
## Summary
- load n8n webhook url from environment
- expose NEXT_PUBLIC_N8N_WEBHOOK_URL in .env.example
- document the new variable in README
- log documentation update

## Testing
- `npm run lint` *(fails: 'suggestions' and 'content' unused in app/blog/post/[slug]/page.tsx)*
- `npm run build` *(fails: same lint errors during build)*

------
https://chatgpt.com/codex/tasks/task_e_6850a99e552c832cbbbeb666c3dedf00