### PR TITLE
Add bairro autofill to InscricaoForm

### DIFF
--- a/app/loja/components/InscricaoForm.tsx
+++ b/app/loja/components/InscricaoForm.tsx
@@ -30,6 +30,7 @@ export default function InscricaoForm({ eventoId }: InscricaoFormProps) {
   const [endereco, setEndereco] = useState(String(user?.endereco ?? ""));
   const [cidade, setCidade] = useState(String(user?.cidade ?? ""));
   const [estado, setEstado] = useState(String(user?.estado ?? ""));
+  const [bairro, setBairro] = useState(String(user?.bairro ?? ""));
   const formRef = useRef<HTMLFormElement>(null);
 
   useEffect(() => {
@@ -58,6 +59,7 @@ export default function InscricaoForm({ eventoId }: InscricaoFormProps) {
     setEndereco(String(user.endereco ?? ""));
     setCidade(String(user.cidade ?? ""));
     setEstado(String(user.estado ?? ""));
+    setBairro(String(user.bairro ?? ""));
     setVal("user_number", String(user.numero ?? ""));
     setVal("user_complement", String(user.complemento ?? ""));
     setVal("user_neighborhood", String(user.bairro ?? ""));
@@ -80,6 +82,7 @@ export default function InscricaoForm({ eventoId }: InscricaoFormProps) {
         setEndereco(data.logradouro || data.street || "");
         setCidade(data.localidade || data.city || "");
         setEstado(data.uf || data.state || "");
+        setBairro(data.bairro || data.neighborhood || "");
       })
       .catch(() => console.warn("Erro ao buscar o CEP"));
   }, [cep]);
@@ -297,7 +300,8 @@ export default function InscricaoForm({ eventoId }: InscricaoFormProps) {
                     name="user_neighborhood"
                     required
                     className="input-base"
-                    defaultValue={String(user?.bairro ?? "")}
+                    value={bairro}
+                    onChange={(e) => setBairro(e.target.value)}
                   />
                 </div>
                 <div className="flex-1">

--- a/logs/DOC_LOG.md
+++ b/logs/DOC_LOG.md
@@ -125,3 +125,4 @@
 ## [2025-06-27] Página de detalhes dos eventos adicionada em /loja/eventos/[id] com formulário pré-preenchido. Botão da listagem atualizado.
 ## [2025-06-27] InscricaoForm agora carrega dados do usuario, consulta CEP pela URL configurada e envia para o webhook mesmo em caso de erro. Lint e build executados com sucesso.
 ## [2025-06-17] Carrinho agora diferencia variações por ID único e páginas de carrinho/checkout exibem itens separadamente.
+## [2025-06-28] Inclusão do bairro no autofill do InscricaoForm.


### PR DESCRIPTION
## Summary
- include `bairro` state in `InscricaoForm`
- populate bairro from user profile and CEP lookup
- update DOC_LOG

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_685181f8dcb0832cb1336409e6a01d26