### PR TITLE
Add extra fields to UserModel

### DIFF
--- a/app/admin/perfil/page.tsx
+++ b/app/admin/perfil/page.tsx
@@ -11,6 +11,11 @@ interface UsuarioAuthModel {
   telefone?: string;
   cpf?: string;
   data_nascimento?: string;
+  endereco?: string;
+  numero?: string;
+  estado?: string;
+  cep?: string;
+  cidade?: string;
   role: "coordenador" | "lider" | string;
   campo?: string;
   expand?: {

--- a/app/loja/perfil/page.tsx
+++ b/app/loja/perfil/page.tsx
@@ -11,6 +11,11 @@ interface UsuarioAuthModel {
   telefone?: string;
   cpf?: string;
   data_nascimento?: string;
+  endereco?: string;
+  numero?: string;
+  estado?: string;
+  cep?: string;
+  cidade?: string;
   role: "coordenador" | "lider" | "usuario" | string;
   campo?: string;
   expand?: {

--- a/lib/context/AuthContext.tsx
+++ b/lib/context/AuthContext.tsx
@@ -6,14 +6,7 @@ import createPocketBase, {
   clearBaseAuth,
 } from "@/lib/pocketbase";
 import type { RecordModel } from "pocketbase";
-
-type UserModel = {
-  id: string;
-  nome: string;
-  role: "coordenador" | "lider" | "usuario";
-  tour?: boolean;
-  [key: string]: unknown;
-};
+import type { UserModel } from "@/types/UserModel";
 
 type AuthContextType = {
   user: UserModel | null;

--- a/types/UserModel.ts
+++ b/types/UserModel.ts
@@ -2,6 +2,14 @@ export type UserModel = {
   id: string;
   nome: string;
   email: string;
+  telefone?: string;
+  cpf?: string;
+  data_nascimento?: string;
+  endereco?: string;
+  numero?: string;
+  estado?: string;
+  cep?: string;
+  cidade?: string;
   role: "coordenador" | "lider" | "usuario";
   cliente?: string;
   tour?: boolean;


### PR DESCRIPTION
## Summary
- extend `UserModel` with address and personal fields
- import `UserModel` in `AuthContext`
- update profile page interfaces with new fields

## Testing
- `npm run lint` *(fails: next not found)*
- `npm run build` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_6853580315f0832ca0530a346ad8f7d4