### PR TITLE
Fix image persistence on edit

### DIFF
--- a/app/admin/eventos/editar/[id]/page.tsx
+++ b/app/admin/eventos/editar/[id]/page.tsx
@@ -19,6 +19,7 @@ export default function EditarEventoPage() {
   }, [ctxUser]);
   const router = useRouter();
   const [initial, setInitial] = useState<Record<string, unknown> | null>(null);
+  const [existingImage, setExistingImage] = useState<string | null>(null);
   const [loading, setLoading] = useState(true);
   const [cobraInscricao, setCobraInscricao] = useState(false);
   const [produtos, setProdutos] = useState<Produto[]>([]);
@@ -56,6 +57,7 @@ export default function EditarEventoPage() {
           cidade: data.cidade,
           status: data.status,
         });
+        setExistingImage(data.imagem || null);
         setCobraInscricao(Boolean(data.cobra_inscricao));
         const arr = Array.isArray(data.produtos)
           ? (data.produtos as string[])
@@ -139,6 +141,16 @@ export default function EditarEventoPage() {
     e.preventDefault();
     const formElement = e.currentTarget as HTMLFormElement;
     const formData = new FormData(formElement);
+    const imagemInput = formElement.querySelector<HTMLInputElement>(
+      "input[name='imagem']"
+    );
+    const files = imagemInput?.files;
+    formData.delete("imagem");
+    if (files && files.length > 0) {
+      formData.append("imagem", files[0]);
+    } else if (existingImage) {
+      formData.append("imagem", existingImage);
+    }
     formData.delete("produtos");
     selectedProdutos.forEach((p) => formData.append("produtos", p));
     formData.set("cobra_inscricao", String(cobraInscricao));

--- a/app/admin/produtos/editar/[id]/page.tsx
+++ b/app/admin/produtos/editar/[id]/page.tsx
@@ -38,6 +38,7 @@ export default function EditarProdutoPage() {
   const [categorias, setCategorias] = useState<Categoria[]>([]);
   const [selectedCategoria, setSelectedCategoria] = useState<string>("");
   const [initial, setInitial] = useState<Record<string, unknown> | null>(null);
+  const [existingImages, setExistingImages] = useState<string[]>([]);
   const [loading, setLoading] = useState(true);
   const [cores, setCores] = useState<string[]>([]);
   const [tamanhos, setTamanhos] = useState<string[]>([]);
@@ -122,7 +123,9 @@ export default function EditarProdutoPage() {
               : Array.isArray(data.cores)
               ? data.cores.join(", ")
               : "",
+          imagens: data.imagens,
         });
+        setExistingImages(Array.isArray(data.imagens) ? data.imagens : []);
         setSelectedCategoria(
           Array.isArray(data.categoria)
             ? data.categoria[0] ?? ""
@@ -173,6 +176,8 @@ export default function EditarProdutoPage() {
       Array.from(arquivos).forEach((file) => {
         formData.append("imagens", file);
       });
+    } else {
+      existingImages.forEach((img) => formData.append("imagens", img));
     }
 
     // Trata o campo de cores: insere como string separada por vírgula


### PR DESCRIPTION
## Summary
- ensure existing event image is sent when editing
- retain product images when updating

## Testing
- `npm run lint` *(fails: next not found)*
- `npm run build` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_68535f4b8bdc832c87094641b17845b8