### PR TITLE
Atualizar mensagem de erro 409

### DIFF
--- a/app/admin/api/inscricoes/route.ts
+++ b/app/admin/api/inscricoes/route.ts
@@ -91,7 +91,10 @@ export async function POST(req: NextRequest) {
           `telefone="${telefoneNumerico}" || cpf="${cpfNumerico}"`
         );
       return NextResponse.json(
-        { erro: "Telefone ou CPF já cadastrado." },
+        {
+          erro:
+            "Telefone ou CPF já cadastrado. Acesse /admin/inscricoes/recuperar para obter o link.",
+        },
         { status: 409 }
       );
     } catch {

--- a/logs/DOC_LOG.md
+++ b/logs/DOC_LOG.md
@@ -133,3 +133,5 @@
 ## [2025-06-30] Callback do Asaas usa URLs do cliente e user-agent com nome do tenant. Lint e build executados.
 ## [2025-07-01] README atualizado explicando que toasts são o padrão para feedback. Impacto: documentação mais clara.
 ## [2025-06-17] Tratamento de erro em /loja/api/inscricoes aprimorado usando ClientResponseError. Lint e build executados.
+
+## [2025-06-17] Atualizada mensagem 409 em inscricoes


### PR DESCRIPTION
## Summary
- update inscricoes route with details for recovery link
- log the new message in `DOC_LOG.md`

## Testing
- `npm run lint` *(fails: next not found)*
- `npm run build` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_6851fdfed880832ca7eb20ef8246b10f