### PR TITLE
Implement toast feedback for transfer forms

### DIFF
--- a/app/admin/financeiro/transferencias/components/TransferenciaForm.tsx
+++ b/app/admin/financeiro/transferencias/components/TransferenciaForm.tsx
@@ -3,6 +3,7 @@
 import { useState, useEffect } from "react";
 import usePocketBase from "@/lib/hooks/usePocketBase";
 import { useAuthContext } from "@/lib/context/AuthContext";
+import { useToast } from "@/lib/context/ToastContext";
 import {
   getBankAccountsByTenant,
   getPixKeysByTenant,
@@ -30,10 +31,10 @@ export default function TransferenciaForm({
     | (ClienteContaBancariaRecord & { kind: "bank" })
     | (PixKeyRecord & { kind: "pix" });
   const [contas, setContas] = useState<ContaOption[]>([]);
-  const [erro, setErro] = useState("");
   const [loading, setLoading] = useState(false);
   const pb = usePocketBase();
   const { tenantId } = useAuthContext();
+  const { showError } = useToast();
 
   const selected = contas.find((c) => c.id === destino);
   const isPix = selected?.kind === "pix";
@@ -55,10 +56,9 @@ export default function TransferenciaForm({
 
   async function handleSubmit(e: React.FormEvent) {
     e.preventDefault();
-    setErro("");
     const parsed = Number(valor);
     if (!destino || isNaN(parsed) || parsed <= 0) {
-      setErro("Dados inv\u00e1lidos.");
+      showError("Dados inv\u00e1lidos.");
       return;
     }
     setLoading(true);
@@ -66,7 +66,7 @@ export default function TransferenciaForm({
       const pixKey = isPix ? (selected as PixKeyRecord & { kind: "pix" }) : undefined;
       await onTransfer?.(destino, parsed, description, isPix, pixKey);
     } catch {
-      setErro("Erro ao transferir.");
+      showError("Erro ao transferir.");
     } finally {
       setLoading(false);
     }
@@ -74,7 +74,6 @@ export default function TransferenciaForm({
 
   return (
     <form onSubmit={handleSubmit} className="space-y-4 max-w-sm">
-      {erro && <p className="text-sm text-error-600">{erro}</p>}
       <select
         className="input-base"
         value={destino}

--- a/app/admin/financeiro/transferencias/modals/BankAccountModal.tsx
+++ b/app/admin/financeiro/transferencias/modals/BankAccountModal.tsx
@@ -17,6 +17,7 @@ import {
   isValidCNPJ,
   isValidDate,
 } from "@/utils/validators";
+import { useToast } from "@/lib/context/ToastContext";
 
 interface BankAccountModalProps {
   open: boolean;
@@ -44,7 +45,7 @@ export default function BankAccountModal({ open, onClose }: BankAccountModalProp
   const [pixAddressKeyType, setPixAddressKeyType] = useState("cpf");
   const [description, setDescription] = useState("");
   const [scheduleDate, setScheduleDate] = useState("");
-  const [erro, setErro] = useState("");
+  const { showError, showSuccess } = useToast();
 
   useEffect(() => {
     searchBanks("")
@@ -76,13 +77,12 @@ export default function BankAccountModal({ open, onClose }: BankAccountModalProp
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
     if (!user) return;
-    setErro("");
     if (cpfCnpj && !isValidCPF(cpfCnpj) && !isValidCNPJ(cpfCnpj)) {
-      setErro("CPF/CNPJ inválido.");
+      showError("CPF/CNPJ inválido.");
       return;
     }
     if (ownerBirthDate && !isValidDate(ownerBirthDate)) {
-      setErro("Data de nascimento inválida.");
+      showError("Data de nascimento inválida.");
       return;
     }
     try {
@@ -118,10 +118,11 @@ export default function BankAccountModal({ open, onClose }: BankAccountModalProp
           (user as UserModel & { cliente?: string }).cliente || user.id
         );
       }
+      showSuccess("Conta salva!");
       onClose();
     } catch (err) {
       console.error(err);
-      setErro("Erro ao salvar.");
+      showError("Erro ao salvar.");
     }
   };
 
@@ -266,7 +267,6 @@ export default function BankAccountModal({ open, onClose }: BankAccountModalProp
             },
           ]}
         />
-        {erro && <p className="text-error-600 text-sm">{erro}</p>}
         <div className="flex justify-end gap-2 pt-2">
           <button type="button" className="btn btn-secondary" onClick={onClose}>
             Cancelar


### PR DESCRIPTION
## Summary
- display validation errors via toast on TransferenciaForm
- show toast messages in BankAccountModal

## Testing
- `npm run lint`
- `npm run build` *(fails: Unexpected any)*

------
https://chatgpt.com/codex/tasks/task_e_6851fe8ce07c832c9e31f0cd649d1981