### PR TITLE
Fix checkout item length

### DIFF
--- a/app/admin/api/asaas/checkout/route.ts
+++ b/app/admin/api/asaas/checkout/route.ts
@@ -4,14 +4,18 @@ import { createCheckout } from "@/lib/asaas";
 import { requireClienteFromHost } from "@/lib/clienteAuth";
 import { logInfo } from "@/lib/logger";
 import { logConciliacaoErro } from "@/lib/server/logger";
+import {
+  MAX_ITEM_DESCRIPTION_LENGTH,
+  MAX_ITEM_NAME_LENGTH,
+} from "@/lib/constants";
 
 const checkoutSchema = z.object({
   valor: z.number(),
   itens: z
     .array(
       z.object({
-        name: z.string(),
-        description: z.string().optional(),
+        name: z.string().max(MAX_ITEM_NAME_LENGTH),
+        description: z.string().max(MAX_ITEM_DESCRIPTION_LENGTH).optional(),
         quantity: z.number(),
         value: z.number(),
         fotoBase64: z.string().optional().nullable(),

--- a/app/admin/eventos/editar/[id]/page.tsx
+++ b/app/admin/eventos/editar/[id]/page.tsx
@@ -76,8 +76,21 @@ export default function EditarEventoPage() {
         Editar Evento
       </h1>
       <form onSubmit={handleSubmit} className="space-y-4">
-        <input className="input-base" name="titulo" defaultValue={String(initial.titulo)} required />
-        <textarea className="input-base" name="descricao" rows={2} defaultValue={String(initial.descricao)} required />
+        <input
+          className="input-base"
+          name="titulo"
+          defaultValue={String(initial.titulo)}
+          maxLength={30}
+          required
+        />
+        <textarea
+          className="input-base"
+          name="descricao"
+          rows={2}
+          defaultValue={String(initial.descricao)}
+          maxLength={150}
+          required
+        />
         <input className="input-base" name="data" type="date" defaultValue={String(initial.data)} required />
         <input className="input-base" name="cidade" defaultValue={String(initial.cidade)} required />
         <input type="file" name="imagem" accept="image/*" className="input-base" />

--- a/app/admin/eventos/novo/ModalEvento.tsx
+++ b/app/admin/eventos/novo/ModalEvento.tsx
@@ -68,8 +68,22 @@ export function ModalEvento<T extends Record<string, unknown>>({
             </button>
           </div>
 
-        <input className="input-base" name="titulo" placeholder="Título" defaultValue={initial.titulo || ""} required />
-        <textarea className="input-base" name="descricao" rows={2} defaultValue={initial.descricao || ""} required />
+        <input
+          className="input-base"
+          name="titulo"
+          placeholder="Título"
+          defaultValue={initial.titulo || ""}
+          maxLength={30}
+          required
+        />
+        <textarea
+          className="input-base"
+          name="descricao"
+          rows={2}
+          defaultValue={initial.descricao || ""}
+          maxLength={150}
+          required
+        />
         <input className="input-base" name="data" type="date" defaultValue={initial.data || ""} required />
         <input className="input-base" name="cidade" defaultValue={initial.cidade || ""} required />
         <input type="file" name="imagem" accept="image/*" className="input-base" />

--- a/app/admin/produtos/editar/[id]/page.tsx
+++ b/app/admin/produtos/editar/[id]/page.tsx
@@ -248,6 +248,7 @@ export default function EditarProdutoPage() {
             name="nome"
             placeholder="Ex: Camiseta Básica Preta"
             defaultValue={String(initial.nome)}
+            maxLength={30}
             required
           />
           <input
@@ -427,6 +428,7 @@ export default function EditarProdutoPage() {
             rows={2}
             placeholder="Ex: Camiseta 100% algodão, confortável, não desbota."
             defaultValue={String(initial.descricao || "")}
+            maxLength={150}
             required
           />
           <span className="text-xs text-gray-400 ml-1">

--- a/app/admin/produtos/novo/ModalProduto.tsx
+++ b/app/admin/produtos/novo/ModalProduto.tsx
@@ -215,6 +215,7 @@ export function ModalProduto<T extends Record<string, unknown>>({
                 name="nome"
                 placeholder="Ex: Camiseta Básica Preta"
                 defaultValue={initial.nome || ""}
+                maxLength={30}
                 required
               />
             </div>
@@ -338,6 +339,7 @@ export function ModalProduto<T extends Record<string, unknown>>({
                 placeholder="Ex: Camiseta 100% algodão, confortável, não desbota."
                 defaultValue={initial.descricao || ""}
                 rows={2}
+                maxLength={150}
                 required
               />
               <span className="text-xs text-gray-400 ml-1">

--- a/app/loja/checkout/page.tsx
+++ b/app/loja/checkout/page.tsx
@@ -6,6 +6,10 @@ import { Suspense, useState, useEffect } from "react";
 import { useAuthContext } from "@/lib/context/AuthContext";
 import { CheckCircle } from "lucide-react";
 import { hexToPtName } from "@/utils/colorNamePt";
+import {
+  MAX_ITEM_DESCRIPTION_LENGTH,
+  MAX_ITEM_NAME_LENGTH,
+} from "@/lib/constants";
 
 function formatCurrency(n: number) {
   return `R$ ${n.toFixed(2).replace(".", ",")}`;
@@ -90,8 +94,8 @@ function CheckoutContent() {
             }
           }
           return {
-            name: i.nome,
-            description: i.descricao,
+            name: i.nome.slice(0, MAX_ITEM_NAME_LENGTH),
+            description: i.descricao?.slice(0, MAX_ITEM_DESCRIPTION_LENGTH),
             quantity: i.quantidade,
             value: i.preco,
             fotoBase64,

--- a/lib/asaas.ts
+++ b/lib/asaas.ts
@@ -1,3 +1,8 @@
+import {
+  MAX_ITEM_DESCRIPTION_LENGTH,
+  MAX_ITEM_NAME_LENGTH,
+} from "./constants";
+
 export function buildCheckoutUrl(baseUrl: string): string {
   return baseUrl.replace(/\/$/, "") + "/checkouts";
 }
@@ -78,8 +83,8 @@ export async function createCheckout(
     },
     minutesToExpire: 10,
     items: params.itens.map((i) => ({
-      description: i.description ?? i.name,
-      name: i.name,
+      description: (i.description ?? i.name).slice(0, MAX_ITEM_DESCRIPTION_LENGTH),
+      name: i.name.slice(0, MAX_ITEM_NAME_LENGTH),
       quantity: i.quantity,
       value: i.value,
     })),

--- a/lib/constants.ts
+++ b/lib/constants.ts
@@ -1,2 +1,5 @@
 export const PRECO_PULSEIRA = 10.0;
 export const PRECO_KIT = 50.0;
+
+export const MAX_ITEM_NAME_LENGTH = 30;
+export const MAX_ITEM_DESCRIPTION_LENGTH = 150;

--- a/logs/ERR_LOG.md
+++ b/logs/ERR_LOG.md
@@ -66,3 +66,5 @@
 
 ## [2025-06-26] Consulta por ID na clientes_config gerava 404. Commit c58e7c1 mudou para filtrar por campo cliente.
 ## [2025-06-17] Erro ao criar transferência: {"errors":[{"code":"invalid_action","description":"A sua conta ainda não está totalmente aprovada para utilizar o Pix."}]} - development
+
+## [2025-06-17] Limite de caracteres para checkout implementado - dev - 66b7255


### PR DESCRIPTION
## Summary
- restrict item `name` and `description` length
- truncate item values before sending to Asaas
- enforce max length in product and event forms
- document fix in ERR_LOG

## Testing
- `npm run lint` *(fails: next not found)*
- `npm run build` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_6851ae0e7ce4832ca665234be97df0a2