### PR TITLE
Conditionally show parcelas

### DIFF
--- a/__tests__/lojaCheckout.test.tsx
+++ b/__tests__/lojaCheckout.test.tsx
@@ -1,0 +1,43 @@
+/* @vitest-environment jsdom */
+import { render, screen } from '@testing-library/react';
+import { vi } from 'vitest';
+import CheckoutPage from '@/app/loja/checkout/page';
+
+vi.mock('@/lib/context/CartContext', () => ({
+  useCart: () => ({
+    itens: [
+      {
+        id: 'p1',
+        variationId: 'p1-',
+        nome: 'Produto',
+        preco: 10,
+        quantidade: 1,
+        slug: 'prod1',
+        generos: '',
+        tamanhos: '',
+        cores: '',
+      },
+    ],
+    clearCart: vi.fn(),
+  }),
+}));
+
+vi.mock('@/lib/context/AuthContext', () => ({
+  useAuthContext: () => ({
+    isLoggedIn: true,
+    user: { id: 'u1', nome: 'User' },
+    tenantId: 't1',
+  }),
+}));
+
+vi.mock('next/navigation', () => ({
+  useRouter: () => ({ replace: vi.fn(), push: vi.fn() }),
+  useSearchParams: () => ({ get: () => null }),
+}));
+
+describe('CheckoutContent', () => {
+  it('não exibe valor da parcela quando há uma parcela', () => {
+    render(<CheckoutPage />);
+    expect(screen.queryByText('Valor da parcela')).toBeNull();
+  });
+});

--- a/app/loja/checkout/page.tsx
+++ b/app/loja/checkout/page.tsx
@@ -404,10 +404,12 @@ function CheckoutContent() {
               <span>Total a pagar</span>
               <span>{formatCurrency(gross)}</span>
             </div>
-            <div className="flex justify-between text-sm text-gray-500">
-              <span>Valor da parcela</span>
-              <span>{formatCurrency(gross / installments)}</span>
-            </div>
+            {installments > 1 && (
+              <div className="flex justify-between text-sm text-gray-500">
+                <span>Valor da parcela</span>
+                <span>{formatCurrency(gross / installments)}</span>
+              </div>
+            )}
           </div>
           <button
             onClick={handleConfirm}


### PR DESCRIPTION
## Summary
- render installment value row only when there are multiple installments
- add test ensuring the row is hidden with one installment

## Testing
- `npm run lint` *(fails: config and TypingEffect unused)*
- `npm run build` *(fails: same lint errors)*

------
https://chatgpt.com/codex/tasks/task_e_6852b14d62f0832c87fb23476032a3cc