### PR TITLE
Update docs about inscription confirmations

### DIFF
--- a/docs/iniciar-tour.md
+++ b/docs/iniciar-tour.md
@@ -33,6 +33,15 @@ Ao acessar **Configurações**, marque o novo checkbox **Modo de Demonstração*
 para ocultar dados reais durante o tour. Desmarque-o quando quiser voltar ao
 uso normal da plataforma.
 
+### Confirmação de inscrições
+
+Em **Configurações** há também a opção **Confirmar inscrições manualmente?**. Quando
+ativada, cada inscrição permanece em status pendente até que a liderança a
+aprove na tela **Inscrições**, momento em que o link de pagamento é gerado. Se a
+opção estiver desmarcada, o pedido e a cobrança são criados de forma automática
+logo após o envio do formulário (desde que o evento possua o campo
+`cobra_inscricao` habilitado e um produto de inscrição selecionado).
+
 ## 4. Blog
 
 1. Acesse a aba **Blog** para ler ou criar posts (via admin).

--- a/logs/DOC_LOG.md
+++ b/logs/DOC_LOG.md
@@ -142,3 +142,5 @@
 ## [2025-07-05] Campo `confirma_inscricoes` documentado e suportado pelo AppConfig. Lint e build executados.
 ## [2025-07-05] Guia iniciar-tour atualizado explicando checkbox Modo de Demonstração em Configurações. Lint e build executados.
 ## [2025-07-05] Exibido total bruto na página de inscrição e teste atualizado. Lint e build executados.
+
+## [2025-07-06] Guia iniciar-tour complementado com explicações sobre a opção "Confirmar inscrições manualmente?" e cobranças automáticas em eventos com `cobra_inscricao`. - Lint: falhou (next not found) - Build: falhou (next not found)


### PR DESCRIPTION
## Summary
- document the Configurações option to confirmar inscrições manualmente
- explain automatic charges on events with `cobra_inscricao`
- log the documentation update

## Testing
- `npm run lint` *(fails: next not found)*
- `npm run build` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_685341620da4832c9606844f207109f1