### PR TITLE
Restrict settings link to coordinators

### DIFF
--- a/app/admin/components/Header.tsx
+++ b/app/admin/components/Header.tsx
@@ -336,15 +336,17 @@ export default function Header() {
                             <User size={16} /> Visualizar perfil
                           </Link>
                         </li>
-                        <li>
-                          <Link
-                            href="/admin/configuracoes"
-                            className="flex items-center gap-2 px-4 py-2 hover:bg-zinc-100 dark:hover:bg-zinc-800 cursor-pointer"
-                          >
-                            <Settings size={16} />
-                            Configurações
-                          </Link>
-                        </li>
+                        {user?.role === "coordenador" && (
+                          <li>
+                            <Link
+                              href="/admin/configuracoes"
+                              className="flex items-center gap-2 px-4 py-2 hover:bg-zinc-100 dark:hover:bg-zinc-800 cursor-pointer"
+                            >
+                              <Settings size={16} />
+                              Configurações
+                            </Link>
+                          </li>
+                        )}
                         <li>
                           <button
                             onClick={() => {
@@ -495,13 +497,15 @@ export default function Header() {
                 >
                   Perfil
                 </Link>
-                <Link
-                  href="/admin/configuracoes"
-                  onClick={() => setMenuAberto(false)}
-                  className="px-4 py-2 text-sm hover:bg-[var(--background)] hover:text-[var(--foreground)]"
-                >
-                  Configurações
-                </Link>
+                  {user?.role === "coordenador" && (
+                    <Link
+                      href="/admin/configuracoes"
+                      onClick={() => setMenuAberto(false)}
+                      className="px-4 py-2 text-sm hover:bg-[var(--background)] hover:text-[var(--foreground)]"
+                    >
+                      Configurações
+                    </Link>
+                  )}
                 <button
                   onClick={() => {
                     setMenuAberto(false);

--- a/app/blog/post/[slug]/page.tsx
+++ b/app/blog/post/[slug]/page.tsx
@@ -66,9 +66,7 @@ export default async function BlogPostPage({
     thumbnail: s.thumbnail || "",
     category: s.category || "",
   }));
-  const safeSuggestions = suggestions;
   const mdxContent = post.content || "";
-  const safeSuggestions = suggestions;
 
   const words = mdxContent.split(/\s+/).length;
   const readingTime = Math.ceil(words / 200);

--- a/logs/DOC_LOG.md
+++ b/logs/DOC_LOG.md
@@ -112,3 +112,4 @@
 ## [2025-06-17] BankAccountModal criado com busca BrasilAPI e registro em clientes_contas_bancarias. Documentação e testes adicionados.
 ## [2025-06-16] Documentada variavel NEXT_PUBLIC_BRASILAPI_URL e formulario usa BrasilAPI
 ## [2025-06-16] Documentada variavel NEXT_PUBLIC_N8N_WEBHOOK_URL e InscricaoForm usa URL do env. Impacto: integração n8n configurável.
+## [2025-06-17] Menu Configurações restrito a coordenadores no Header e mobile. Lint e build executados com sucesso.


### PR DESCRIPTION
## Summary
- show the Configurações link only for `coordenador` role in both desktop and mobile menus
- fix duplicated variable in blog post page to restore build
- document lint/build success

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6850bf6d6140832cadf20eb40a07b021