### PR TITLE
Add Asaas payment method mapping

### DIFF
--- a/__tests__/asaasCheckout.test.ts
+++ b/__tests__/asaasCheckout.test.ts
@@ -59,7 +59,7 @@ describe('checkout route', () => {
       cidade: '123',
     },
     installments: 1,
-    paymentMethods: ['PIX', 'CREDIT_CARD'],
+    // billing types inferred via toAsaasBilling
   };
 
   it('executa POST e retorna checkoutUrl', async () => {
@@ -84,6 +84,7 @@ describe('checkout route', () => {
     expect(sentBody.externalReference).toBe(
       'cliente_cli1_usuario_user1_inscricao_ins1'
     );
+    expect(sentBody.billingTypes).toEqual(['PIX']);
     expect(sentBody.value).toBe(12.69);
     expect(sentBody.split[0].fixedValue).toBe(0.7);
     expect(data.checkoutUrl).toBe('url');

--- a/__tests__/paymentMethodMap.test.ts
+++ b/__tests__/paymentMethodMap.test.ts
@@ -1,0 +1,11 @@
+import { describe, it, expect } from 'vitest'
+import { toAsaasBilling } from '../lib/paymentMethodMap'
+
+describe('toAsaasBilling', () => {
+  it('converte formas de pagamento', () => {
+    expect(toAsaasBilling('pix')).toBe('PIX')
+    expect(toAsaasBilling('boleto')).toBe('BOLETO')
+    expect(toAsaasBilling('debito')).toBe('DEBIT_CARD')
+    expect(toAsaasBilling('credito')).toBe('CREDIT_CARD')
+  })
+})

--- a/app/admin/api/asaas/route.ts
+++ b/app/admin/api/asaas/route.ts
@@ -3,6 +3,7 @@ import { requireClienteFromHost } from "@/lib/clienteAuth";
 import { logInfo } from "@/lib/logger";
 import { buildExternalReference } from "@/lib/asaas";
 import { calculateGross, PaymentMethod } from "@/lib/asaasFees";
+import { toAsaasBilling } from "@/lib/paymentMethodMap";
 import { logConciliacaoErro } from "@/lib/server/logger";
 
 export async function POST(req: NextRequest) {
@@ -188,7 +189,7 @@ export async function POST(req: NextRequest) {
 
     const paymentPayload = {
       customer: clienteId,
-      billingType: "UNDEFINED",
+      billingType: toAsaasBilling(paymentMethod as PaymentMethod),
       value: gross,
       dueDate: dueDateStr,
       description: pedido.produto || "Produto",

--- a/lib/asaas.ts
+++ b/lib/asaas.ts
@@ -1,5 +1,6 @@
 import { MAX_ITEM_DESCRIPTION_LENGTH, MAX_ITEM_NAME_LENGTH } from "./constants";
 import { calculateGross, PaymentMethod } from "./asaasFees";
+import { toAsaasBilling } from "./paymentMethodMap";
 
 export function buildCheckoutUrl(baseUrl: string): string {
   return baseUrl.replace(/\/$/, "") + "/checkouts";
@@ -75,7 +76,8 @@ export async function createCheckout(
   );
 
   const payload = {
-    billingTypes: params.paymentMethods ?? ["CREDIT_CARD", "PIX"],
+    billingTypes:
+      params.paymentMethods ?? [toAsaasBilling(params.paymentMethod)],
     chargeTypes: ["DETACHED", "INSTALLMENT"],
     callback: {
       successUrl: params.successUrl,

--- a/lib/paymentMethodMap.ts
+++ b/lib/paymentMethodMap.ts
@@ -1,0 +1,16 @@
+import { PaymentMethod } from './asaasFees'
+
+export function toAsaasBilling(method: PaymentMethod): string {
+  switch (method) {
+    case 'pix':
+      return 'PIX'
+    case 'boleto':
+      return 'BOLETO'
+    case 'debito':
+      return 'DEBIT_CARD'
+    case 'credito':
+      return 'CREDIT_CARD'
+    default:
+      return 'UNDEFINED'
+  }
+}


### PR DESCRIPTION
## Summary
- map internal payment methods to Asaas billing codes
- use new mapper in Asaas API route and createCheckout
- update checkout tests to assert billingTypes
- add unit tests for the mapper

## Testing
- `npm run lint` *(fails: 'Image' defined but never used in app/login/page.tsx)*
- `npm run build` *(fails: ESLint errors in app/login/page.tsx)*

------
https://chatgpt.com/codex/tasks/task_e_6852ae3fa9a8832cacbb8b1e97b2464a