### PR TITLE
Aplicar config de inscrição e redirecionar pagamento

### DIFF
--- a/__tests__/InscricaoPage.test.tsx
+++ b/__tests__/InscricaoPage.test.tsx
@@ -7,6 +7,10 @@ vi.mock('next/navigation', () => ({
   useParams: () => ({ liderId: 'lid1', eventoId: 'ev1' })
 }));
 
+vi.mock('@/lib/context/AppConfigContext', () => ({
+  useAppConfig: () => ({ config: { confirmaInscricoes: true } }),
+}));
+
 describe('InscricaoPage', () => {
   it('renderiza título do evento', async () => {
     global.fetch = vi

--- a/__tests__/headerLinks.test.tsx
+++ b/__tests__/headerLinks.test.tsx
@@ -26,7 +26,9 @@ vi.mock('@/lib/context/ThemeContext', () => ({
 }));
 
 vi.mock('@/lib/context/AppConfigContext', () => ({
-  useAppConfig: () => ({ config: { logoUrl: '', font: '', primaryColor: '' } }),
+  useAppConfig: () => ({
+    config: { logoUrl: '', font: '', primaryColor: '', confirmaInscricoes: true },
+  }),
 }));
 
 vi.mock('@/lib/context/AuthContext', () => ({

--- a/app/inscricoes/[liderId]/[eventoId]/page.tsx
+++ b/app/inscricoes/[liderId]/[eventoId]/page.tsx
@@ -5,6 +5,7 @@ import { useParams } from "next/navigation";
 import Link from "next/link";
 import { logInfo } from "@/lib/logger";
 import { useToast } from "@/lib/context/ToastContext";
+import { useAppConfig } from "@/lib/context/AppConfigContext";
 import type { PaymentMethod } from "@/lib/asaasFees";
 
 const PRODUTOS = [
@@ -29,6 +30,7 @@ export default function InscricaoPage() {
   const eventoId = params.eventoId as string;
 
   const { showError, showSuccess } = useToast();
+  const { config } = useAppConfig();
 
   const [form, setForm] = useState<FormFields>({
     nome: "",
@@ -158,10 +160,15 @@ export default function InscricaoPage() {
         );
       }
 
-      // 3. Exibe mensagem de sucesso
-      showSuccess(
-        "✅ Inscrição enviada com sucesso! Em breve você receberá o link de pagamento."
-      );
+      // 3. Se a API retornar URL de pagamento, redireciona
+      if (result.url) {
+        showSuccess("Redirecionando para pagamento...");
+        window.location.href = result.url as string;
+      } else {
+        showSuccess(
+          "✅ Inscrição enviada com sucesso! Em breve você receberá o link de pagamento."
+        );
+      }
     } catch (erro) {
       console.error("❌ Erro no handleSubmit:", erro);
       showError("❌ Erro ao processar inscrição.");
@@ -344,6 +351,7 @@ export default function InscricaoPage() {
           </select>
         </div>
 
+        {config.confirmaInscricoes && (
           <div className="flex items-start mt-4">
             <input
               type="checkbox"
@@ -356,6 +364,7 @@ export default function InscricaoPage() {
               liberação do pagamento pela liderança.
             </label>
           </div>
+        )}
 
           <button
             type="submit"

--- a/lib/context/AppConfigContext.tsx
+++ b/lib/context/AppConfigContext.tsx
@@ -10,12 +10,14 @@ export type AppConfig = {
   font: string;
   primaryColor: string;
   logoUrl: string;
+  confirmaInscricoes: boolean;
 };
 
 const defaultConfig: AppConfig = {
   font: "var(--font-geist)",
   primaryColor: "#7c3aed",
   logoUrl: "/img/logo_umadeus_branco.png",
+  confirmaInscricoes: false,
 };
 
 type AppConfigContextType = {
@@ -49,6 +51,10 @@ export function AppConfigProvider({ children }: { children: React.ReactNode }) {
               font: cliente.font || defaultConfig.font,
               primaryColor: cliente.cor_primary || defaultConfig.primaryColor,
               logoUrl: cliente.logo_url || defaultConfig.logoUrl,
+              confirmaInscricoes:
+                cliente.confirmaInscricoes ??
+                cliente.confirma_inscricoes ??
+                defaultConfig.confirmaInscricoes,
             };
             setConfigId(cliente.id);
             setConfig(cfg);
@@ -92,6 +98,10 @@ export function AppConfigProvider({ children }: { children: React.ReactNode }) {
                 font: cliente.font || defaultConfig.font,
                 primaryColor: cliente.cor_primary || defaultConfig.primaryColor,
                 logoUrl: cliente.logo_url || defaultConfig.logoUrl,
+                confirmaInscricoes:
+                  cliente.confirmaInscricoes ??
+                  cliente.confirma_inscricoes ??
+                  defaultConfig.confirmaInscricoes,
               };
               setConfigId(cliente.id);
               setConfig(cfg);
@@ -122,6 +132,10 @@ export function AppConfigProvider({ children }: { children: React.ReactNode }) {
                 font: data.font || defaultConfig.font,
                 primaryColor: data.cor_primary || defaultConfig.primaryColor,
                 logoUrl: data.logo_url || defaultConfig.logoUrl,
+                confirmaInscricoes:
+                  data.confirmaInscricoes ??
+                  data.confirma_inscricoes ??
+                  defaultConfig.confirmaInscricoes,
               };
               try {
                 const { cliente } = JSON.parse(user);
@@ -185,6 +199,7 @@ export function AppConfigProvider({ children }: { children: React.ReactNode }) {
             cor_primary: newCfg.primaryColor,
             logo_url: newCfg.logoUrl,
             font: newCfg.font,
+            confirma_inscricoes: newCfg.confirmaInscricoes,
           }),
         }).catch((err) => console.error("Erro ao salvar config:", err));
       }


### PR DESCRIPTION
## Summary
- incluir `confirmaInscricoes` no contexto de configuração
- ajustar mocks de testes para novo campo
- usar `useAppConfig` na página de inscrição
- renderizar checkbox de confirmação apenas quando configurado
- redirecionar usuário ao link de pagamento quando API retornar URL

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68533cf2e670832cad6b6ecf24c78e05