### PR TITLE
Use calculateGross on cart preview total

### DIFF
--- a/__tests__/CarrinhoPreco.test.tsx
+++ b/__tests__/CarrinhoPreco.test.tsx
@@ -2,6 +2,7 @@
 import { render, screen } from "@testing-library/react";
 import { vi, describe, it, expect } from "vitest";
 import CarrinhoPage from "@/app/loja/carrinho/page";
+import CartPreview from "@/app/components/CartPreview";
 import { CartProvider } from "@/lib/context/CartContext";
 import { calculateGross } from "@/lib/asaasFees";
 
@@ -12,6 +13,11 @@ vi.mock("next/image", () => ({
 
 vi.mock("next/navigation", () => ({
   useRouter: () => ({ push: vi.fn() }),
+}));
+
+vi.mock("next/link", () => ({
+  __esModule: true,
+  default: ({ children, href }: any) => <a href={href}>{children}</a>,
 }));
 
 vi.mock("@/lib/context/AuthContext", () => ({
@@ -43,6 +49,21 @@ describe("CarrinhoPage", () => {
       </CartProvider>,
     );
     await screen.findByText("Carrinho");
+    expect(
+      screen.getByText(`R$ ${gross.toFixed(2).replace(".", ",")}`),
+    ).toBeInTheDocument();
+  });
+});
+
+describe("CartPreview", () => {
+  it("mostra total bruto calculado", () => {
+    const { preco } = renderWithItem();
+    const gross = calculateGross(preco, "pix", 1).gross;
+    render(
+      <CartProvider>
+        <CartPreview />
+      </CartProvider>,
+    );
     expect(
       screen.getByText(`R$ ${gross.toFixed(2).replace(".", ",")}`),
     ).toBeInTheDocument();

--- a/app/components/CartPreview.tsx
+++ b/app/components/CartPreview.tsx
@@ -3,10 +3,15 @@
 import Link from "next/link";
 import Image from "next/image";
 import { useCart } from "@/lib/context/CartContext";
+import { calculateGross } from "@/lib/asaasFees";
 
 export default function CartPreview() {
   const { itens } = useCart();
-  const total = itens.reduce((sum, i) => sum + i.preco * i.quantidade, 0);
+  const total = itens.reduce(
+    (sum, i) =>
+      sum + calculateGross(i.preco, "pix", 1).gross * i.quantidade,
+    0,
+  );
 
   if (itens.length === 0) {
     return (


### PR DESCRIPTION
## Summary
- use `calculateGross` to compute the cart preview total
- test that CartPreview displays the gross total value

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6852eaa9015c832caa45be36aa0d6d4b