### PR TITLE
Update checkout charge types

### DIFF
--- a/__tests__/asaasCheckout.test.ts
+++ b/__tests__/asaasCheckout.test.ts
@@ -139,7 +139,7 @@ describe('checkout route', () => {
     await res.json();
     const sentBody = JSON.parse(fetchMock.mock.calls[0][1].body);
     expect(sentBody.billingTypes).toEqual(payload.paymentMethods);
-    expect(sentBody.chargeTypes).toEqual(['INSTALLMENT']);
+    expect(sentBody.chargeTypes).toEqual(['DETACHED', 'INSTALLMENT']);
     expect(sentBody.installment).toEqual({ maxInstallmentCount: 3 });
   });
 

--- a/lib/asaas.ts
+++ b/lib/asaas.ts
@@ -81,7 +81,9 @@ export async function createCheckout(
   const payload = {
     billingTypes:
       params.paymentMethods ?? [toAsaasBilling(params.paymentMethod)],
-    chargeTypes: isInstallmentCredit ? ["INSTALLMENT"] : ["DETACHED"],
+    chargeTypes: isInstallmentCredit
+      ? ["DETACHED", "INSTALLMENT"]
+      : ["DETACHED"],
     callback: {
       successUrl: params.successUrl,
       cancelUrl: params.errorUrl,


### PR DESCRIPTION
## Summary
- adjust DETACHED/INSTALLMENT charge types for installment payments
- expect both charge types in tests for credit card installments

## Testing
- `npm run lint`
- `npm run build` *(fails: `valorLiquido` does not exist in type `CreateCheckoutParams`)*
- `npm test` *(fails: various assertions in existing test suite)*

------
https://chatgpt.com/codex/tasks/task_e_68530f47f5f4832c9ef449b9c9577cad