### PR TITLE
Add tenant API route

### DIFF
--- a/app/api/produtos/[slug]/route.ts
+++ b/app/api/produtos/[slug]/route.ts
@@ -3,20 +3,19 @@ import createPocketBase from "@/lib/pocketbase";
 import { getTenantFromHost } from "@/lib/getTenantFromHost";
 import type { Produto } from "@/types";
 
-export async function GET(req: NextRequest, { params }: { params: { slug: string } }) {
+export async function GET(req: NextRequest) {
   const pb = createPocketBase();
   const tenantId = await getTenantFromHost();
-  const slug = params.slug;
+  const slug = req.nextUrl.pathname.split("/").pop() ?? "";
   const filter = tenantId ? `slug = '${slug}' && cliente='${tenantId}'` : `slug = '${slug}'`;
   try {
     const p = await pb.collection("produtos").getFirstListItem<Produto>(filter);
     const imagens = Array.isArray(p.imagens)
       ? p.imagens.map((img) => pb.files.getURL(p, img))
       : Object.fromEntries(
-          Object.entries(p.imagens as Record<string, string[]>).map(([g, arr]) => [
-            g,
-            arr.map((img) => pb.files.getURL(p, img)),
-          ])
+          Object.entries((p.imagens ?? {}) as Record<string, string[]>).map(
+            ([g, arr]) => [g, arr.map((img) => pb.files.getURL(p, img))]
+          )
         );
     return NextResponse.json({ ...p, imagens });
   } catch {

--- a/app/api/tenant/route.ts
+++ b/app/api/tenant/route.ts
@@ -1,0 +1,11 @@
+import { NextResponse } from "next/server";
+import { getTenantFromHost } from "@/lib/getTenantFromHost";
+
+export async function GET() {
+  try {
+    const tenantId = await getTenantFromHost();
+    return NextResponse.json({ tenantId }, { status: 200 });
+  } catch {
+    return NextResponse.json({ tenantId: null }, { status: 200 });
+  }
+}

--- a/app/loja/eventos/page.tsx
+++ b/app/loja/eventos/page.tsx
@@ -25,7 +25,7 @@ export default function EventosPage() {
       fetch("/api/eventos")
         .then((r) => r.json())
         .then((data) => {
-          Array.isArray(data) ? setEventos(data) : setEventos([]);
+          setEventos(Array.isArray(data) ? data : []);
         })
         .catch((err) => {
           console.error("Erro ao carregar eventos:", err);


### PR DESCRIPTION
## Summary
- expose tenantId via new `/api/tenant` route
- fix lint issue in eventos page
- adjust slug route to avoid build error

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6850d42bb808832c8d6487ef024ad002