### PR TITLE
Fix lint errors by removing `any` usage

### DIFF
--- a/app/admin/api/pedidos/route.tsx
+++ b/app/admin/api/pedidos/route.tsx
@@ -1,7 +1,7 @@
 import { NextRequest, NextResponse } from "next/server";
 import createPocketBase from "@/lib/pocketbase";
 import { logConciliacaoErro } from "@/lib/server/logger";
-import type { Inscricao, Pedido } from "@/types";
+import type { Inscricao, Pedido, Produto } from "@/types";
 
 export async function POST(req: NextRequest) {
   const pb = createPocketBase();
@@ -32,7 +32,7 @@ export async function POST(req: NextRequest) {
     const campoId = inscricao.expand?.campo?.id;
     const responsavelId = inscricao.expand?.criado_por;
 
-    let produtoRecord: Record<string, any> | undefined;
+    let produtoRecord: Produto | undefined;
     try {
       produtoRecord = await pb
         .collection("produtos")
@@ -44,7 +44,7 @@ export async function POST(req: NextRequest) {
             .collection("eventos")
             .getOne(inscricao.evento, { expand: "produtos" });
           const lista = Array.isArray(ev.expand?.produtos)
-            ? (ev.expand.produtos as Record<string, any>[])
+            ? (ev.expand.produtos as Produto[])
             : [];
           produtoRecord = lista.find((p) => p.nome === inscricao.produto);
         }

--- a/app/admin/inscricoes/page.tsx
+++ b/app/admin/inscricoes/page.tsx
@@ -10,7 +10,7 @@ import { CheckCircle, XCircle, Pencil, Trash2, Eye } from "lucide-react";
 import TooltipIcon from "../components/TooltipIcon";
 import { useToast } from "@/lib/context/ToastContext";
 import { useAuthGuard } from "@/lib/hooks/useAuthGuard";
-import type { Evento, Inscricao as InscricaoRecord, Pedido } from "@/types";
+import type { Evento, Inscricao as InscricaoRecord, Pedido, Produto } from "@/types";
 
 const statusBadge = {
   pendente: "bg-yellow-100 text-yellow-800",
@@ -197,7 +197,7 @@ export default function ListaInscricoesPage() {
       const campo = inscricao.expand?.campo as CampoExpand | undefined;
 
       // 🔹 2. Carregar produto escolhido
-      let produtoRecord: Record<string, any> | undefined;
+      let produtoRecord: Produto | undefined;
       try {
         produtoRecord = await pb
           .collection("produtos")
@@ -209,7 +209,7 @@ export default function ListaInscricoesPage() {
               .collection("eventos")
               .getOne(inscricao.evento, { expand: "produtos" });
             const lista = Array.isArray(ev.expand?.produtos)
-              ? (ev.expand.produtos as Record<string, any>[])
+              ? (ev.expand.produtos as Produto[])
               : [];
             produtoRecord = lista.find((p) => p.nome === inscricao.produto);
           }


### PR DESCRIPTION
## Summary
- use `Produto` type in pedido route
- avoid `any` in inscrições page

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68534dca6fc4832c8d6e9404fc264f4d