### PR TITLE
Add tenant and user IDs to checkout payload

### DIFF
--- a/app/loja/checkout/page.tsx
+++ b/app/loja/checkout/page.tsx
@@ -15,7 +15,7 @@ function CheckoutContent() {
   const { itens, clearCart } = useCart();
   const router = useRouter();
   const searchParams = useSearchParams();
-  const { isLoggedIn, user } = useAuthContext();
+  const { isLoggedIn, user, tenantId } = useAuthContext();
 
   const [nome, setNome] = useState(user?.nome || "");
   const [telefone, setTelefone] = useState(String(user?.telefone ?? ""));
@@ -99,11 +99,17 @@ function CheckoutContent() {
         })
       );
 
+      if (!tenantId || !user?.id) {
+        throw new Error("Autenticação inválida");
+      }
+
       const payload = {
         valor: total,
         itens: itensPayload,
         successUrl: `${window.location.origin}/loja/sucesso?pedido=${pedidoId}`,
         errorUrl: `${window.location.origin}/loja/sucesso?pedido=${pedidoId}`,
+        clienteId: tenantId,
+        usuarioId: user.id,
         cliente: {
           nome,
           email,


### PR DESCRIPTION
## Summary
- include `tenantId` and `user.id` in the checkout request body
- validate that both ids exist before sending the request

## Testing
- `npm run lint`
- `npm run build`
- `npm test` *(fails: assertions in existing tests)*

------
https://chatgpt.com/codex/tasks/task_e_68519e4b8cdc832c86a2b662a2609ef5