### PR TITLE
Fix margin calculation in Asaas utilities

### DIFF
--- a/lib/asaasFees.ts
+++ b/lib/asaasFees.ts
@@ -31,9 +31,8 @@ export function calculateGross(
   payment: PaymentMethod,
   installments: number,
 ): { gross: number; margin: number } {
-  const M = 0.07
+  const margin = Number((V * 0.07).toFixed(2))
   const { fixedFee: F, percentFee: P } = getAsaasFees(payment, installments)
-  const gross = Number(((V * (1 + M) + F) / (1 - P)).toFixed(2))
-  const margin = Number((V * M).toFixed(2))
+  const gross = Number(((V + margin + F) / (1 - P)).toFixed(2))
   return { gross, margin }
 }


### PR DESCRIPTION
## Summary
- calculate margin directly from the net value in `calculateGross`
- ensure checkout and payment payloads send this computed margin for split

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68521a724314832ca565a00f660c4171