### PR TITLE
Fix Evento type and build issue

### DIFF
--- a/app/inscricoes/[liderId]/[eventoId]/page.tsx
+++ b/app/inscricoes/[liderId]/[eventoId]/page.tsx
@@ -55,8 +55,8 @@ export default function InscricaoPage() {
   const [evento, setEvento] = useState<{ titulo: string; descricao: string } | null>(null);
 
   const base = useMemo(
-    () => PRODUTOS.find((p) => p.nome === form.produto)?.valor ?? 0,
-    [form.produto],
+    () => produtos.find((p) => p.nome === form.produto)?.valor ?? 0,
+    [form.produto, produtos],
   );
   const totalGross = useMemo(
     () => calculateGross(base, paymentMethod, installments).gross,

--- a/types/index.ts
+++ b/types/index.ts
@@ -115,14 +115,13 @@ export type Evento = {
   imagem?: string;
   status: "realizado" | "em breve";
   cobra_inscricao?: boolean;
+  /** Produto associado à inscrição do evento */
+  produto_inscricao?: string;
   produtos?: string[];
   expand?: {
     produtos?: Produto[];
   };
   created?: string;
-  expand?: {
-    produtos?: Produto[];
-  };
 };
 
 export type Cliente = {


### PR DESCRIPTION
## Summary
- fix Evento type by removing duplicate expand field
- add `produto_inscricao` optional field
- use correct `produtos` list when calculating base price

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68533e510144832ca7f0b8fe6c9d525d