### PR TITLE
Ajusta links de administração para líderes

### DIFF
--- a/app/admin/components/Header.tsx
+++ b/app/admin/components/Header.tsx
@@ -67,14 +67,12 @@ export default function Header() {
     user?.role === "lider"
       ? [
           { href: "/admin/posts", label: "Posts" },
-          { href: "/admin/inscricoes", label: "Inscrições" },
-          { href: "/admin/pedidos", label: "Pedidos" },
         ]
       : [
-          { href: "/admin/usuarios", label: "Usuários" },
-          { href: "/admin/posts", label: "Posts" },
-          { href: "/admin/campos", label: "Campos" },
-        ];
+        { href: "/admin/usuarios", label: "Usuários" },
+        { href: "/admin/posts", label: "Posts" },
+        { href: "/admin/campos", label: "Campos" },
+      ];
 
   const handleLogout = () => {
     pb.authStore.clear();

--- a/logs/DOC_LOG.md
+++ b/logs/DOC_LOG.md
@@ -112,3 +112,5 @@
 ## [2025-06-17] BankAccountModal criado com busca BrasilAPI e registro em clientes_contas_bancarias. Documentação e testes adicionados.
 ## [2025-06-16] Documentada variavel NEXT_PUBLIC_BRASILAPI_URL e formulario usa BrasilAPI
 ## [2025-06-16] Documentada variavel NEXT_PUBLIC_N8N_WEBHOOK_URL e InscricaoForm usa URL do env. Impacto: integração n8n configurável.
+
+## [2025-06-17] Atualizado Header removendo links de Inscricoes e Pedidos para lideres. Lint sem erros; build falhou em app/blog/post/[slug]/page.tsx.


### PR DESCRIPTION
## Summary
- remove Inscrições e Pedidos do menu `gerenciamentoLinks` quando o usuário é líder
- update DOC_LOG with lint/build results

## Testing
- `npm run lint`
- `npm run build` *(falhou)*

------
https://chatgpt.com/codex/tasks/task_e_6850bf7480b0832ca0eb7fc2049d1bfd