### PR TITLE
Fix toast persistence and render via portal

### DIFF
--- a/lib/context/ToastContext.tsx
+++ b/lib/context/ToastContext.tsx
@@ -1,5 +1,13 @@
 "use client";
-import { createContext, useContext, useState, useCallback } from "react";
+import {
+  createContext,
+  useContext,
+  useState,
+  useCallback,
+  useEffect,
+} from "react";
+import { createPortal } from "react-dom";
+import { usePathname } from "next/navigation";
 
 export type ToastType = "success" | "error";
 
@@ -17,6 +25,12 @@ export function ToastProvider({ children }: { children: React.ReactNode }) {
   const [toasts, setToasts] = useState<
     { id: string; message: string; type: ToastType }[]
   >([]);
+  const pathname = usePathname();
+  useEffect(() => setToasts([]), [pathname]);
+  const [mounted, setMounted] = useState(false);
+  useEffect(() => {
+    setMounted(true);
+  }, []);
 
   const addToast = useCallback((message: string, type: ToastType) => {
     const id = globalThis.crypto?.randomUUID
@@ -45,18 +59,22 @@ export function ToastProvider({ children }: { children: React.ReactNode }) {
       }}
     >
       {children}
-      <div className="fixed top-4 right-4 space-y-2 z-50">
-        {toasts.map((t) => (
-          <div
-            key={t.id}
-            className={`px-4 py-2 rounded text-white shadow ${
-              t.type === "success" ? "bg-green-600" : "bg-red-600"
-            }`}
-          >
-            {t.message}
-          </div>
-        ))}
-      </div>
+      {mounted &&
+        createPortal(
+          <div className="fixed top-4 right-4 space-y-2 z-50">
+            {toasts.map((t) => (
+              <div
+                key={t.id}
+                className={`px-4 py-2 rounded text-white shadow ${
+                  t.type === "success" ? "bg-green-600" : "bg-red-600"
+                }`}
+              >
+                {t.message}
+              </div>
+            ))}
+          </div>,
+          document.body
+        )}
     </ToastContext.Provider>
   );
 }


### PR DESCRIPTION
## Summary
- clear toast notifications when the route changes
- render toasts in a portal so they appear above all layouts

## Testing
- `npm run lint`
- `npm run build`
- `npm test` *(fails: calculateGross.test.ts and others)*

------
https://chatgpt.com/codex/tasks/task_e_6853540fa350832c931e985fe1c0908f