### PR TITLE
Derivar valor do produto ao criar pedido

### DIFF
--- a/__tests__/orderFlow.test.ts
+++ b/__tests__/orderFlow.test.ts
@@ -14,6 +14,9 @@ const dadosValidos = {
   tamanho: 'M'
 }
 
+const pulseira = { nome: 'Somente Pulseira', preco: 10 }
+const kit = { nome: 'Kit Camisa + Pulseira', preco: 50 }
+
 describe('Fluxo de inscrição e pedido', () => {
   it('cria inscrição válida com status pendente', () => {
     const inscricao = criarInscricao(dadosValidos)
@@ -32,7 +35,7 @@ describe('Fluxo de inscrição e pedido', () => {
 
   it('cria pedido com valor correto', () => {
     const inscricao = criarInscricao(dadosValidos)
-    const pedido = criarPedido(inscricao)
+    const pedido = criarPedido(inscricao, pulseira)
     expect(pedido.id_inscricao).toBe(inscricao.id)
     expect(pedido.valor).toBe('10.00')
     expect(pedido.status).toBe('pendente')
@@ -43,7 +46,7 @@ describe('Fluxo de inscrição e pedido', () => {
       ...dadosValidos,
       produto: 'Kit Camisa + Pulseira'
     })
-    const pedido = criarPedido(inscricao)
+    const pedido = criarPedido(inscricao, kit)
     expect(pedido.valor).toBe('50.00')
     expect(pedido.email).toBe('sememail@teste.com')
     expect(pedido.status).toBe('pendente')

--- a/lib/constants.ts
+++ b/lib/constants.ts
@@ -1,5 +1,2 @@
-export const PRECO_PULSEIRA = 10.0;
-export const PRECO_KIT = 50.0;
-
 export const MAX_ITEM_NAME_LENGTH = 30;
 export const MAX_ITEM_DESCRIPTION_LENGTH = 120;

--- a/lib/flows/orderFlow.ts
+++ b/lib/flows/orderFlow.ts
@@ -46,18 +46,23 @@ export function criarInscricao(dados: DadosInscricao): Inscricao {
   }
 }
 
-export function criarPedido(inscricao: Inscricao): Pedido {
-  const valor = inscricao.produto === 'Somente Pulseira' ? 10.0 : 50.0
+export function criarPedido(
+  inscricao: Inscricao,
+  produto: { nome?: string; preco: number; tamanhos?: string[] | string; generos?: string[] | string }
+): Pedido {
+  const first = (v?: string[] | string) =>
+    Array.isArray(v) ? v[0] : v;
+  const valor = produto.preco
 
   return {
     id: `ped_${inscricao.id}`,
     id_pagamento: '',
     id_inscricao: inscricao.id,
-    produto: inscricao.produto || 'Kit Camisa + Pulseira',
-    tamanho: inscricao.tamanho,
+    produto: produto.nome ?? inscricao.produto ?? 'Kit Camisa + Pulseira',
+    tamanho: inscricao.tamanho || first(produto.tamanhos),
     status: 'pendente',
     cor: 'Roxo',
-    genero: inscricao.genero,
+    genero: inscricao.genero || first(produto.generos),
     responsavel: inscricao.criado_por,
     email: dadosEmail(inscricao),
     valor: valor.toFixed(2)


### PR DESCRIPTION
## Summary
- remover constantes de preço
- buscar preço do produto ao gerar pedido via API
- atualizar fluxo de confirmação de inscrição
- ajustar criação de pedido em `orderFlow`
- atualizar teste de fluxo de pedido

## Testing
- `npm run lint` *(fails: next not found)*
- `npm run build` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_6853455477f4832c9a879a98f38d3245