### PR TITLE
Atualizar painel de líder usando useAuthGuard

### DIFF
--- a/app/blog/post/[slug]/page.tsx
+++ b/app/blog/post/[slug]/page.tsx
@@ -66,9 +66,7 @@ export default async function BlogPostPage({
     thumbnail: s.thumbnail || "",
     category: s.category || "",
   }));
-  const safeSuggestions = suggestions;
   const mdxContent = post.content || "";
-  const safeSuggestions = suggestions;
 
   const words = mdxContent.split(/\s+/).length;
   const readingTime = Math.ceil(words / 200);


### PR DESCRIPTION
## Summary
- usar `useAuthGuard` no painel da liderança
- corrigir declaração duplicada em `page.tsx` de post

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6850bf87301c832c95bdfd971998c0ca