### PR TITLE
Implement Asaas reverse charge calculation

### DIFF
--- a/__tests__/admin/asaasRoute.test.ts
+++ b/__tests__/admin/asaasRoute.test.ts
@@ -36,7 +36,7 @@ describe('POST /admin/api/asaas', () => {
       user: { role: 'coordenador' }
     })
     delete process.env.ASAAS_API_KEY
-    const req = new Request('http://test', { method: 'POST', body: JSON.stringify({ pedidoId:'1', valor:1 }) })
+    const req = new Request('http://test', { method: 'POST', body: JSON.stringify({ pedidoId:'1', valorLiquido:1, paymentMethod:'pix', installments:1 }) })
     await expect(POST(req as unknown as NextRequest)).rejects.toThrow()
   })
 })

--- a/__tests__/asaasCheckout.test.ts
+++ b/__tests__/asaasCheckout.test.ts
@@ -31,7 +31,8 @@ describe('checkout route', () => {
   });
 
   const basePayload = {
-    valor: 10,
+    valorLiquido: 10,
+    paymentMethod: 'pix',
     itens: [
       {
         name: 'p',
@@ -83,6 +84,8 @@ describe('checkout route', () => {
     expect(sentBody.externalReference).toBe(
       'cliente_cli1_usuario_user1_inscricao_ins1'
     );
+    expect(sentBody.value).toBe(12.69);
+    expect(sentBody.split[0].fixedValue).toBe(0.7);
     expect(data.checkoutUrl).toBe('url');
   });
 
@@ -91,7 +94,7 @@ describe('checkout route', () => {
       method: 'POST',
       body: JSON.stringify({
         ...basePayload,
-        valor: 'a',
+        valorLiquido: 'a',
         itens: [],
       })
     });

--- a/__tests__/calculateGross.test.ts
+++ b/__tests__/calculateGross.test.ts
@@ -1,0 +1,14 @@
+import { describe, it, expect } from 'vitest'
+import { calculateGross } from '../lib/asaasFees'
+
+describe('calculateGross', () => {
+  it('calcula valor para pix', () => {
+    const { gross, margin } = calculateGross(50, 'pix', 1)
+    expect(gross).toBe(55.49)
+    expect(margin).toBe(3.5)
+  })
+  it('calcula valor para credito 3x', () => {
+    const { gross } = calculateGross(50, 'credito', 3)
+    expect(gross).toBeCloseTo(56.06, 2)
+  })
+})

--- a/app/admin/api/asaas/checkout/route.ts
+++ b/app/admin/api/asaas/checkout/route.ts
@@ -10,7 +10,8 @@ import {
 } from "@/lib/constants";
 
 const checkoutSchema = z.object({
-  valor: z.number(),
+  valorLiquido: z.number(),
+  paymentMethod: z.enum(["pix", "boleto", "debito", "credito"]),
   itens: z
     .array(
       z.object({
@@ -38,7 +39,7 @@ const checkoutSchema = z.object({
     cep: z.string(),
     cidade: z.string(),
   }),
-  installments: z.number().int().min(1).max(2).optional(),
+  installments: z.number().int().min(1).max(21),
   paymentMethods: z
     .array(z.enum(["PIX", "CREDIT_CARD"]))
     .min(1)
@@ -74,7 +75,8 @@ export async function POST(req: NextRequest) {
     }
 
     const {
-      valor,
+      valorLiquido,
+      paymentMethod,
       itens,
       successUrl,
       errorUrl,
@@ -100,7 +102,8 @@ export async function POST(req: NextRequest) {
     const userAgent = cliente.nome;
 
     logInfo("🔧 Chamando createCheckout com:", {
-      valor,
+      valorLiquido,
+      paymentMethod,
       itens,
       successUrl,
       errorUrl,
@@ -116,7 +119,8 @@ export async function POST(req: NextRequest) {
 
     const checkoutUrl = await createCheckout(
       {
-        valor,
+        valorLiquido,
+        paymentMethod,
         itens,
         successUrl,
         errorUrl,

--- a/app/loja/api/compras/[id]/reenviar/route.ts
+++ b/app/loja/api/compras/[id]/reenviar/route.ts
@@ -1,6 +1,7 @@
 import { NextRequest, NextResponse } from "next/server";
 import { requireRole } from "@/lib/apiAuth";
 import { createCheckout } from "@/lib/asaas";
+import type { PaymentMethod } from "@/lib/asaasFees";
 import type { Compra } from "@/types";
 
 interface UsuarioInfo {
@@ -79,7 +80,11 @@ export async function POST(req: NextRequest): Promise<NextResponse> {
 
     const checkoutUrl = await createCheckout(
       {
-        valor: Number(compra.valor_total),
+        valorLiquido: Number(compra.valor_total),
+        paymentMethod:
+          compra.metodo_pagamento === "cartao"
+            ? "credito"
+            : (compra.metodo_pagamento as PaymentMethod),
         itens,
         successUrl: `${req.nextUrl.origin}/loja/sucesso?compra=${compra.id}`,
         errorUrl: `${req.nextUrl.origin}/loja/sucesso?compra=${compra.id}`,

--- a/lib/asaasFees.ts
+++ b/lib/asaasFees.ts
@@ -1,0 +1,39 @@
+export type PaymentMethod = 'pix' | 'boleto' | 'debito' | 'credito'
+
+interface FeeRange { min: number; max: number; fixed: number; percent: number }
+
+const feeTable: Record<PaymentMethod, FeeRange[]> = {
+  pix: [{ min: 1, max: 1, fixed: 1.99, percent: 0 }],
+  boleto: [{ min: 1, max: 1, fixed: 1.99, percent: 0 }],
+  debito: [{ min: 1, max: 1, fixed: 0.35, percent: 0.0189 }],
+  credito: [
+    { min: 1, max: 1, fixed: 0.49, percent: 0.0299 },
+    { min: 2, max: 6, fixed: 0.49, percent: 0.0349 },
+    { min: 7, max: 12, fixed: 0.49, percent: 0.0399 },
+    { min: 13, max: 21, fixed: 0.49, percent: 0.0429 },
+  ],
+}
+
+export function getAsaasFees(payment: PaymentMethod, installments = 1) {
+  const ranges = feeTable[payment]
+  for (const r of ranges) {
+    if (installments >= r.min && installments <= r.max) {
+      return { fixedFee: r.fixed, percentFee: r.percent }
+    }
+  }
+  // fallback to last range
+  const last = ranges[ranges.length - 1]
+  return { fixedFee: last.fixed, percentFee: last.percent }
+}
+
+export function calculateGross(
+  V: number,
+  payment: PaymentMethod,
+  installments: number,
+): { gross: number; margin: number } {
+  const M = 0.07
+  const { fixedFee: F, percentFee: P } = getAsaasFees(payment, installments)
+  const gross = Number(((V * (1 + M) + F) / (1 - P)).toFixed(2))
+  const margin = Number((V * M).toFixed(2))
+  return { gross, margin }
+}

--- a/logs/DOC_LOG.md
+++ b/logs/DOC_LOG.md
@@ -135,3 +135,4 @@
 ## [2025-06-17] Tratamento de erro em /loja/api/inscricoes aprimorado usando ClientResponseError. Lint e build executados.
 
 ## [2025-06-17] Atualizada mensagem 409 em inscricoes
+## [2025-06-18] Implementada utilidade de taxas do Asaas e cálculo reverso nas rotas de checkout e cobrança. - Lint: falhou (next not found) - Build: falhou (next not found)


### PR DESCRIPTION
## Summary
- store Asaas fees table and add function to calculate gross value
- compute gross values in createCheckout and Asaas routes
- adjust API routes to accept desired net value and payment info
- record calculated values in PocketBase
- update checkout flow for compras
- add unit tests for new calculations

## Testing
- `npm run lint` *(fails: next not found)*
- `npm run build` *(fails: next not found)*
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68521854a638832cb5a32081cf023640