### PR TITLE
Atualiza cálculo do total no checkout

### DIFF
--- a/app/loja/checkout/page.tsx
+++ b/app/loja/checkout/page.tsx
@@ -2,7 +2,7 @@
 
 import { useCart } from "@/lib/context/CartContext";
 import { useRouter, useSearchParams } from "next/navigation";
-import { Suspense, useState, useEffect } from "react";
+import { Suspense, useState, useEffect, useMemo } from "react";
 import { useAuthContext } from "@/lib/context/AuthContext";
 import { CheckCircle } from "lucide-react";
 import { hexToPtName } from "@/utils/colorNamePt";
@@ -35,9 +35,6 @@ function CheckoutContent() {
   const [status, setStatus] = useState<"idle" | "loading" | "success">("idle");
   const [paymentMethod, setPaymentMethod] = useState<PaymentMethod>("pix");
   const [installments, setInstallments] = useState(1);
-  const [gross, setGross] = useState(() =>
-    calculateGross(total, "pix", 1).gross
-  );
 
   useEffect(() => {
     if (user) {
@@ -62,16 +59,22 @@ function CheckoutContent() {
   const pedidoId = searchParams.get("pedido") || Date.now().toString();
   const total = itens.reduce((sum, i) => sum + i.preco * i.quantidade, 0);
 
+  const pixTotal = useMemo(
+    () => calculateGross(total, "pix", 1).gross,
+    [total],
+  );
+
+  const installmentGross = useMemo(
+    () => calculateGross(total, paymentMethod, installments).gross,
+    [total, paymentMethod, installments],
+  );
+
   useEffect(() => {
     if (paymentMethod !== "credito" && installments !== 1) {
       setInstallments(1);
     }
   }, [paymentMethod, installments]);
 
-  useEffect(() => {
-    const { gross: g } = calculateGross(total, paymentMethod, installments);
-    setGross(g);
-  }, [total, paymentMethod, installments]);
 
   function maskTelefone(valor: string) {
     // Remove tudo que não for número
@@ -402,11 +405,11 @@ function CheckoutContent() {
           <div className="border-t pt-4 space-y-1">
             <div className="flex justify-between text-base">
               <span>Total a pagar</span>
-              <span>{formatCurrency(gross)}</span>
+              <span>{formatCurrency(pixTotal)}</span>
             </div>
             <div className="flex justify-between text-sm text-gray-500">
               <span>Valor da parcela</span>
-              <span>{formatCurrency(gross / installments)}</span>
+              <span>{formatCurrency(installmentGross / installments)}</span>
             </div>
           </div>
           <button

--- a/docs/plano_calculo_cobrancas.md
+++ b/docs/plano_calculo_cobrancas.md
@@ -100,7 +100,8 @@ Para **Pix**, com V = R$ 50,00:
 1. O sistema cobra **R$ 55,49**.  
 2. O Asaas desconta R$ 1,99 → sobra R$ 53,50.  
 3. Via `split`, R$ 3,50 (7% de 50) vai para a plataforma.  
-4. R$ 50,00 fica com o coordenador.
+> - O sistema deve atualizar dinamicamente o valor de `G` e os detalhes de split sempre que o usuário alterar forma de pagamento ou número de parcelas.
+> - Ao exibir o "Total a pagar" para o cliente, sempre usar `calculateGross(total, "pix", 1)`. O cálculo com a forma de pagamento selecionada serve apenas para mostrar o valor das parcelas e enviar ao Asaas.
 
 Parcelado em 3x (Cartão 2–6x):
 

--- a/logs/DOC_LOG.md
+++ b/logs/DOC_LOG.md
@@ -138,3 +138,4 @@
 ## [2025-06-18] Implementada utilidade de taxas do Asaas e cálculo reverso nas rotas de checkout e cobrança. - Lint: falhou (next not found) - Build: falhou (next not found)
 ## [2025-07-02] Documentação atualizada indicando `npm install` antes de rodar lint, build ou testes. Nota adicionada ao CONTRIBUTING. Impacto: evitar erros por dependências ausentes.
 ## [2025-07-03] Atualizados exemplos de chamadas ao endpoint `/admin/api/asaas` com os campos `valorLiquido`, `paymentMethod` e `installments`. Lint e build executados.
+## [2025-07-04] Adicionada regra de exibição do total no checkout em docs/plano_calculo_cobrancas.md.


### PR DESCRIPTION
## Summary
- calcula `pixTotal` com `calculateGross(total, "pix", 1)`
- exibe sempre `pixTotal` como Total a pagar
- usa cálculo conforme forma de pagamento apenas para parcelas
- documenta a regra no guia de cobranças
- registra alteração no DOC_LOG

## Testing
- `npm run lint` *(fails: next not found)*
- `npm run build` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_6852b14d8b30832c90f88403ea6fb106