### PR TITLE
Add manual inscription confirmation option

### DIFF
--- a/__tests__/headerLinks.test.tsx
+++ b/__tests__/headerLinks.test.tsx
@@ -26,7 +26,9 @@ vi.mock('@/lib/context/ThemeContext', () => ({
 }));
 
 vi.mock('@/lib/context/AppConfigContext', () => ({
-  useAppConfig: () => ({ config: { logoUrl: '', font: '', primaryColor: '' } }),
+  useAppConfig: () => ({
+    config: { logoUrl: '', font: '', primaryColor: '', confirmaInscricoes: false },
+  }),
 }));
 
 vi.mock('@/lib/context/AuthContext', () => ({

--- a/app/admin/api/configuracoes/route.ts
+++ b/app/admin/api/configuracoes/route.ts
@@ -18,6 +18,7 @@ export async function GET(req: NextRequest) {
         cor_primary: cfg.cor_primary ?? "",
         logo_url: cfg.logo_url ?? "",
         font: cfg.font ?? "",
+        confirma_inscricoes: cfg.confirma_inscricoes ?? false,
       },
       { status: 200 }
     );
@@ -34,7 +35,7 @@ export async function PUT(req: NextRequest) {
   }
   const { pb, user } = auth;
   try {
-    const { cor_primary, logo_url, font } = await req.json();
+    const { cor_primary, logo_url, font, confirma_inscricoes } = await req.json();
     const cfg = await pb
       .collection("clientes_config")
       .getFirstListItem(`cliente='${user.cliente}'`);
@@ -42,6 +43,7 @@ export async function PUT(req: NextRequest) {
       cor_primary,
       logo_url,
       font,
+      confirma_inscricoes,
     });
     return NextResponse.json(updated, { status: 200 });
   } catch (err) {

--- a/app/admin/configuracoes/page.tsx
+++ b/app/admin/configuracoes/page.tsx
@@ -83,6 +83,9 @@ export default function ConfiguracoesPage() {
   const [font, setFont] = useState(config.font);
   const [primaryColor, setPrimaryColor] = useState(config.primaryColor);
   const [logoUrl, setLogoUrl] = useState(config.logoUrl);
+  const [confirmaInscricoes, setConfirmaInscricoes] = useState(
+    config.confirmaInscricoes,
+  );
   const [error, setError] = useState("");
   const fileRef = useRef<HTMLInputElement>(null);
 
@@ -143,11 +146,12 @@ export default function ConfiguracoesPage() {
           cor_primary: primaryColor,
           logo_url: logoUrl,
           font,
+          confirma_inscricoes: confirmaInscricoes,
         }),
       });
     }
 
-    updateConfig({ font, primaryColor, logoUrl });
+    updateConfig({ font, primaryColor, logoUrl, confirmaInscricoes });
 
     try {
       const token = localStorage.getItem("pb_token");
@@ -163,6 +167,7 @@ export default function ConfiguracoesPage() {
           cor_primary: primaryColor,
           logo_url: logoUrl,
           font,
+          confirma_inscricoes: confirmaInscricoes,
         }),
       });
     } catch (err) {
@@ -249,6 +254,15 @@ export default function ConfiguracoesPage() {
             <span className="text-xs text-neutral-500">Prévia</span>
           </div>
         )}
+        <label className="checkbox-label">
+          <input
+            type="checkbox"
+            checked={confirmaInscricoes}
+            onChange={(e) => setConfirmaInscricoes(e.target.checked)}
+            className="checkbox-base"
+          />
+          Confirmar inscrições manualmente?
+        </label>
         <div className="mt-4">
           <span className="block mb-1 text-sm">Preview do botão:</span>
           <button

--- a/lib/context/AppConfigContext.tsx
+++ b/lib/context/AppConfigContext.tsx
@@ -10,12 +10,14 @@ export type AppConfig = {
   font: string;
   primaryColor: string;
   logoUrl: string;
+  confirmaInscricoes: boolean;
 };
 
 const defaultConfig: AppConfig = {
   font: "var(--font-geist)",
   primaryColor: "#7c3aed",
   logoUrl: "/img/logo_umadeus_branco.png",
+  confirmaInscricoes: false,
 };
 
 type AppConfigContextType = {
@@ -49,6 +51,8 @@ export function AppConfigProvider({ children }: { children: React.ReactNode }) {
               font: cliente.font || defaultConfig.font,
               primaryColor: cliente.cor_primary || defaultConfig.primaryColor,
               logoUrl: cliente.logo_url || defaultConfig.logoUrl,
+              confirmaInscricoes:
+                cliente.confirma_inscricoes ?? defaultConfig.confirmaInscricoes,
             };
             setConfigId(cliente.id);
             setConfig(cfg);
@@ -92,6 +96,8 @@ export function AppConfigProvider({ children }: { children: React.ReactNode }) {
                 font: cliente.font || defaultConfig.font,
                 primaryColor: cliente.cor_primary || defaultConfig.primaryColor,
                 logoUrl: cliente.logo_url || defaultConfig.logoUrl,
+                confirmaInscricoes:
+                  cliente.confirma_inscricoes ?? defaultConfig.confirmaInscricoes,
               };
               setConfigId(cliente.id);
               setConfig(cfg);
@@ -122,6 +128,8 @@ export function AppConfigProvider({ children }: { children: React.ReactNode }) {
                 font: data.font || defaultConfig.font,
                 primaryColor: data.cor_primary || defaultConfig.primaryColor,
                 logoUrl: data.logo_url || defaultConfig.logoUrl,
+                confirmaInscricoes:
+                  data.confirma_inscricoes ?? defaultConfig.confirmaInscricoes,
               };
               try {
                 const { cliente } = JSON.parse(user);
@@ -185,6 +193,7 @@ export function AppConfigProvider({ children }: { children: React.ReactNode }) {
             cor_primary: newCfg.primaryColor,
             logo_url: newCfg.logoUrl,
             font: newCfg.font,
+            confirma_inscricoes: newCfg.confirmaInscricoes,
           }),
         }).catch((err) => console.error("Erro ao salvar config:", err));
       }


### PR DESCRIPTION
## Summary
- allow manual confirmation of subscriptions via new checkbox
- persist `confirma_inscricoes` in AppConfig context
- expose new option in admin config API
- adjust Header tests for updated config shape

## Testing
- `npm run lint`
- `npm run build`
- `npm test` *(fails: calculateGross and other tests)*

------
https://chatgpt.com/codex/tasks/task_e_68533cd329fc832c85acc08819065930