### PR TITLE
Fix Asaas charge types for installments

### DIFF
--- a/__tests__/asaasCheckout.test.ts
+++ b/__tests__/asaasCheckout.test.ts
@@ -139,7 +139,7 @@ describe('checkout route', () => {
     await res.json();
     const sentBody = JSON.parse(fetchMock.mock.calls[0][1].body);
     expect(sentBody.billingTypes).toEqual(payload.paymentMethods);
-    expect(sentBody.chargeTypes).toEqual(['INSTALLMENT']);
+    expect(sentBody.chargeTypes).toEqual(['DETACHED', 'INSTALLMENT']);
     expect(sentBody.installment).toEqual({ maxInstallmentCount: 3 });
   });
 

--- a/lib/asaas.ts
+++ b/lib/asaas.ts
@@ -81,7 +81,9 @@ export async function createCheckout(
   const payload = {
     billingTypes:
       params.paymentMethods ?? [toAsaasBilling(params.paymentMethod)],
-    chargeTypes: isInstallmentCredit ? ["INSTALLMENT"] : ["DETACHED"],
+    chargeTypes: isInstallmentCredit
+      ? ["DETACHED", "INSTALLMENT"]
+      : ["DETACHED"],
     callback: {
       successUrl: params.successUrl,
       cancelUrl: params.errorUrl,


### PR DESCRIPTION
## Summary
- update charge types logic for installment credit
- update checkout route tests for installment credit

## Testing
- `npm run lint`
- `npm run build`
- `npx vitest run __tests__/asaasCheckout.test.ts` *(fails)*

------
https://chatgpt.com/codex/tasks/task_e_6853061a96c8832ca06c58788abd452a