### PR TITLE
Use toast for feedback

### DIFF
--- a/app/admin/usuarios/novo/page.tsx
+++ b/app/admin/usuarios/novo/page.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useState, useEffect } from "react";
+import { useToast } from "@/lib/context/ToastContext";
 
 interface Campo {
   id: string;
@@ -24,6 +25,7 @@ function formatCpf(value: string) {
 }
 
 export default function NovoUsuarioPage() {
+  const { showError, showSuccess } = useToast();
   const [nome, setNome] = useState("");
   const [email, setEmail] = useState("");
   const [senha, setSenha] = useState("");
@@ -33,7 +35,6 @@ export default function NovoUsuarioPage() {
   const [role, setRole] = useState("usuario");
   const [campoId, setCampoId] = useState("");
   const [campos, setCampos] = useState<Campo[]>([]);
-  const [mensagem, setMensagem] = useState("");
 
   useEffect(() => {
     const token = localStorage.getItem("pb_token");
@@ -47,7 +48,7 @@ export default function NovoUsuarioPage() {
     })
       .then((res) => res.json())
       .then((data) => setCampos(data))
-      .catch(() => setMensagem("❌ Erro ao carregar os campos."));
+      .catch(() => showError("Erro ao carregar os campos."));
   }, []);
 
   async function handleSubmit(e: React.FormEvent) {
@@ -79,7 +80,7 @@ export default function NovoUsuarioPage() {
     const data = await res.json();
 
     if (res.ok) {
-      setMensagem("✅ Usuário cadastrado com sucesso!");
+      showSuccess("Usuário cadastrado com sucesso!");
       setNome("");
       setEmail("");
       setSenha("");
@@ -89,23 +90,13 @@ export default function NovoUsuarioPage() {
       setRole("usuario");
       setCampoId("");
     } else {
-      setMensagem("❌ Erro: " + (data?.error || "Erro desconhecido"));
+      showError("Erro: " + (data?.error || "Erro desconhecido"));
     }
   }
 
   return (
     <main className="max-w-xl mx-auto px-4 py-8">
       <h1 className="text-2xl font-bold mb-4">Cadastrar Novo Usuário</h1>
-
-      {mensagem && (
-        <div
-          className={`mb-4 text-sm ${
-            mensagem.startsWith("✅") ? "text-green-600" : "text-red-600"
-          }`}
-        >
-          {mensagem}
-        </div>
-      )}
 
       <form onSubmit={handleSubmit} className="space-y-4">
         <input

--- a/app/admin/usuarios/page.tsx
+++ b/app/admin/usuarios/page.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useEffect, useState } from "react";
+import { useToast } from "@/lib/context/ToastContext";
 import Link from "next/link";
 import type { Evento } from "@/types";
 import LoadingOverlay from "@/components/LoadingOverlay";
@@ -18,9 +19,9 @@ interface Usuario {
 }
 
 export default function UsuariosPage() {
+  const { showError } = useToast();
   const [usuarios, setUsuarios] = useState<Usuario[]>([]);
   const [loading, setLoading] = useState(true);
-  const [mensagem, setMensagem] = useState("");
   const [eventos, setEventos] = useState<Evento[]>([]);
   const [eventoId, setEventoId] = useState("");
 
@@ -39,7 +40,7 @@ export default function UsuariosPage() {
 
         if (!res.ok) {
           const erro = await res.json();
-          setMensagem("Erro ao buscar usuários: " + erro.error);
+          showError("Erro ao buscar usuários: " + erro.error);
           return;
         }
 
@@ -47,7 +48,7 @@ export default function UsuariosPage() {
         setUsuarios(data);
       } catch (error) {
         console.error("❌ Erro ao carregar usuários:", error);
-        setMensagem("Erro inesperado ao carregar usuários.");
+        showError("Erro inesperado ao carregar usuários.");
       } finally {
         setLoading(false);
       }
@@ -107,12 +108,6 @@ export default function UsuariosPage() {
           </Link>
         </div>
       </div>
-
-      {mensagem && (
-        <div className="mb-4 text-sm text-red-600 text-center">
-          {mensagem}
-        </div>
-      )}
 
       {loading ? (
         <LoadingOverlay show={true} text="Carregando usuários..." />

--- a/app/campos/page.tsx
+++ b/app/campos/page.tsx
@@ -2,6 +2,7 @@
 
 import { useEffect, useState } from "react";
 import { logInfo } from "@/lib/logger";
+import { useToast } from "@/lib/context/ToastContext";
 
 interface Campo {
   id: string;
@@ -9,10 +10,10 @@ interface Campo {
 }
 
 export default function GerenciarCamposPage() {
+  const { showError, showSuccess } = useToast();
   const [campos, setCampos] = useState<Campo[]>([]);
   const [nome, setNome] = useState("");
   const [editandoId, setEditandoId] = useState<string | null>(null);
-  const [mensagem, setMensagem] = useState("");
   const [loading, setLoading] = useState(false);
 
   const token =
@@ -26,7 +27,7 @@ export default function GerenciarCamposPage() {
       logInfo("🔐 Iniciando carregamento de campos...");
       if (!token || !user) {
         logInfo("⚠️ Usuário ou token ausente.");
-        setMensagem("Usuário não autenticado.");
+        showError("Usuário não autenticado.");
         return;
       }
 
@@ -43,22 +44,23 @@ export default function GerenciarCamposPage() {
 
         if (!res.ok) {
           console.error("❌ Erro ao buscar campos:", data);
-          setMensagem("Erro: " + data.error);
+          showError("Erro: " + data.error);
           return;
         }
 
         if (!Array.isArray(data)) {
           logInfo("⚠️ Resposta inesperada", data);
-          setMensagem("Dados inválidos recebidos.");
+          showError("Dados inválidos recebidos.");
           return;
         }
 
         setCampos(data);
-        setMensagem(`✅ ${data.length} campos carregados.`);
+        showSuccess(`${data.length} campos carregados.`);
       } catch (err: unknown) {
         if (err instanceof Error) {
           console.error("Erro:", err.message);
         }
+        showError("Erro ao carregar campos.");
       }
     }
 
@@ -68,10 +70,9 @@ export default function GerenciarCamposPage() {
   async function handleCriarOuAtualizar(e: React.FormEvent) {
     e.preventDefault();
     setLoading(true);
-    setMensagem("");
 
     if (!token || !user) {
-      setMensagem("Usuário não autenticado.");
+      showError("Usuário não autenticado.");
       return;
     }
 
@@ -92,18 +93,19 @@ export default function GerenciarCamposPage() {
       const data = await res.json();
 
       if (res.ok) {
-        setMensagem(editandoId ? "✅ Campo atualizado" : "✅ Campo criado");
+        showSuccess(editandoId ? "Campo atualizado" : "Campo criado");
         setNome("");
         setEditandoId(null);
         await fetchCampos(); // chamada separada para carregar após salvar
       } else {
-        setMensagem("Erro: " + data.error);
+        showError("Erro: " + data.error);
         console.error("❌ Erro no envio:", data);
       }
     } catch (err: unknown) {
       if (err instanceof Error) {
         console.error("Erro:", err.message);
       }
+      showError("Erro ao enviar dados.");
     } finally {
       setLoading(false);
     }
@@ -130,7 +132,7 @@ export default function GerenciarCamposPage() {
     if (!confirm("Tem certeza que deseja excluir este campo?")) return;
 
     if (!token || !user) {
-      setMensagem("Usuário não autenticado.");
+      showError("Usuário não autenticado.");
       return;
     }
 
@@ -146,16 +148,17 @@ export default function GerenciarCamposPage() {
       const data = await res.json();
 
       if (res.ok) {
-        setMensagem("✅ Campo excluído com sucesso");
+        showSuccess("Campo excluído com sucesso");
         await fetchCampos();
       } else {
-        setMensagem("Erro: " + data.error);
+        showError("Erro: " + data.error);
         console.error("❌ Erro ao excluir:", data);
       }
     } catch (err: unknown) {
       if (err instanceof Error) {
         console.error("Erro:", err.message);
       }
+      showError("Erro ao excluir campo.");
     }
   }
 
@@ -167,10 +170,6 @@ export default function GerenciarCamposPage() {
   return (
     <main className="max-w-xl mx-auto px-4 py-8">
       <h1 className="text-2xl font-bold mb-4">Gerenciar Campos de Atuação</h1>
-
-      {mensagem && (
-        <div className="mb-4 text-sm text-center text-gray-800">{mensagem}</div>
-      )}
 
       {/* Formulário de criação/edição */}
       <form onSubmit={handleCriarOuAtualizar} className="space-y-4 mb-6">


### PR DESCRIPTION
## Summary
- use toast in Admin Usuarios
- toast feedback on new user form
- toast messages on admin campos pages
- toast messages on campos page

## Testing
- `npm run lint` *(fails: next not found)*
- `npm run build` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_6851f46ab250832ca91f956a37062b44