### PR TITLE
Atualiza cálculo de preços na loja

### DIFF
--- a/app/loja/carrinho/page.tsx
+++ b/app/loja/carrinho/page.tsx
@@ -17,7 +17,6 @@ export default function CarrinhoPage() {
   const { isLoggedIn } = useAuthContext();
   const router = useRouter();
   const [showPrompt, setShowPrompt] = useState(false);
-  const total = itens.reduce((sum, i) => sum + i.preco * i.quantidade, 0);
   const totalBruto = itens.reduce(
     (sum, i) => sum + calculateGross(i.preco, "pix", 1).gross * i.quantidade,
     0,

--- a/app/loja/produtos/ProdutosFiltrados.tsx
+++ b/app/loja/produtos/ProdutosFiltrados.tsx
@@ -103,35 +103,36 @@ export default function ProdutosFiltrados({
           <button className="btn btn-secondary">Filtrar</button>
         </div>
         <div className="grid grid-cols-2 sm:grid-cols-3 lg:grid-cols-4 gap-6">
-          {filtrados.map((p) => (
-            <div
-              key={p.id}
-              className="bg-white rounded-2xl shadow-lg border border-[var(--accent-900)]/10 flex flex-col items-center p-4 transition hover:shadow-xl"
-            >
-              <div className="w-full aspect-square overflow-hidden rounded-xl mb-2 bg-neutral-100 border border-[var(--accent)]/5 relative">
-                <Image
-                  src={p.imagens[0]}
-                  alt={p.nome}
-                  fill
-                  className="object-cover object-center transition group-hover:scale-105"
-                />
-              </div>
-              <h2 className="text-base font-semibold text-[var(--text-primary)] mb-1 line-clamp-2 text-center">
-                {p.nome}
-              </h2>
-              <p className="text-base font-bold text-[var(--accent-900)] mb-2">
-                R$ {calculateGross(p.preco, "pix", 1).gross
-                  .toFixed(2)
-                  .replace(".", ",")}
-              </p>
-              <Link
-                href={`/loja/produtos/${p.slug}`}
-                className="btn btn-primary w-full text-center mt-auto"
+          {filtrados.map((p) => {
+            const precoBruto = calculateGross(p.preco, "pix", 1).gross;
+            return (
+              <div
+                key={p.id}
+                className="bg-white rounded-2xl shadow-lg border border-[var(--accent-900)]/10 flex flex-col items-center p-4 transition hover:shadow-xl"
               >
-                Ver detalhes
-              </Link>
-            </div>
-          ))}
+                <div className="w-full aspect-square overflow-hidden rounded-xl mb-2 bg-neutral-100 border border-[var(--accent)]/5 relative">
+                  <Image
+                    src={p.imagens[0]}
+                    alt={p.nome}
+                    fill
+                    className="object-cover object-center transition group-hover:scale-105"
+                  />
+                </div>
+                <h2 className="text-base font-semibold text-[var(--text-primary)] mb-1 line-clamp-2 text-center">
+                  {p.nome}
+                </h2>
+                <p className="text-base font-bold text-[var(--accent-900)] mb-2">
+                  R$ {precoBruto.toFixed(2).replace(".", ",")}
+                </p>
+                <Link
+                  href={`/loja/produtos/${p.slug}`}
+                  className="btn btn-primary w-full text-center mt-auto"
+                >
+                  Ver detalhes
+                </Link>
+              </div>
+            );
+          })}
         </div>
       </section>
     </div>

--- a/app/loja/produtos/[slug]/ProdutoInterativo.tsx
+++ b/app/loja/produtos/[slug]/ProdutoInterativo.tsx
@@ -1,5 +1,5 @@
 "use client";
-import { useState, useRef, useEffect } from "react";
+import { useState, useRef, useEffect, useMemo } from "react";
 import Image from "next/image";
 import type { Produto } from "@/types";
 import { calculateGross } from "@/lib/asaasFees";
@@ -136,6 +136,11 @@ export default function ProdutoInterativo({
   const [indexImg, setIndexImg] = useState(0);
   const pauseRef = useRef(false);
 
+  const precoBruto = useMemo(
+    () => calculateGross(preco, "pix", 1).gross,
+    [preco],
+  );
+
   const firstImgKey = Object.keys(imagens)[0];
   const imgs = imagens[genero] || imagens["default"] || imagens[firstImgKey];
 
@@ -228,9 +233,7 @@ export default function ProdutoInterativo({
           {nome}
         </h1>
         <p className="text-xl font-semibold text-[var(--text-primary)]">
-          R$ {calculateGross(preco, "pix", 1).gross
-            .toFixed(2)
-            .replace(".", ",")}
+          R$ {precoBruto.toFixed(2).replace(".", ",")}
         </p>
         <div className="hidden md:block">
           <DetalhesSelecao

--- a/app/loja/produtos/page.tsx
+++ b/app/loja/produtos/page.tsx
@@ -1,7 +1,6 @@
 import createPocketBase from "@/lib/pocketbase";
 import ProdutosFiltrados from "./ProdutosFiltrados";
 import { getTenantFromHost } from "@/lib/getTenantFromHost";
-import { calculateGross } from "@/lib/asaasFees";
 
 export const dynamic = "force-dynamic";
 
@@ -24,7 +23,6 @@ export default async function ProdutosPage() {
 
   const produtos = produtosPB.map((p) => ({
     ...p,
-    preco: calculateGross(p.preco, "pix", 1).gross,
     imagens: (p.imagens || []).map((img) => pb.files.getURL(p, img)),
   }));
 


### PR DESCRIPTION
## Summary
- remove price conversion on product fetch so database prices are preserved
- compute gross price once inside `ProdutosFiltrados` and `ProdutoInterativo`
- clean unused total variable in cart page

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6852d6097d1c832c833f13d0f63d9692