### PR TITLE
Implement event selection in inscription editing

### DIFF
--- a/app/admin/inscricoes/page.tsx
+++ b/app/admin/inscricoes/page.tsx
@@ -26,7 +26,10 @@ type Inscricao = {
   nome: string;
   telefone: string;
   cpf: string;
+  /** Título do evento para exibição */
   evento: string;
+  /** ID do evento */
+  eventoId: string;
   status: StatusInscricao;
   created: string;
   campo?: string;
@@ -112,6 +115,7 @@ export default function ListaInscricoesPage() {
           nome: r.nome,
           telefone: r.telefone,
           evento: r.expand?.evento?.titulo,
+          eventoId: r.evento,
           cpf: r.cpf,
           status: r.status,
           created: r.created,
@@ -527,10 +531,13 @@ export default function ListaInscricoesPage() {
         <ModalEditarInscricao
           inscricao={inscricaoEmEdicao}
           onClose={() => setInscricaoEmEdicao(null)}
-          onSave={async (dadosAtualizados: Partial<Inscricao>) => {
-            await pb
-              .collection("inscricoes")
-              .update(inscricaoEmEdicao.id, dadosAtualizados);
+          onSave={async (
+            dadosAtualizados: Partial<Inscricao & { eventoId: string }>
+          ) => {
+            await pb.collection("inscricoes").update(inscricaoEmEdicao.id, {
+              ...dadosAtualizados,
+              evento: dadosAtualizados.eventoId ?? inscricaoEmEdicao.eventoId,
+            });
             setInscricoes((prev) =>
               prev.map((i) =>
                 i.id === inscricaoEmEdicao.id

--- a/logs/DOC_LOG.md
+++ b/logs/DOC_LOG.md
@@ -118,3 +118,5 @@
 ## [2025-06-17] Adicionada utilidade getTenantFromClient, atualizadas páginas da loja para buscá-lo e novos testes.
 - Lint: sem erros
 - Build: sucesso
+
+## [2025-06-17] Inclusao de eventoId nas inscricoes e ajuste no ModalEditarInscricao para selecionar eventos do tenant.


### PR DESCRIPTION
## Summary
- include `eventoId` in admin inscricoes list
- fetch tenant events in edit modal and let user change event
- propagate `eventoId` through edit flows in ClientesPage
- document updated workflow

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6850c98d3aac832c9e560ed31fc0e163