### PR TITLE
Implement installment payload logic

### DIFF
--- a/lib/asaas.ts
+++ b/lib/asaas.ts
@@ -75,10 +75,13 @@ export async function createCheckout(
     params.installments,
   );
 
+  const isInstallmentCredit =
+    params.paymentMethod === "credito" && params.installments > 1;
+
   const payload = {
     billingTypes:
       params.paymentMethods ?? [toAsaasBilling(params.paymentMethod)],
-    chargeTypes: ["DETACHED", "INSTALLMENT"],
+    chargeTypes: isInstallmentCredit ? ["INSTALLMENT"] : ["DETACHED"],
     callback: {
       successUrl: params.successUrl,
       cancelUrl: params.errorUrl,
@@ -106,7 +109,9 @@ export async function createCheckout(
       city: params.cliente.cidade,
       cpfCnpj: params.cliente.cpf,
     },
-    installment: { maxInstallmentCount: params.installments },
+    ...(isInstallmentCredit
+      ? { installment: { maxInstallmentCount: params.installments } }
+      : {}),
     customFields:
       (params.itens
         .map((item, idx) =>


### PR DESCRIPTION
## Summary
- support Asaas installment logic only for credit card multi-parcel
- adjust tests for checkout payload logic

## Testing
- `npm run lint` *(fails: config is assigned a value but never used)*
- `npm run build` *(fails: config is assigned a value but never used)*
- `npm test` *(fails: Tests failed. Watching for file changes...)*

------
https://chatgpt.com/codex/tasks/task_e_6852b87e7fa8832cbbda7bf90a54fb08