### PR TITLE
Add split wallet to Asaas payloads

### DIFF
--- a/__tests__/asaasCheckout.test.ts
+++ b/__tests__/asaasCheckout.test.ts
@@ -15,7 +15,7 @@ describe('buildCheckoutUrl', () => {
 describe('checkout route', () => {
   const originalEnv = process.env;
   beforeEach(() => {
-    process.env = { ...originalEnv, ASAAS_API_URL: 'https://asaas', ASAAS_API_KEY: 'key' };
+    process.env = { ...originalEnv, ASAAS_API_URL: 'https://asaas', ASAAS_API_KEY: 'key', WALLETID_M24: 'wallet' };
     (requireRole as unknown as { mockReturnValue: (v: any) => void }).mockReturnValue({
       pb: {
         authStore: { isValid: true },

--- a/app/admin/api/asaas/route.ts
+++ b/app/admin/api/asaas/route.ts
@@ -172,6 +172,12 @@ export async function POST(req: NextRequest) {
         value: parsedValor,
         dueDate: dueDateStr,
         description: pedido.produto || "Produto",
+        split: [
+          {
+            walletId: process.env.WALLETID_M24,
+            percentageValue: 7,
+          },
+        ],
         externalReference,
       }),
     });

--- a/lib/asaas.ts
+++ b/lib/asaas.ts
@@ -101,6 +101,12 @@ export async function createCheckout(
           item.fotoBase64 ? { name: `item${idx + 1}Foto`, value: item.fotoBase64 } : null
         )
         .filter(Boolean) as { name: string; value: string }[]) || undefined,
+    split: [
+      {
+        walletId: process.env.WALLETID_M24,
+        percentageValue: 7,
+      },
+    ],
     externalReference,
   };
 


### PR DESCRIPTION
## Summary
- include `split` config in checkout payload
- add `split` when creating boleto payments
- set `WALLETID_M24` env in checkout tests

## Testing
- `npm run lint`
- `npm run build`
- `npm test` *(fails: tests assert status codes)*

------
https://chatgpt.com/codex/tasks/task_e_6851a16b1480832cb796ea8b33532f8f