### PR TITLE
Disable credit installments when payment not credit

### DIFF
--- a/__tests__/lojaCheckout.test.tsx
+++ b/__tests__/lojaCheckout.test.tsx
@@ -40,4 +40,10 @@ describe('CheckoutContent', () => {
     render(<CheckoutPage />);
     expect(screen.queryByText('Valor da parcela')).toBeNull();
   });
+
+  it('desabilita select de parcelas quando forma de pagamento não é crédito', () => {
+    render(<CheckoutPage />);
+    const selects = screen.getAllByRole('combobox');
+    expect(selects[1]).toBeDisabled();
+  });
 });

--- a/app/loja/checkout/page.tsx
+++ b/app/loja/checkout/page.tsx
@@ -394,10 +394,11 @@ function CheckoutContent() {
                 Parcelas
               </label>
               <select
-                value={installments}
-                onChange={(e) => setInstallments(Number(e.target.value))}
-                className="w-full bg-white border border-gray-200 rounded-lg px-3 py-2 text-sm focus:border-black focus:outline-none"
-              >
+                  value={installments}
+                  onChange={(e) => setInstallments(Number(e.target.value))}
+                  disabled={paymentMethod !== "credito"}
+                  className="w-full bg-white border border-gray-200 rounded-lg px-3 py-2 text-sm focus:border-black focus:outline-none"
+                >
                 {Array.from({ length: 21 }).map((_, i) => (
                   <option key={i + 1} value={i + 1}>
                     {i + 1}x


### PR DESCRIPTION
## Summary
- disable installment select when payment method isn't credit
- add test covering this behaviour

## Testing
- `npm run lint` *(fails: 'useMemo' and others unused)*
- `npm run build` *(fails to compile due to ESLint errors)*

------
https://chatgpt.com/codex/tasks/task_e_6852c695159c832c8e1fa1333163d3ae