### PR TITLE
Update config fetch by tenant

### DIFF
--- a/app/admin/api/configuracoes/route.ts
+++ b/app/admin/api/configuracoes/route.ts
@@ -11,7 +11,7 @@ export async function GET(req: NextRequest) {
   try {
     const cliente = await pb
       .collection("clientes_config")
-      .getOne(user.cliente);
+      .getFirstListItem(`cliente='${user.cliente}'`);
     return NextResponse.json(
       {
         cor_primary: cliente.cor_primary ?? "",
@@ -34,12 +34,15 @@ export async function PUT(req: NextRequest) {
   const { pb, user } = auth;
   try {
     const { cor_primary, logo_url, font } = await req.json();
-    const cliente = await pb.collection("clientes_config").update(user.cliente, {
+    const cliente = await pb
+      .collection("clientes_config")
+      .getFirstListItem(`cliente='${user.cliente}'`);
+    const atualizado = await pb.collection("clientes_config").update(cliente.id, {
       cor_primary,
       logo_url,
       font,
     });
-    return NextResponse.json(cliente, { status: 200 });
+    return NextResponse.json(atualizado, { status: 200 });
   } catch (err) {
     await logConciliacaoErro(`Erro ao atualizar configuracoes: ${String(err)}`);
     return NextResponse.json({ error: "Erro ao atualizar" }, { status: 500 });

--- a/lib/context/AppConfigContext.tsx
+++ b/lib/context/AppConfigContext.tsx
@@ -28,6 +28,7 @@ const AppConfigContext = createContext<AppConfigContextType>({
 
 export function AppConfigProvider({ children }: { children: React.ReactNode }) {
   const [config, setConfig] = useState<AppConfig>(defaultConfig);
+  const [configId, setConfigId] = useState<string | null>(null);
 
   useEffect(() => {
     async function loadConfig() {
@@ -41,7 +42,8 @@ export function AppConfigProvider({ children }: { children: React.ReactNode }) {
             const pb = createPocketBase();
             const cliente = await pb
               .collection("clientes_config")
-              .getOne(String(tenantId));
+              .getFirstListItem(`cliente='${tenantId}'`);
+            setConfigId(cliente.id);
             const cfg: AppConfig = {
               font: cliente.font || defaultConfig.font,
               primaryColor: cliente.cor_primary || defaultConfig.primaryColor,
@@ -109,7 +111,7 @@ export function AppConfigProvider({ children }: { children: React.ReactNode }) {
     if (typeof window !== "undefined") {
       const token = localStorage.getItem("pb_token");
       const user = localStorage.getItem("pb_user");
-      if (token && user) {
+      if (token && user && configId) {
         fetch("/admin/api/configuracoes", {
           method: "PUT",
           headers: {
@@ -118,6 +120,7 @@ export function AppConfigProvider({ children }: { children: React.ReactNode }) {
             "X-PB-User": user,
           },
           body: JSON.stringify({
+            id: configId,
             cor_primary: newCfg.primaryColor,
             logo_url: newCfg.logoUrl,
             font: newCfg.font,


### PR DESCRIPTION
## Summary
- load config from `clientes_config` using tenant filter
- keep config record id for updates
- adjust backend route to query/update by tenant id

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68516b2082a8832c81fdb67ec20ceb06