### PR TITLE
Delay redirects after signup and inscrição

### DIFF
--- a/app/components/SignUpForm.tsx
+++ b/app/components/SignUpForm.tsx
@@ -112,7 +112,9 @@ export default function SignUpForm({
         senha
       );
       showSuccess("Conta criada com sucesso!");
-      onSuccess?.();
+      setTimeout(() => {
+        onSuccess?.();
+      }, 500);
     } catch (err: unknown) {
       console.error("Erro no cadastro:", err);
       const e = err as ClientResponseError;

--- a/app/loja/checkout/page.tsx
+++ b/app/loja/checkout/page.tsx
@@ -27,6 +27,7 @@ function CheckoutContent() {
   const router = useRouter();
   const { isLoggedIn, user, tenantId } = useAuthContext();
   const pb = useMemo(() => createPocketBase(), []);
+  const { showError } = useToast();
 
   const [nome, setNome] = useState(user?.nome || "");
   const [telefone, setTelefone] = useState(String(user?.telefone ?? ""));

--- a/app/loja/cliente/page.tsx
+++ b/app/loja/cliente/page.tsx
@@ -6,7 +6,6 @@ import type { Inscricao, Pedido } from "@/types";
 
 export default function AreaCliente() {
   const { user, pb, authChecked } = useAuthGuard(["usuario"]);
-  const { showSuccess, showError } = useToast();
   const [inscricoes, setInscricoes] = useState<Inscricao[]>([]);
   const [pedidos, setPedidos] = useState<Pedido[]>([]);
 

--- a/app/loja/components/InscricaoForm.tsx
+++ b/app/loja/components/InscricaoForm.tsx
@@ -110,7 +110,9 @@ export default function InscricaoForm({ eventoId }: InscricaoFormProps) {
 
       setStatus("success");
       showSuccess("Inscrição registrada! Em breve entraremos em contato.");
-      router.push("/loja/inscricoes/confirmacao");
+      setTimeout(() => {
+        router.push("/loja/inscricoes/confirmacao");
+      }, 500);
     } catch (err) {
       console.warn("Erro ao enviar inscrição:", err);
       setStatus("error");

--- a/types/index.ts
+++ b/types/index.ts
@@ -46,7 +46,6 @@ export type Pedido = {
   tamanho?: string;
   status: "pendente" | "pago" | "cancelado";
   cor: string;
-  canal?: string;
   genero?: string;
   responsavel?: string;
   cliente?: string;


### PR DESCRIPTION
## Summary
- delay login view switch in `SignUpForm` so toast is visible
- delay redirect in `InscricaoForm` for confirmation page
- fix checkout to use `useToast` and remove unused toast hooks
- remove duplicate property in `Pedido` type

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6853606f84e0832c88798e44ab575400