### PR TITLE
Atualiza docs sobre dependências antes de lint e build

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,6 +1,7 @@
 # Contribuindo
 
 Este projeto segue algumas boas práticas para manter a qualidade do código e da documentação.
+Após clonar o repositório, execute `npm install` para instalar o **Next**, o **Vitest** e todas as demais dependências.
 
 ## Validação de código
 

--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ Consulte a [documentação de deploy do Next.js](https://nextjs.org/docs/app/bui
 ## Lint e boas práticas
 
 Execute `npm run lint` para verificar problemas de código. Evite o uso de `any` especificando tipos adequados e sempre inclua todas as dependências utilizadas dentro dos hooks `useEffect`.
-Antes de rodar o lint ou o TypeScript (`tsc`), execute `npm install` para garantir que todas as dependências estejam disponíveis.
+Antes de rodar `npm run lint`, `npm run build` ou `npm run test`, execute `npm install` para garantir que todos os pacotes (como **Next** e **Vitest**) estejam disponíveis.
 
 ## Funcionalidades Adicionais
 

--- a/docs/testes.md
+++ b/docs/testes.md
@@ -23,4 +23,6 @@ npm run lint
 npm run test
 ```
 
+Antes de rodar `npm run lint`, `npm run build` ou `npm run test`, certifique-se de executar `npm install` para instalar todos os módulos necessários, como **Next** e **Vitest**.
+
 Recomenda-se executar estes comandos antes de abrir um pull request.

--- a/logs/DOC_LOG.md
+++ b/logs/DOC_LOG.md
@@ -135,3 +135,4 @@
 ## [2025-06-17] Tratamento de erro em /loja/api/inscricoes aprimorado usando ClientResponseError. Lint e build executados.
 
 ## [2025-06-17] Atualizada mensagem 409 em inscricoes
+## [2025-07-02] Documentação atualizada indicando `npm install` antes de rodar lint, build ou testes. Nota adicionada ao CONTRIBUTING. Impacto: evitar erros por dependências ausentes.


### PR DESCRIPTION
## Summary
- atualiza README informando que `npm install` é necessário antes de `npm run lint`, `npm run build` ou `npm run test`
- inclui mesma observação em `docs/testes.md`
- reforça no `CONTRIBUTING.md` que é preciso rodar `npm install` após o clone
- registra mudança em `logs/DOC_LOG.md`

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_685218216028832ca09634169368e10b