### PR TITLE
Update AppConfigProvider tenant logic

### DIFF
--- a/lib/context/AppConfigContext.tsx
+++ b/lib/context/AppConfigContext.tsx
@@ -34,19 +34,24 @@ export function AppConfigProvider({ children }: { children: React.ReactNode }) {
       if (typeof window === "undefined") return;
 
       try {
-        const pb = createPocketBase();
-        const dominio = window.location.hostname;
-        const cliente = await pb
-          .collection("clientes_config")
-          .getFirstListItem(`dominio='${dominio}'`);
-        const cfg: AppConfig = {
-          font: cliente.font || defaultConfig.font,
-          primaryColor: cliente.cor_primary || defaultConfig.primaryColor,
-          logoUrl: cliente.logo_url || defaultConfig.logoUrl,
-        };
-        setConfig(cfg);
-        localStorage.setItem("app_config", JSON.stringify(cfg));
-        return;
+        const tenantRes = await fetch("/api/tenant");
+        if (tenantRes.ok) {
+          const { tenantId } = await tenantRes.json();
+          if (tenantId) {
+            const pb = createPocketBase();
+            const cliente = await pb
+              .collection("clientes_config")
+              .getOne(String(tenantId));
+            const cfg: AppConfig = {
+              font: cliente.font || defaultConfig.font,
+              primaryColor: cliente.cor_primary || defaultConfig.primaryColor,
+              logoUrl: cliente.logo_url || defaultConfig.logoUrl,
+            };
+            setConfig(cfg);
+            localStorage.setItem("app_config", JSON.stringify(cfg));
+            return;
+          }
+        }
       } catch {
         /* ignore */
       }


### PR DESCRIPTION
## Summary
- fetch `/api/tenant` before contacting PocketBase
- use returned tenantId to query `clientes_config`
- drop usage of `window.location.hostname`

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6850d61e4f68832c9ef9afcd8594209c