### PR TITLE
Add toasts for event save actions

### DIFF
--- a/app/admin/eventos/editar/[id]/page.tsx
+++ b/app/admin/eventos/editar/[id]/page.tsx
@@ -5,10 +5,12 @@ import { useAuthContext } from "@/lib/context/AuthContext";
 import LoadingOverlay from "@/components/LoadingOverlay";
 import type { Produto } from "@/types";
 import { ModalProduto } from "../../../produtos/novo/ModalProduto";
+import { useToast } from "@/lib/context/ToastContext";
 
 export default function EditarEventoPage() {
   const { id } = useParams<{ id: string }>();
   const { user: ctxUser, isLoggedIn } = useAuthContext();
+  const { showSuccess, showError } = useToast();
   const getAuth = useCallback(() => {
     const token =
       typeof window !== "undefined" ? localStorage.getItem("pb_token") : null;
@@ -143,16 +145,24 @@ export default function EditarEventoPage() {
     selectedProdutos.forEach((p) => formData.append("produtos", p));
     formData.set("cobra_inscricao", String(cobraInscricao));
     const { token, user } = getAuth();
-    const res = await fetch(`/admin/api/eventos/${id}`, {
-      method: "PUT",
-      body: formData,
-      headers: {
-        Authorization: `Bearer ${token}`,
-        "X-PB-User": JSON.stringify(user),
-      },
-    });
-    if (res.ok) {
-      router.push("/admin/eventos");
+    try {
+      const res = await fetch(`/admin/api/eventos/${id}`, {
+        method: "PUT",
+        body: formData,
+        headers: {
+          Authorization: `Bearer ${token}`,
+          "X-PB-User": JSON.stringify(user),
+        },
+      });
+      if (res.ok) {
+        showSuccess("Evento salvo com sucesso");
+        router.push("/admin/eventos");
+      } else {
+        showError("Falha ao salvar evento");
+      }
+    } catch (err) {
+      console.error("Erro ao salvar evento:", err);
+      showError("Falha ao salvar evento");
     }
   }
 

--- a/app/admin/eventos/page.tsx
+++ b/app/admin/eventos/page.tsx
@@ -6,6 +6,7 @@ import { useRouter } from "next/navigation";
 import { useAuthContext } from "@/lib/context/AuthContext";
 import { ModalEvento } from "./novo/ModalEvento";
 import { formatDate } from "@/utils/formatDate";
+import { useToast } from "@/lib/context/ToastContext";
 
 interface Evento {
   id: string;
@@ -17,6 +18,7 @@ interface Evento {
 
 export default function AdminEventosPage() {
   const { user: ctxUser, isLoggedIn } = useAuthContext();
+  const { showSuccess, showError } = useToast();
   const router = useRouter();
   const getAuth = useCallback(() => {
     const token = typeof window !== "undefined" ? localStorage.getItem("pb_token") : null;
@@ -90,12 +92,15 @@ export default function AdminEventosPage() {
       if (res.ok) {
         const data = await res.json();
         setEventos((prev) => [data, ...prev]);
+        showSuccess("Evento salvo com sucesso");
       } else {
         const data = await res.json().catch(() => ({}));
         console.error("Falha ao criar evento", data);
+        showError("Falha ao salvar evento");
       }
     } catch (err) {
       console.error("Erro ao criar evento:", err);
+      showError("Falha ao salvar evento");
     } finally {
       setModalOpen(false);
     }

--- a/app/loja/checkout/page.tsx
+++ b/app/loja/checkout/page.tsx
@@ -27,6 +27,7 @@ function CheckoutContent() {
   const router = useRouter();
   const { isLoggedIn, user, tenantId } = useAuthContext();
   const pb = useMemo(() => createPocketBase(), []);
+  const { showError } = useToast();
 
   const [nome, setNome] = useState(user?.nome || "");
   const [telefone, setTelefone] = useState(String(user?.telefone ?? ""));

--- a/app/loja/cliente/page.tsx
+++ b/app/loja/cliente/page.tsx
@@ -6,7 +6,6 @@ import type { Inscricao, Pedido } from "@/types";
 
 export default function AreaCliente() {
   const { user, pb, authChecked } = useAuthGuard(["usuario"]);
-  const { showSuccess, showError } = useToast();
   const [inscricoes, setInscricoes] = useState<Inscricao[]>([]);
   const [pedidos, setPedidos] = useState<Pedido[]>([]);
 

--- a/types/index.ts
+++ b/types/index.ts
@@ -46,7 +46,6 @@ export type Pedido = {
   tamanho?: string;
   status: "pendente" | "pago" | "cancelado";
   cor: string;
-  canal?: string;
   genero?: string;
   responsavel?: string;
   cliente?: string;


### PR DESCRIPTION
## Summary
- show toast notifications for saving events
- fix lint warnings in checkout and client pages
- correct duplicated property in Pedido type

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68536066e378832cafe86c0a966d40aa