### PR TITLE
Replace alert usage with toast hooks

### DIFF
--- a/app/loja/checkout/page.tsx
+++ b/app/loja/checkout/page.tsx
@@ -5,6 +5,7 @@ import { useRouter, useSearchParams } from "next/navigation";
 import { Suspense, useState, useEffect } from "react";
 import LoadingOverlay from "@/components/LoadingOverlay";
 import { useAuthContext } from "@/lib/context/AuthContext";
+import { useToast } from "@/lib/context/ToastContext";
 import { CheckCircle } from "lucide-react";
 import { hexToPtName } from "@/utils/colorNamePt";
 import { calculateGross, calculateNet, PaymentMethod } from "@/lib/asaasFees";
@@ -24,6 +25,7 @@ function CheckoutContent() {
   const router = useRouter();
   const searchParams = useSearchParams();
   const { isLoggedIn, user, tenantId } = useAuthContext();
+  const { showError } = useToast();
 
   const [nome, setNome] = useState(user?.nome || "");
   const [telefone, setTelefone] = useState(String(user?.telefone ?? ""));
@@ -234,7 +236,7 @@ function CheckoutContent() {
         }, 1000);
       }, 1000);
     } catch {
-      alert("Erro ao processar pagamento. Tente novamente.");
+      showError("Erro ao processar pagamento. Tente novamente.");
       setStatus("idle");
     }
   };

--- a/app/loja/cliente/page.tsx
+++ b/app/loja/cliente/page.tsx
@@ -2,10 +2,12 @@
 
 import { useEffect, useState } from "react";
 import { useAuthGuard } from "@/lib/hooks/useAuthGuard";
+import { useToast } from "@/lib/context/ToastContext";
 import type { Inscricao, Compra, Pedido } from "@/types";
 
 export default function AreaCliente() {
   const { user, pb, authChecked } = useAuthGuard(["usuario"]);
+  const { showSuccess, showError } = useToast();
   const [inscricoes, setInscricoes] = useState<Inscricao[]>([]);
   const [compras, setCompras] = useState<Compra[]>([]);
   const [pedidos, setPedidos] = useState<Pedido[]>([]);
@@ -21,10 +23,10 @@ export default function AreaCliente() {
       });
       const data = await res.json();
       if (!res.ok) throw new Error(data?.error || "Erro ao gerar link");
-      alert(`URL de pagamento: ${data.url}`);
+      showSuccess(`URL de pagamento: ${data.url}`);
     } catch (err: unknown) {
       const msg = err instanceof Error ? err.message : "Erro ao gerar link";
-      alert(msg);
+      showError(msg);
     }
   };
 


### PR DESCRIPTION
## Summary
- use toast context in checkout page
- show error toast when payment link generation fails
- use toast in client area for payment link messages

## Testing
- `npm run lint` *(fails: next not found)*
- `npm run build` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_685358901530832c91c6332c62cc0a16