### PR TITLE
Fix clientes_config lookup

### DIFF
--- a/app/admin/api/configuracoes/route.ts
+++ b/app/admin/api/configuracoes/route.ts
@@ -11,7 +11,7 @@ export async function GET(req: NextRequest) {
   try {
     const cliente = await pb
       .collection("clientes_config")
-      .getOne(user.cliente);
+      .getFirstListItem(`cliente='${user.cliente}'`);
     return NextResponse.json(
       {
         cor_primary: cliente.cor_primary ?? "",
@@ -34,7 +34,10 @@ export async function PUT(req: NextRequest) {
   const { pb, user } = auth;
   try {
     const { cor_primary, logo_url, font } = await req.json();
-    const cliente = await pb.collection("clientes_config").update(user.cliente, {
+    const current = await pb
+      .collection("clientes_config")
+      .getFirstListItem(`cliente='${user.cliente}'`);
+    const cliente = await pb.collection("clientes_config").update(current.id, {
       cor_primary,
       logo_url,
       font,

--- a/lib/context/AppConfigContext.tsx
+++ b/lib/context/AppConfigContext.tsx
@@ -41,7 +41,7 @@ export function AppConfigProvider({ children }: { children: React.ReactNode }) {
             const pb = createPocketBase();
             const cliente = await pb
               .collection("clientes_config")
-              .getOne(String(tenantId));
+              .getFirstListItem(`cliente='${tenantId}'`);
             const cfg: AppConfig = {
               font: cliente.font || defaultConfig.font,
               primaryColor: cliente.cor_primary || defaultConfig.primaryColor,


### PR DESCRIPTION
## Summary
- fix config retrieval by tenant when loading the app
- update admin config route to query clientes_config by tenant before updating

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68517124563c832c8392d8de661e3410