### PR TITLE
Implement route and section for inscrições

### DIFF
--- a/app/loja/api/minhas-inscricoes/route.ts
+++ b/app/loja/api/minhas-inscricoes/route.ts
@@ -1,0 +1,21 @@
+import { NextRequest, NextResponse } from "next/server";
+import { requireRole } from "@/lib/apiAuth";
+
+export async function GET(req: NextRequest) {
+  const auth = requireRole(req, "usuario");
+  if ("error" in auth) {
+    return NextResponse.json({ error: auth.error }, { status: auth.status });
+  }
+  const { pb, user } = auth;
+  try {
+    const inscricoes = await pb.collection("inscricoes").getFullList({
+      filter: `criado_por="${user.id}"`,
+      expand: "evento",
+      sort: "-created",
+    });
+    return NextResponse.json(inscricoes, { status: 200 });
+  } catch (err) {
+    console.error("Erro ao listar inscricoes:", err);
+    return NextResponse.json({ error: "Erro ao listar" }, { status: 500 });
+  }
+}

--- a/app/loja/cliente/page.tsx
+++ b/app/loja/cliente/page.tsx
@@ -1,9 +1,29 @@
 "use client";
 
+import { useEffect, useState } from "react";
 import { useAuthGuard } from "@/lib/hooks/useAuthGuard";
+import type { Inscricao } from "@/types";
 
 export default function AreaCliente() {
-  const { user, authChecked } = useAuthGuard(["usuario"]);
+  const { user, pb, authChecked } = useAuthGuard(["usuario"]);
+  const [inscricoes, setInscricoes] = useState<Inscricao[]>([]);
+
+  useEffect(() => {
+    if (!authChecked || !user) return;
+    const token = pb.authStore.token;
+    fetch("/loja/api/minhas-inscricoes", {
+      headers: {
+        Authorization: `Bearer ${token}`,
+        "X-PB-User": JSON.stringify(user),
+      },
+    })
+      .then((res) => res.json())
+      .then((data) => setInscricoes(Array.isArray(data) ? data : []))
+      .catch((err) => {
+        console.error("Erro ao carregar inscricoes", err);
+        setInscricoes([]);
+      });
+  }, [authChecked, user, pb]);
 
   if (!authChecked) return null;
 
@@ -89,6 +109,32 @@ export default function AreaCliente() {
                     Ver detalhes
                   </a>
                   <button className="btn btn-primary">Recomprar</button>
+                </td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      </section>
+
+      <section className="card">
+        <h2 className="text-xl font-bold mb-4">Minhas Inscrições</h2>
+        <table className="table-base">
+          <thead>
+            <tr>
+              <th>Status</th>
+              <th>Evento</th>
+              <th>Data</th>
+            </tr>
+          </thead>
+          <tbody>
+            {inscricoes.map((i) => (
+              <tr key={i.id}>
+                <td className="capitalize">{i.status}</td>
+                <td>{i.expand?.evento?.titulo || "-"}</td>
+                <td>
+                  {i.created
+                    ? new Date(i.created).toLocaleDateString("pt-BR")
+                    : "-"}
                 </td>
               </tr>
             ))}

--- a/logs/DOC_LOG.md
+++ b/logs/DOC_LOG.md
@@ -125,3 +125,4 @@
 ## [2025-06-27] Página de detalhes dos eventos adicionada em /loja/eventos/[id] com formulário pré-preenchido. Botão da listagem atualizado.
 ## [2025-06-27] InscricaoForm agora carrega dados do usuario, consulta CEP pela URL configurada e envia para o webhook mesmo em caso de erro. Lint e build executados com sucesso.
 ## [2025-06-17] Carrinho agora diferencia variações por ID único e páginas de carrinho/checkout exibem itens separadamente.
+## [2025-06-28] Criada rota /loja/api/minhas-inscricoes filtrando por usuário e nova seção em /loja/cliente exibindo inscrições.


### PR DESCRIPTION
## Summary
- add `minhas-inscricoes` API route filtering by user
- load and display user's inscrições in Area do Cliente
- log new documentation entry

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_685182c8434c832ca2c6ca69dff35f62