### PR TITLE
Implement multi-product selection for events

### DIFF
--- a/app/admin/eventos/editar/[id]/page.tsx
+++ b/app/admin/eventos/editar/[id]/page.tsx
@@ -22,7 +22,7 @@ export default function EditarEventoPage() {
   const [loading, setLoading] = useState(true);
   const [cobraInscricao, setCobraInscricao] = useState(false);
   const [produtos, setProdutos] = useState<Produto[]>([]);
-  const [selectedProduto, setSelectedProduto] = useState("");
+  const [selectedProdutos, setSelectedProdutos] = useState<string[]>([]);
   const [produtoModalOpen, setProdutoModalOpen] = useState(false);
 
   useEffect(() => {
@@ -51,7 +51,12 @@ export default function EditarEventoPage() {
           status: data.status,
         });
         setCobraInscricao(Boolean(data.cobra_inscricao));
-        setSelectedProduto(data.produto_inscricao || "");
+        const arr = Array.isArray(data.produtos)
+          ? (data.produtos as string[])
+          : data.produto_inscricao
+          ? [data.produto_inscricao as string]
+          : [];
+        setSelectedProdutos(arr);
       })
       .finally(() => setLoading(false));
   }, [id, isLoggedIn, getAuth]);
@@ -112,7 +117,7 @@ export default function EditarEventoPage() {
       if (!res.ok) return;
       const data = await res.json();
       setProdutos((prev) => [data, ...prev]);
-      setSelectedProduto(data.id);
+      setSelectedProdutos((prev) => [...prev, data.id]);
     } catch (err) {
       console.error("Erro ao criar produto:", err);
     } finally {
@@ -128,6 +133,9 @@ export default function EditarEventoPage() {
     e.preventDefault();
     const formElement = e.currentTarget as HTMLFormElement;
     const formData = new FormData(formElement);
+    formData.delete("produtos");
+    selectedProdutos.forEach((p) => formData.append("produtos", p));
+    formData.set("cobra_inscricao", String(cobraInscricao));
     const { token, user } = getAuth();
     const res = await fetch(`/admin/api/eventos/${id}`, {
       method: "PUT",
@@ -186,15 +194,19 @@ export default function EditarEventoPage() {
         </div>
         {cobraInscricao && (
           <div>
-            <label className="label-base">Produto para inscrição</label>
+            <label className="label-base">Produtos para inscrição</label>
             <div className="flex gap-2">
               <select
-                name="produto_inscricao"
-                value={selectedProduto}
-                onChange={(e) => setSelectedProduto(e.target.value)}
+                name="produtos"
+                multiple
+                value={selectedProdutos}
+                onChange={(e) =>
+                  setSelectedProdutos(
+                    Array.from(e.target.selectedOptions, (o) => o.value)
+                  )
+                }
                 className="input-base flex-1"
               >
-                <option value="">Selecione o produto</option>
                 {produtos.map((p) => (
                   <option key={p.id} value={p.id}>
                     {p.nome}

--- a/app/admin/eventos/page.tsx
+++ b/app/admin/eventos/page.tsx
@@ -69,6 +69,15 @@ export default function AdminEventosPage() {
     if (form.imagem instanceof File) {
       formData.append("imagem", form.imagem);
     }
+    if (form.cobra_inscricao !== undefined) {
+      formData.set(
+        "cobra_inscricao",
+        String(form.cobra_inscricao as boolean)
+      );
+    }
+    if (Array.isArray(form.produtos)) {
+      (form.produtos as string[]).forEach((p) => formData.append("produtos", p));
+    }
     try {
       const res = await fetch("/admin/api/eventos", {
         method: "POST",


### PR DESCRIPTION
## Summary
- allow selecting multiple `produtos` when creating or editing eventos
- send selected products to the event API
- adapt existing handlers to persist `cobra_inscricao` and `produtos`
- fetch initial product list for edit forms

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6853413c0164832c822b85123287a434