### PR TITLE
Add success toast on checkout

### DIFF
--- a/app/loja/checkout/page.tsx
+++ b/app/loja/checkout/page.tsx
@@ -27,6 +27,7 @@ function CheckoutContent() {
   const router = useRouter();
   const { isLoggedIn, user, tenantId } = useAuthContext();
   const pb = useMemo(() => createPocketBase(), []);
+  const { showSuccess, showError } = useToast();
 
   const [nome, setNome] = useState(user?.nome || "");
   const [telefone, setTelefone] = useState(String(user?.telefone ?? ""));
@@ -223,6 +224,9 @@ function CheckoutContent() {
       const link = data?.checkoutUrl || data?.link;
       if (!res.ok || !link) throw new Error("Falha ao gerar link de pagamento");
       setRedirecting(true);
+      showSuccess(
+        "Pedido registrado! Você será redirecionado para o pagamento."
+      );
       clearCart();
       setTimeout(() => {
         setStatus("success");


### PR DESCRIPTION
## Summary
- notify user that the order was registered before redirecting to payment

## Testing
- `npm run lint` *(fails: next not found)*
- `npm run build` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_685360647c64832c8df02f1f113e0299