### PR TITLE
Add produtos expand to eventos API

### DIFF
--- a/app/admin/api/eventos/[id]/route.ts
+++ b/app/admin/api/eventos/[id]/route.ts
@@ -30,6 +30,12 @@ export async function PUT(req: NextRequest) {
   }
   const { pb } = auth;
   try {
+    const contentType = req.headers.get("content-type") || "";
+    if (contentType.includes("application/json")) {
+      const body = await req.json();
+      const evento = await pb.collection("eventos").update(id, body);
+      return NextResponse.json(evento, { status: 200 });
+    }
     const formData = await req.formData();
     const evento = await pb.collection("eventos").update(id, formData);
     return NextResponse.json(evento, { status: 200 });

--- a/app/admin/api/eventos/route.ts
+++ b/app/admin/api/eventos/route.ts
@@ -30,6 +30,13 @@ export async function POST(req: NextRequest) {
   const { pb, user } = auth;
   logInfo("PocketBase host:", pb.baseUrl);
   try {
+    const contentType = req.headers.get("content-type") || "";
+    if (contentType.includes("application/json")) {
+      const body = await req.json();
+      body.cliente = user.cliente as string;
+      const evento = await pb.collection("eventos").create(body);
+      return NextResponse.json(evento, { status: 201 });
+    }
     const formData = await req.formData();
     formData.set("cliente", user.cliente as string);
     const evento = await pb.collection("eventos").create(formData);

--- a/app/api/eventos/[id]/route.ts
+++ b/app/api/eventos/[id]/route.ts
@@ -9,7 +9,7 @@ export async function GET(req: NextRequest) {
 
   const pb = createPocketBase();
   try {
-    const evento = await pb.collection("eventos").getOne(id);
+    const evento = await pb.collection("eventos").getOne(id, { expand: "produtos" });
     const withUrl = {
       ...evento,
       imagem: evento.imagem ? pb.files.getURL(evento, evento.imagem) : undefined,

--- a/app/api/eventos/route.ts
+++ b/app/api/eventos/route.ts
@@ -10,6 +10,7 @@ export async function GET() {
     const eventos = await pb.collection("eventos").getFullList<EventoRecord>({
       sort: "-data",
       filter: tenant ? `cliente='${tenant}'` : undefined,
+      expand: "produtos",
     });
     await atualizarStatus(eventos, pb);
     const comUrls = eventos.map((e) => ({

--- a/types/index.ts
+++ b/types/index.ts
@@ -114,7 +114,12 @@ export type Evento = {
   cidade: string;
   imagem?: string;
   status: "realizado" | "em breve";
+  cobra_inscricao?: boolean;
+  produtos?: string[];
   created?: string;
+  expand?: {
+    produtos?: Produto[];
+  };
 };
 
 export type Cliente = {


### PR DESCRIPTION
## Summary
- support JSON bodies on admin eventos CRUD
- include product relations when fetching eventos
- extend Evento type with cobra_inscricao and produtos

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68533aca3058832c88cb64817f4b1d2e