### PR TITLE
Update tenant fetch logic

### DIFF
--- a/app/blog/BlogClient.tsx
+++ b/app/blog/BlogClient.tsx
@@ -17,30 +17,27 @@ const POSTS_PER_PAGE = 6;
 export default function BlogClient() {
   const [nomeCliente, setNomeCliente] = useState("");
 
-  useEffect(() => {
-    const pb = createPocketBase();
-    async function fetchCliente() {
-      try {
-        const tenantId = localStorage.getItem("tenant_id");
-        if (tenantId) {
-          const c = await pb
-            .collection("clientes_config")
-            .getOne<Cliente>(tenantId);
-          setNomeCliente(c.nome ?? "");
-          return;
+    useEffect(() => {
+      const pb = createPocketBase();
+      async function fetchCliente() {
+        try {
+          const res = await fetch("/api/tenant");
+          const data = (await res.json()) as { tenantId: string | null };
+          const id = data.tenantId;
+          if (id) {
+            const c = await pb
+              .collection("clientes_config")
+              .getOne<Cliente>(id);
+            setNomeCliente(c.nome ?? "");
+          } else {
+            setNomeCliente("");
+          }
+        } catch (err) {
+          console.error("Erro ao buscar nome do cliente:", err);
         }
-        const dominio = window.location.hostname;
-        const c = await pb
-          .collection("clientes_config")
-          .getFirstListItem<Cliente>(`dominio='${dominio}'`);
-        localStorage.setItem("tenant_id", c.id);
-        setNomeCliente(c.nome ?? "");
-      } catch (err) {
-        console.error("Erro ao buscar nome do cliente:", err);
       }
-    }
-    fetchCliente();
-  }, []);
+      fetchCliente();
+    }, []);
 
   const introText = {
     title: "Criamos este espaço porque acreditamos no poder do conhecimento.",

--- a/app/components/SignUpForm.tsx
+++ b/app/components/SignUpForm.tsx
@@ -44,9 +44,6 @@ export default function SignUpForm({
             .collection("clientes_config")
             .getFirstListItem(`dominio='${window.location.hostname}'`);
           tenantId = cliente?.id;
-          if (tenantId) {
-            localStorage.setItem("tenant_id", tenantId);
-          }
         }
 
         if (!tenantId) return;

--- a/app/loja/page.tsx
+++ b/app/loja/page.tsx
@@ -20,21 +20,9 @@ export default function Home() {
     async function fetchProdutos() {
       try {
         const pb = createPocketBase();
-        const storedTenant = localStorage.getItem("tenant_id");
-        let tenantId = storedTenant;
-
-        if (!tenantId) {
-          const host = window.location.hostname;
-          try {
-            const cliente = await pb
-              .collection("clientes_config")
-              .getFirstListItem(`dominio='${host}'`);
-            tenantId = cliente.id;
-            localStorage.setItem("tenant_id", tenantId);
-          } catch {
-            tenantId = null;
-          }
-        }
+        const res = await fetch("/api/tenant");
+        const data = (await res.json()) as { tenantId: string | null };
+        const tenantId = data.tenantId;
 
         const filterStr = tenantId
           ? `ativo = true && cliente='${tenantId}'`

--- a/lib/context/AuthContext.tsx
+++ b/lib/context/AuthContext.tsx
@@ -106,7 +106,6 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
       const cliente = await pb
         .collection("clientes_config")
         .getFirstListItem(`dominio='${dominio}'`);
-      localStorage.setItem("tenant_id", cliente.id);
       setTenantId(cliente.id);
     } catch {
       setTenantId(null);
@@ -140,7 +139,6 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
         .collection("clientes_config")
         .getFirstListItem(`dominio='${dominio}'`);
       clienteId = cliente.id;
-      localStorage.setItem("tenant_id", clienteId);
       setTenantId(clienteId);
     } catch {
       setTenantId(null);

--- a/lib/posts/getPostsClientPB.ts
+++ b/lib/posts/getPostsClientPB.ts
@@ -15,20 +15,9 @@ export interface PostClientRecord {
 
 export async function getPostsClientPB(): Promise<PostClientRecord[]> {
   const pb = createPocketBase();
-  let tenantId = localStorage.getItem("tenant_id");
-
-  if (!tenantId) {
-    const host = window.location.hostname;
-    try {
-      const cliente = await pb
-        .collection("clientes_config")
-        .getFirstListItem(`dominio='${host}'`);
-      tenantId = cliente.id;
-      localStorage.setItem("tenant_id", tenantId);
-    } catch {
-      tenantId = null;
-    }
-  }
+  const res = await fetch("/api/tenant");
+  const data = (await res.json()) as { tenantId: string | null };
+  const tenantId = data.tenantId;
 
   const list = await pb.collection("posts").getFullList<PostClientRecord>({
     sort: "-date",


### PR DESCRIPTION
## Summary
- fetch tenant ID via `/api/tenant` in store and blog pages
- use same API when loading posts
- remove `tenant_id` storage in localStorage

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6850d6158f90832ca4c03b98aa8b21b8