### PR TITLE
Update personalization docs

### DIFF
--- a/docs/design-system.md
+++ b/docs/design-system.md
@@ -189,10 +189,9 @@ Execute `npm run storybook` para iniciar a interface e validar os componentes. Q
 O portal permite ajustar fonte, cor primária e logotipo dinamicamente. As configurações são gerenciadas pelo `AppConfigProvider` (`lib/context/AppConfigContext.tsx`).
 Ao montar, o provedor executa a seguinte sequência:
 
-1. verifica se há valores no `localStorage`;
-2. consulta `/api/tenant` para descobrir o ID do cliente;
-3. carrega a coleção `clientes_config` **filtrando pelo campo `cliente`**, e não pelo ID do documento;
-4. caso o usuário esteja autenticado, permite editar as preferências via `/admin/api/configuracoes`.
+1. tenta ler as configurações armazenadas no `localStorage`. Se existirem e ainda estiverem válidas, elas são usadas diretamente;
+2. quando não há dados ou eles estão desatualizados, consulta `/api/tenant` para descobrir o ID do cliente e então carrega a coleção `clientes_config` **filtrando pelo campo `cliente`**, e não pelo ID do documento;
+3. caso o usuário esteja autenticado, permite editar as preferências via `/admin/api/configuracoes`.
 
 Quando `updateConfig` é chamado, os dados são enviados para essa mesma rota e gravados no `localStorage`, mantendo navegador e PocketBase sincronizados.
 

--- a/logs/DOC_LOG.md
+++ b/logs/DOC_LOG.md
@@ -120,3 +120,4 @@
 ## [2025-06-26] Documentada sequência de carregamento de personalização no design system. Lint e build executados.
 ## [2025-06-26] Atualizada seção Personalização em docs/design-system.md com nova sequência de carregamento e busca pelo campo cliente.
 ## [2025-06-25] Registrado erro 404 ao ler clientes_config e correção documentada. - Lint: falhou (next not found) - Build: falhou (next not found)
+## [2025-06-17] Especificado que o AppConfigProvider verifica o `localStorage` antes de requisitar `/api/tenant` e `clientes_config`, usando sempre o campo `cliente` na busca. Documentação esclarecida.


### PR DESCRIPTION
## Summary
- explain AppConfigProvider reads from `localStorage` first
- document lookup by `cliente` field
- log documentation change

## Testing
- `npm run lint` *(fails: next not found)*
- `npm run build` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_68517675bb4c832c9e5b3a018d8976a6