### PR TITLE
Conditionally show parcelas

### DIFF
--- a/__tests__/lojaCheckout.test.tsx
+++ b/__tests__/lojaCheckout.test.tsx
@@ -1,0 +1,49 @@
+/* @vitest-environment jsdom */
+import { render, screen } from '@testing-library/react';
+import { vi } from 'vitest';
+import CheckoutPage from '@/app/loja/checkout/page';
+
+vi.mock('@/lib/context/CartContext', () => ({
+  useCart: () => ({
+    itens: [
+      {
+        id: 'p1',
+        variationId: 'p1-',
+        nome: 'Produto',
+        preco: 10,
+        quantidade: 1,
+        slug: 'prod1',
+        generos: '',
+        tamanhos: '',
+        cores: '',
+      },
+    ],
+    clearCart: vi.fn(),
+  }),
+}));
+
+vi.mock('@/lib/context/AuthContext', () => ({
+  useAuthContext: () => ({
+    isLoggedIn: true,
+    user: { id: 'u1', nome: 'User' },
+    tenantId: 't1',
+  }),
+}));
+
+vi.mock('next/navigation', () => ({
+  useRouter: () => ({ replace: vi.fn(), push: vi.fn() }),
+  useSearchParams: () => ({ get: () => null }),
+}));
+
+describe('CheckoutContent', () => {
+  it('não exibe valor da parcela quando há uma parcela', () => {
+    render(<CheckoutPage />);
+    expect(screen.queryByText('Valor da parcela')).toBeNull();
+  });
+
+  it('limita opções de parcela a 6x', () => {
+    render(<CheckoutPage />);
+    const select = screen.getByLabelText('Parcelas');
+    expect(select.querySelectorAll('option')).toHaveLength(6);
+  });
+});

--- a/app/login/page.tsx
+++ b/app/login/page.tsx
@@ -2,7 +2,6 @@
 
 import { Suspense, useEffect, useState } from "react";
 import { useSearchParams } from "next/navigation";
-import { useAppConfig } from "@/lib/context/AppConfigContext";
 import LoginForm from "../components/LoginForm";
 import SignUpForm from "../components/SignUpForm";
 import LayoutWrapper from "../components/LayoutWrapper";
@@ -18,7 +17,6 @@ export default function LoginPage() {
 function LoginClient() {
   "use client";
   const searchParams = useSearchParams();
-  const { config } = useAppConfig();
   const initial = searchParams.get("view") === "signup" ? "signup" : "login";
   const [view, setView] = useState<"login" | "signup">(initial);
   const redirectTo = searchParams.get("redirect") || undefined;
@@ -65,17 +63,3 @@ function LoginClient() {
   );
 }
 
-// Opcional: animação de digitação (caso use em outro local)
-function TypingEffect({ text }: { text: string }) {
-  const [displayedText, setDisplayedText] = useState("");
-  useEffect(() => {
-    let i = 0;
-    const interval = setInterval(() => {
-      setDisplayedText((prev) => prev + text[i]);
-      i++;
-      if (i === text.length) clearInterval(interval);
-    }, 40);
-    return () => clearInterval(interval);
-  }, [text]);
-  return <span>{displayedText}</span>;
-}

--- a/app/loja/checkout/page.tsx
+++ b/app/loja/checkout/page.tsx
@@ -18,6 +18,7 @@ function formatCurrency(n: number) {
 
 function CheckoutContent() {
   const { itens, clearCart } = useCart();
+  const total = itens.reduce((sum, i) => sum + i.preco * i.quantidade, 0);
   const router = useRouter();
   const searchParams = useSearchParams();
   const { isLoggedIn, user, tenantId } = useAuthContext();
@@ -60,7 +61,6 @@ function CheckoutContent() {
   }, [isLoggedIn, router]);
 
   const pedidoId = searchParams.get("pedido") || Date.now().toString();
-  const total = itens.reduce((sum, i) => sum + i.preco * i.quantidade, 0);
 
   useEffect(() => {
     if (paymentMethod !== "credito" && installments !== 1) {
@@ -391,7 +391,7 @@ function CheckoutContent() {
                 onChange={(e) => setInstallments(Number(e.target.value))}
                 className="w-full bg-white border border-gray-200 rounded-lg px-3 py-2 text-sm focus:border-black focus:outline-none"
               >
-                {Array.from({ length: 21 }).map((_, i) => (
+                {Array.from({ length: 6 }).map((_, i) => (
                   <option key={i + 1} value={i + 1}>
                     {i + 1}x
                   </option>
@@ -404,10 +404,12 @@ function CheckoutContent() {
               <span>Total a pagar</span>
               <span>{formatCurrency(gross)}</span>
             </div>
-            <div className="flex justify-between text-sm text-gray-500">
-              <span>Valor da parcela</span>
-              <span>{formatCurrency(gross / installments)}</span>
-            </div>
+            {installments > 1 && (
+              <div className="flex justify-between text-sm text-gray-500">
+                <span>Valor da parcela</span>
+                <span>{formatCurrency(gross / installments)}</span>
+              </div>
+            )}
           </div>
           <button
             onClick={handleConfirm}


### PR DESCRIPTION
## Summary
- render installment value row only when there are multiple installments
- restrict checkout to 6 installment options
- remove unused code in the login page
- add unit test confirming parcel row hidden and options limited

## Testing
- `npm run lint`
- `npm run build`
- `npm test` *(fails: asaas checkout, calculateGross, posts utils, validators, API route tests)*

------
https://chatgpt.com/codex/tasks/task_e_6852b14d62f0832c87fb23476032a3cc