### PR TITLE
Exibe total de inscrição calculado

### DIFF
--- a/__tests__/InscricaoPage.test.tsx
+++ b/__tests__/InscricaoPage.test.tsx
@@ -2,6 +2,7 @@
 import { describe, it, expect, vi } from 'vitest';
 import { render, screen } from '@testing-library/react';
 import InscricaoPage from '@/app/inscricoes/[liderId]/[eventoId]/page';
+import { calculateGross } from '@/lib/asaasFees';
 
 vi.mock('next/navigation', () => ({
   useParams: () => ({ liderId: 'lid1', eventoId: 'ev1' })
@@ -17,5 +18,16 @@ describe('InscricaoPage', () => {
     render(<InscricaoPage />);
     const heading = await screen.findByRole('heading', { level: 1 });
     expect(heading.textContent).toContain('Evento X');
+  });
+
+  it('exibe total calculado', async () => {
+    global.fetch = vi
+      .fn()
+      .mockResolvedValueOnce({ ok: true, json: () => Promise.resolve({ campo: 'Campo' }) })
+      .mockResolvedValueOnce({ ok: true, json: () => Promise.resolve({ titulo: 'Evento', descricao: 'Desc' }) });
+
+    render(<InscricaoPage />);
+    const gross = calculateGross(50, 'pix', 1).gross;
+    expect(await screen.findByText(`R$ ${gross.toFixed(2).replace('.', ',')}`)).toBeInTheDocument();
   });
 });

--- a/app/inscricoes/[liderId]/[eventoId]/page.tsx
+++ b/app/inscricoes/[liderId]/[eventoId]/page.tsx
@@ -1,11 +1,11 @@
 "use client";
 
-import { useEffect, useState } from "react";
+import { useEffect, useState, useMemo } from "react";
 import { useParams } from "next/navigation";
 import Link from "next/link";
 import { logInfo } from "@/lib/logger";
 import { useToast } from "@/lib/context/ToastContext";
-import type { PaymentMethod } from "@/lib/asaasFees";
+import { calculateGross, type PaymentMethod } from "@/lib/asaasFees";
 
 const PRODUTOS = [
   { nome: "Kit Camisa + Pulseira", valor: 50.0 },
@@ -46,6 +46,15 @@ export default function InscricaoPage() {
   const [installments, setInstallments] = useState(1);
   const [campoNome, setCampoNome] = useState("");
   const [evento, setEvento] = useState<{ titulo: string; descricao: string } | null>(null);
+
+  const base = useMemo(
+    () => PRODUTOS.find((p) => p.nome === form.produto)?.valor ?? 0,
+    [form.produto],
+  );
+  const totalGross = useMemo(
+    () => calculateGross(base, paymentMethod, installments).gross,
+    [base, paymentMethod, installments],
+  );
 
   useEffect(() => {
     if (!liderId) return;
@@ -342,6 +351,16 @@ export default function InscricaoPage() {
               </option>
             ))}
           </select>
+          <p className="text-sm mt-1">
+            Total: R$ {totalGross.toFixed(2).replace(".", ",")}
+          </p>
+          {installments > 1 && (
+            <p className="text-xs text-gray-500">
+              Valor da parcela: R$ {(totalGross / installments)
+                .toFixed(2)
+                .replace(".", ",")}
+            </p>
+          )}
         </div>
 
           <div className="flex items-start mt-4">

--- a/logs/DOC_LOG.md
+++ b/logs/DOC_LOG.md
@@ -139,3 +139,4 @@
 ## [2025-07-02] Documentação atualizada indicando `npm install` antes de rodar lint, build ou testes. Nota adicionada ao CONTRIBUTING. Impacto: evitar erros por dependências ausentes.
 ## [2025-07-03] Atualizados exemplos de chamadas ao endpoint `/admin/api/asaas` com os campos `valorBruto`, `paymentMethod` e `installments`. Lint e build executados.
 ## [2025-07-04] Adicionada regra de exibição do total no checkout em docs/plano_calculo_cobrancas.md.
+## [2025-07-05] Exibido total bruto na página de inscrição e teste atualizado. Lint e build executados.


### PR DESCRIPTION
## Summary
- display gross total and parcel value on `InscricaoPage`
- test that total value appears
- log documentation update

## Testing
- `npm run lint`
- `npm run build`
- `npm test` *(fails: various test failures)*

------
https://chatgpt.com/codex/tasks/task_e_6853398a6f50832ca204ccd25eb014ac