### PR TITLE
Implementa valor bruto em produtos

### DIFF
--- a/__tests__/ProdutosFiltradosPreco.test.tsx
+++ b/__tests__/ProdutosFiltradosPreco.test.tsx
@@ -1,0 +1,30 @@
+/* @vitest-environment jsdom */
+import { render, screen } from '@testing-library/react'
+import { describe, it, expect, vi } from 'vitest'
+import ProdutosFiltrados from '@/app/loja/produtos/ProdutosFiltrados'
+import { calculateGross } from '@/lib/asaasFees'
+
+vi.mock('next/image', () => ({
+  __esModule: true,
+  default: (props: any) => {
+    return <img {...props} alt={props.alt} />
+  }
+}))
+
+vi.mock('next/link', () => ({
+  __esModule: true,
+  default: ({ children, href }: any) => <a href={href}>{children}</a>
+}))
+
+describe('ProdutosFiltrados', () => {
+  it('exibe valor bruto calculado', () => {
+    const precoBase = 100
+    const { gross } = calculateGross(precoBase, 'pix', 1)
+    render(
+      <ProdutosFiltrados
+        produtos={[{ id: '1', nome: 'Prod', preco: precoBase, imagens: ['/img.jpg'], slug: 'prod' }]}
+      />
+    )
+    expect(screen.getByText(`R$ ${gross.toFixed(2).replace('.', ',')}`)).toBeInTheDocument()
+  })
+})

--- a/app/admin/produtos/editar/[id]/page.tsx
+++ b/app/admin/produtos/editar/[id]/page.tsx
@@ -3,6 +3,7 @@
 import { useEffect, useState, useCallback, useRef } from "react";
 import { useParams, useRouter } from "next/navigation";
 import { useAuthContext } from "@/lib/context/AuthContext";
+import { calculateGross } from "@/lib/asaasFees";
 import LoadingOverlay from "@/components/LoadingOverlay";
 
 interface Categoria {
@@ -42,6 +43,13 @@ export default function EditarProdutoPage() {
   const [tamanhos, setTamanhos] = useState<string[]>([]);
   const [generos, setGeneros] = useState<string[]>([]);
   const inputHex = useRef<HTMLInputElement | null>(null);
+  const [valorCliente, setValorCliente] = useState(
+    calculateGross(Number(initial?.preco ?? 0), "pix", 1).gross
+  );
+
+  useEffect(() => {
+    setValorCliente(calculateGross(Number(initial?.preco ?? 0), "pix", 1).gross);
+  }, [initial?.preco]);
 
   useEffect(() => {
     const { token, user } = getAuth();
@@ -258,8 +266,17 @@ export default function EditarProdutoPage() {
             step="0.01"
             placeholder="Ex: 39.90"
             defaultValue={String(initial.preco)}
+            onChange={(e) =>
+              setValorCliente(
+                calculateGross(Number(e.target.value || 0), "pix", 1).gross
+              )
+            }
             required
           />
+          <span className="text-xs text-gray-500 ml-1">
+            Valor para o cliente: R${" "}
+            {valorCliente.toFixed(2).replace(".", ",")}
+          </span>
           <input
             className="input-base"
             name="checkout_url"

--- a/app/admin/produtos/novo/ModalProduto.tsx
+++ b/app/admin/produtos/novo/ModalProduto.tsx
@@ -2,6 +2,7 @@
 
 import { useEffect, useRef, useCallback, useState } from "react";
 import { useAuthContext } from "@/lib/context/AuthContext";
+import { calculateGross } from "@/lib/asaasFees";
 import ModalCategoria from "../categorias/ModalCategoria";
 
 export interface ModalProdutoProps<T extends Record<string, unknown>> {
@@ -65,6 +66,9 @@ export function ModalProduto<T extends Record<string, unknown>>({
   // Novos estados para cor
   const [cores, setCores] = useState<string[]>([]);
   const inputHex = useRef<HTMLInputElement | null>(null);
+  const [valorCliente, setValorCliente] = useState(
+    calculateGross(Number(initial.preco ?? 0), "pix", 1).gross
+  );
 
   useEffect(() => {
     if (open) ref.current?.showModal();
@@ -228,8 +232,17 @@ export function ModalProduto<T extends Record<string, unknown>>({
                 type="number"
                 step="0.01"
                 defaultValue={initial.preco || ""}
+                onChange={(e) =>
+                  setValorCliente(
+                    calculateGross(Number(e.target.value || 0), "pix", 1).gross
+                  )
+                }
                 required
               />
+              <span className="text-xs text-gray-500 ml-1">
+                Valor para o cliente: R${" "}
+                {valorCliente.toFixed(2).replace(".", ",")}
+              </span>
             </div>
             <div>
               <label className="label-base">Categoria</label>

--- a/app/loja/produtos/ProdutosFiltrados.tsx
+++ b/app/loja/produtos/ProdutosFiltrados.tsx
@@ -3,6 +3,7 @@
 import Image from "next/image";
 import Link from "next/link";
 import { useMemo, useState } from "react";
+import { calculateGross } from "@/lib/asaasFees";
 
 const faixasPreco = [
   { label: "Até R$ 50", min: 0, max: 50 },
@@ -119,7 +120,9 @@ export default function ProdutosFiltrados({
                 {p.nome}
               </h2>
               <p className="text-base font-bold text-[var(--accent-900)] mb-2">
-                R$ {p.preco.toFixed(2).replace(".", ",")}
+                R$ {calculateGross(p.preco, "pix", 1).gross
+                  .toFixed(2)
+                  .replace(".", ",")}
               </p>
               <Link
                 href={`/loja/produtos/${p.slug}`}

--- a/app/loja/produtos/[slug]/ProdutoInterativo.tsx
+++ b/app/loja/produtos/[slug]/ProdutoInterativo.tsx
@@ -2,6 +2,7 @@
 import { useState, useRef, useEffect } from "react";
 import Image from "next/image";
 import type { Produto } from "@/types";
+import { calculateGross } from "@/lib/asaasFees";
 
 import AddToCartButton from "./AddToCartButton";
 
@@ -227,7 +228,9 @@ export default function ProdutoInterativo({
           {nome}
         </h1>
         <p className="text-xl font-semibold text-[var(--text-primary)]">
-          R$ {preco.toFixed(2).replace(".", ",")}
+          R$ {calculateGross(preco, "pix", 1).gross
+            .toFixed(2)
+            .replace(".", ",")}
         </p>
         <div className="hidden md:block">
           <DetalhesSelecao

--- a/app/loja/produtos/page.tsx
+++ b/app/loja/produtos/page.tsx
@@ -1,6 +1,7 @@
 import createPocketBase from "@/lib/pocketbase";
 import ProdutosFiltrados from "./ProdutosFiltrados";
 import { getTenantFromHost } from "@/lib/getTenantFromHost";
+import { calculateGross } from "@/lib/asaasFees";
 
 export const dynamic = "force-dynamic";
 
@@ -23,6 +24,7 @@ export default async function ProdutosPage() {
 
   const produtos = produtosPB.map((p) => ({
     ...p,
+    preco: calculateGross(p.preco, "pix", 1).gross,
     imagens: (p.imagens || []).map((img) => pb.files.getURL(p, img)),
   }));
 


### PR DESCRIPTION
## Summary
- mostrar valor bruto do cliente nos formulários de produtos do admin
- exibir preço bruto na loja
- ajustar página inicial de produtos para calcular preço bruto
- adicionar teste de vitest

## Testing
- `npm run lint` *(fails: 'config' is assigned a value but never used)*
- `npm run build` *(fails: same lint errors)*
- `npm run test` *(fails: multiple existing tests fail)*

------
https://chatgpt.com/codex/tasks/task_e_6852aec51b04832c925427f5edae589f