### PR TITLE
Add event product fields

### DIFF
--- a/app/admin/api/eventos/[id]/route.ts
+++ b/app/admin/api/eventos/[id]/route.ts
@@ -12,7 +12,9 @@ export async function GET(req: NextRequest) {
   }
   const { pb } = auth;
   try {
-    const evento = await pb.collection("eventos").getOne(id);
+    const evento = await pb.collection("eventos").getOne(id, {
+      expand: "produtos",
+    });
     return NextResponse.json(evento, { status: 200 });
   } catch (err) {
     await logConciliacaoErro(`Erro ao obter evento: ${String(err)}`);
@@ -37,6 +39,13 @@ export async function PUT(req: NextRequest) {
       return NextResponse.json(evento, { status: 200 });
     }
     const formData = await req.formData();
+    if (formData.get("cobra_inscricao") !== null) {
+      const val = formData.get("cobra_inscricao");
+      formData.set("cobra_inscricao", val === "on" ? "true" : String(val));
+    }
+    if (formData.get("produto_inscricao") !== null) {
+      formData.set("produto_inscricao", String(formData.get("produto_inscricao")));
+    }
     const evento = await pb.collection("eventos").update(id, formData);
     return NextResponse.json(evento, { status: 200 });
   } catch (err) {

--- a/app/admin/api/eventos/route.ts
+++ b/app/admin/api/eventos/route.ts
@@ -14,6 +14,7 @@ export async function GET(req: NextRequest) {
     const eventos = await pb.collection("eventos").getFullList({
       sort: "-created",
       filter: `cliente='${user.cliente}'`,
+      expand: "produtos",
     });
     return NextResponse.json(eventos, { status: 200 });
   } catch (err) {
@@ -39,6 +40,19 @@ export async function POST(req: NextRequest) {
     }
     const formData = await req.formData();
     formData.set("cliente", user.cliente as string);
+    if (formData.get("cobra_inscricao") !== null) {
+      const val = formData.get("cobra_inscricao");
+      formData.set(
+        "cobra_inscricao",
+        val === "on" ? "true" : String(val)
+      );
+    }
+    if (formData.get("produto_inscricao") !== null) {
+      formData.set(
+        "produto_inscricao",
+        String(formData.get("produto_inscricao"))
+      );
+    }
     const evento = await pb.collection("eventos").create(formData);
     return NextResponse.json(evento, { status: 201 });
   } catch (err) {

--- a/app/admin/eventos/editar/[id]/page.tsx
+++ b/app/admin/eventos/editar/[id]/page.tsx
@@ -128,6 +128,12 @@ export default function EditarEventoPage() {
     e.preventDefault();
     const formElement = e.currentTarget as HTMLFormElement;
     const formData = new FormData(formElement);
+    formData.set("cobra_inscricao", cobraInscricao ? "true" : "false");
+    if (cobraInscricao && selectedProduto) {
+      formData.set("produto_inscricao", selectedProduto);
+    } else {
+      formData.delete("produto_inscricao");
+    }
     const { token, user } = getAuth();
     const res = await fetch(`/admin/api/eventos/${id}`, {
       method: "PUT",

--- a/app/admin/eventos/page.tsx
+++ b/app/admin/eventos/page.tsx
@@ -69,6 +69,19 @@ export default function AdminEventosPage() {
     if (form.imagem instanceof File) {
       formData.append("imagem", form.imagem);
     }
+    if (form.cobra_inscricao) {
+      formData.set("cobra_inscricao", "true");
+    } else {
+      formData.set("cobra_inscricao", "false");
+    }
+    if (typeof form.produto_inscricao === "string") {
+      formData.set("produto_inscricao", form.produto_inscricao);
+    }
+    if (Array.isArray(form.produtos)) {
+      (form.produtos as string[]).forEach((p) =>
+        formData.append("produtos", p)
+      );
+    }
     try {
       const res = await fetch("/admin/api/eventos", {
         method: "POST",


### PR DESCRIPTION
## Summary
- support `cobra_inscricao` and products in eventos API
- expand products when fetching eventos
- send `cobra_inscricao` and product info from event forms

## Testing
- `npm run lint`
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_6853415e7f90832c8c086ae22af2d892