### PR TITLE
Implementa pagamento único no checkout

### DIFF
--- a/app/loja/checkout/page.tsx
+++ b/app/loja/checkout/page.tsx
@@ -144,7 +144,9 @@ function CheckoutContent() {
           cidade,
         },
         installments,
-        paymentMethods: ["PIX", "CREDIT_CARD"],
+        paymentMethods: [
+          paymentMethod === "pix" ? "PIX" : "CREDIT_CARD",
+        ],
       };
 
       const token = localStorage.getItem("pb_token");


### PR DESCRIPTION
## Summary
- ajusta payload de checkout para usar apenas o método escolhido
- garante em teste que `billingTypes` recebe o array enviado

## Testing
- `npm run lint` *(fails: next not found)*
- `npm run build` *(fails: next not found)*
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6852b0a9041c832ca65f72d790f4fceb