### PR TITLE
Fix cliente config lookup and update logs

### DIFF
--- a/app/admin/api/configuracoes/route.ts
+++ b/app/admin/api/configuracoes/route.ts
@@ -9,14 +9,14 @@ export async function GET(req: NextRequest) {
   }
   const { pb, user } = auth;
   try {
-    const cliente = await pb
+    const cfg = await pb
       .collection("clientes_config")
-      .getOne(user.cliente);
+      .getFirstListItem(`cliente='${user.cliente}'`);
     return NextResponse.json(
       {
-        cor_primary: cliente.cor_primary ?? "",
-        logo_url: cliente.logo_url ?? "",
-        font: cliente.font ?? "",
+        cor_primary: cfg.cor_primary ?? "",
+        logo_url: cfg.logo_url ?? "",
+        font: cfg.font ?? "",
       },
       { status: 200 }
     );
@@ -34,12 +34,15 @@ export async function PUT(req: NextRequest) {
   const { pb, user } = auth;
   try {
     const { cor_primary, logo_url, font } = await req.json();
-    const cliente = await pb.collection("clientes_config").update(user.cliente, {
+    const cfg = await pb
+      .collection("clientes_config")
+      .getFirstListItem(`cliente='${user.cliente}'`);
+    const updated = await pb.collection("clientes_config").update(cfg.id, {
       cor_primary,
       logo_url,
       font,
     });
-    return NextResponse.json(cliente, { status: 200 });
+    return NextResponse.json(updated, { status: 200 });
   } catch (err) {
     await logConciliacaoErro(`Erro ao atualizar configuracoes: ${String(err)}`);
     return NextResponse.json({ error: "Erro ao atualizar" }, { status: 500 });

--- a/logs/DOC_LOG.md
+++ b/logs/DOC_LOG.md
@@ -122,3 +122,4 @@
 - Lint: falhou (next not found)
 - Build: falhou (next not found)
 ## [2025-06-25] Links de administração ajustados por papel no Header. Teste criado para validar comportamentos. Lint e build executados.
+## [2025-06-25] Registrado erro 404 ao ler clientes_config e correção documentada. - Lint: falhou (next not found) - Build: falhou (next not found)

--- a/logs/ERR_LOG.md
+++ b/logs/ERR_LOG.md
@@ -66,3 +66,4 @@
 ## [2025-06-16] Erro ao atualizar configuracoes: ClientResponseError 404: The requested resource wasn't found. - development
 ## [2025-06-16] Erro ao atualizar configuracoes: ClientResponseError 404: The requested resource wasn't found. - development
 ## [2025-06-16] Erro ao atualizar configuracoes: ClientResponseError 404: The requested resource wasn't found. - development
+## [2025-06-25] Erro 404 ao buscar clientes_config por ID em /admin/api/configuracoes; corrigido consultando por campo cliente - dev - a259f55


### PR DESCRIPTION
## Summary
- fix GET/PUT on admin configuracoes API to query by `cliente`
- record 404 error and fix in ERR_LOG
- log the documentation update in DOC_LOG

## Testing
- `npm run lint` *(fails: next not found)*
- `npm run build` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_68516bb8c6b0832cb6a2659b0788b9e3