### PR TITLE
Improve inscrição error typing

### DIFF
--- a/app/admin/api/pedidos/route.tsx
+++ b/app/admin/api/pedidos/route.tsx
@@ -2,6 +2,7 @@ import { NextRequest, NextResponse } from "next/server";
 import createPocketBase from "@/lib/pocketbase";
 import { PRECO_PULSEIRA, PRECO_KIT } from "@/lib/constants";
 import { logConciliacaoErro } from "@/lib/server/logger";
+import type { Inscricao, Pedido } from "@/types";
 
 export async function POST(req: NextRequest) {
   const pb = createPocketBase();
@@ -16,9 +17,11 @@ export async function POST(req: NextRequest) {
       );
     }
 
-    const inscricao = await pb.collection("inscricoes").getOne(inscricaoId, {
-      expand: "campo,criado_por",
-    });
+    const inscricao = await pb
+      .collection("inscricoes")
+      .getOne<Inscricao>(inscricaoId, {
+        expand: "campo,criado_por",
+      });
 
     if (!inscricao) {
       return NextResponse.json(
@@ -33,7 +36,7 @@ export async function POST(req: NextRequest) {
     const valor =
       inscricao.produto === "Somente Pulseira" ? PRECO_PULSEIRA : PRECO_KIT;
 
-    const pedido = await pb.collection("pedidos").create({
+    const pedido = await pb.collection("pedidos").create<Pedido>({
       id_inscricao: inscricaoId,
       valor,
       status: "pendente",

--- a/app/loja/api/inscricoes/route.ts
+++ b/app/loja/api/inscricoes/route.ts
@@ -1,5 +1,6 @@
 import { NextRequest, NextResponse } from "next/server";
 import createPocketBase from "@/lib/pocketbase";
+import { ClientResponseError } from "pocketbase";
 import { getTenantFromHost } from "@/lib/getTenantFromHost";
 import { logConciliacaoErro } from "@/lib/server/logger";
 
@@ -37,27 +38,40 @@ export async function POST(req: NextRequest) {
     console.log("Registro criado com sucesso:", record);
 
     return NextResponse.json(record, { status: 201 });
-  } catch (err: any) {
+  } catch (err: unknown) {
     console.error("Erro ao criar inscrição:", err);
 
-    // Detalhes específicos do erro ClientResponseError do PocketBase
-    if (err && typeof err === "object") {
-      if (err.url) console.error("URL chamada:", err.url);
-      if (err.status) console.error("Status HTTP:", err.status);
-      if (err.response) {
-        console.error(
-          "Resposta do PocketBase:",
-          JSON.stringify(err.response, null, 2)
-        );
-      }
+    let detalhes: unknown = null;
+    if (err instanceof ClientResponseError) {
+      console.error("URL chamada:", err.url);
+      console.error("Status HTTP:", err.status);
+      console.error(
+        "Resposta do PocketBase:",
+        JSON.stringify(err.response, null, 2)
+      );
+      detalhes = err.response;
       if (err.originalError) {
         console.error("Erro original:", err.originalError);
+      }
+    } else if (err && typeof err === "object") {
+      const errorData = err as Record<string, unknown>;
+      if ("url" in errorData) console.error("URL chamada:", errorData.url);
+      if ("status" in errorData) console.error("Status HTTP:", errorData.status);
+      if ("response" in errorData) {
+        console.error(
+          "Resposta do PocketBase:",
+          JSON.stringify(errorData.response, null, 2)
+        );
+        detalhes = errorData.response;
+      }
+      if ("originalError" in errorData) {
+        console.error("Erro original:", errorData.originalError);
       }
     }
 
     await logConciliacaoErro(`Erro ao criar inscrição na loja: ${String(err)}`);
     return NextResponse.json(
-      { error: "Erro ao salvar", detalhes: err?.response ?? null },
+      { error: "Erro ao salvar", detalhes },
       { status: 500 }
     );
   }

--- a/logs/DOC_LOG.md
+++ b/logs/DOC_LOG.md
@@ -130,3 +130,5 @@
 
 ## [2025-06-17] Criado endpoint /loja/api/inscricoes e página de confirmação; formulário atualizado para usar nova rota. Lint e build executados.
 ## [2025-06-28] Inclusão do bairro no autofill do InscricaoForm.
+## [2025-06-17] Tratamento de erro em /loja/api/inscricoes aprimorado usando ClientResponseError. Lint e build executados.
+## [2025-06-17] Ajustadas chamadas PocketBase em /admin para tipagens genéricas, evitando uso de `any`. Lint e build executados.


### PR DESCRIPTION
## Summary
- import and use `ClientResponseError` for precise error handling
- document enhanced error handling
- tipar chamadas PocketBase nos rotas de admin

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6851984ebef4832ca756b8c17a6710ed