### PR TITLE
fix checkout installment display

### DIFF
--- a/__tests__/lojaCheckout.test.tsx
+++ b/__tests__/lojaCheckout.test.tsx
@@ -54,4 +54,13 @@ describe('CheckoutContent', () => {
     fireEvent.change(selects[1], { target: { value: '2' } });
     expect(screen.getByText('R$ 12,69')).toBeInTheDocument();
   });
+
+  it('exibe valor da parcela apenas uma vez quando há mais de uma parcela', () => {
+    render(<CheckoutPage />);
+    const selects = screen.getAllByRole('combobox');
+    fireEvent.change(selects[0], { target: { value: 'credito' } });
+    fireEvent.change(selects[1], { target: { value: '2' } });
+    expect(screen.getAllByText('Valor da parcela')).toHaveLength(1);
+    expect(screen.getByText('R$ 5,79')).toBeInTheDocument();
+  });
 });

--- a/app/loja/checkout/page.tsx
+++ b/app/loja/checkout/page.tsx
@@ -427,14 +427,7 @@ function CheckoutContent() {
             {installments > 1 && (
               <div className="flex justify-between text-sm text-gray-500">
                 <span>Valor da parcela</span>
-                <span>
-                  {installments > 1 && (
-                    <div className="flex justify-between text-sm text-gray-500">
-                      <span>Valor da parcela</span>
-                      <span>{formatCurrency(totalGross / installments)}</span>
-                    </div>
-                  )}
-                </span>
+                <span>{formatCurrency(totalGross / installments)}</span>
               </div>
             )}
           </div>


### PR DESCRIPTION
## Summary
- remove duplicated installment info in checkout page
- test installment display when more than one payment installment

## Testing
- `npm run lint`
- `npm run build` *(fails: valorLiquido does not exist in CreateCheckoutParams)*
- `npm run test -- --run -t lojaCheckout.test.tsx` *(tests skipped)*


------
https://chatgpt.com/codex/tasks/task_e_68530f528598832ca3f3fa2f15afdce5