### PR TITLE
Update checkout payment method payload

### DIFF
--- a/__tests__/asaasCheckout.test.ts
+++ b/__tests__/asaasCheckout.test.ts
@@ -84,7 +84,7 @@ describe('checkout route', () => {
     expect(sentBody.externalReference).toBe(
       'cliente_cli1_usuario_user1_inscricao_ins1'
     );
-    expect(sentBody.billingTypes).toEqual(['PIX']);
+    expect(sentBody.billingTypes).toEqual(basePayload.paymentMethods);
     expect(sentBody.chargeTypes).toEqual(['DETACHED']);
     expect(sentBody.installment).toBeUndefined();
     expect(sentBody.value).toBe(12.69);
@@ -99,19 +99,20 @@ describe('checkout route', () => {
     });
     global.fetch = fetchMock as unknown as typeof fetch;
 
+    const payload = {
+      ...basePayload,
+      paymentMethod: 'credito',
+      paymentMethods: ['CREDIT_CARD'],
+    };
     const req = new Request('http://test', {
       method: 'POST',
-      body: JSON.stringify({
-        ...basePayload,
-        paymentMethod: 'credito',
-        paymentMethods: ['CREDIT_CARD'],
-      })
+      body: JSON.stringify(payload)
     });
 
     const res = await POST(req as unknown as NextRequest);
     await res.json();
     const sentBody = JSON.parse(fetchMock.mock.calls[0][1].body);
-    expect(sentBody.billingTypes).toEqual(['CREDIT_CARD']);
+    expect(sentBody.billingTypes).toEqual(payload.paymentMethods);
     expect(sentBody.chargeTypes).toEqual(['DETACHED']);
     expect(sentBody.installment).toBeUndefined();
   });
@@ -123,19 +124,21 @@ describe('checkout route', () => {
     });
     global.fetch = fetchMock as unknown as typeof fetch;
 
+    const payload = {
+      ...basePayload,
+      paymentMethod: 'credito',
+      installments: 3,
+      paymentMethods: ['CREDIT_CARD'],
+    };
     const req = new Request('http://test', {
       method: 'POST',
-      body: JSON.stringify({
-        ...basePayload,
-        paymentMethod: 'credito',
-        installments: 3,
-        paymentMethods: ['CREDIT_CARD'],
-      })
+      body: JSON.stringify(payload)
     });
 
     const res = await POST(req as unknown as NextRequest);
     await res.json();
     const sentBody = JSON.parse(fetchMock.mock.calls[0][1].body);
+    expect(sentBody.billingTypes).toEqual(payload.paymentMethods);
     expect(sentBody.chargeTypes).toEqual(['INSTALLMENT']);
     expect(sentBody.installment).toEqual({ maxInstallmentCount: 3 });
   });

--- a/app/loja/checkout/page.tsx
+++ b/app/loja/checkout/page.tsx
@@ -148,7 +148,9 @@ function CheckoutContent() {
           cidade,
         },
         installments,
-        paymentMethods: ["PIX", "CREDIT_CARD"],
+        paymentMethods: [
+          paymentMethod === "pix" ? "PIX" : "CREDIT_CARD",
+        ],
       };
 
       const token = localStorage.getItem("pb_token");


### PR DESCRIPTION
## Summary
- send only the selected payment method in checkout
- improve tests to assert sent billing types

## Testing
- `npm run lint` *(fails: next not found)*
- `npm run build` *(fails: next not found)*
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6852f701a858832c8a5c5a17f75bd3f6