### PR TITLE
Add toast feedback on product actions

### DIFF
--- a/app/admin/produtos/editar/[id]/page.tsx
+++ b/app/admin/produtos/editar/[id]/page.tsx
@@ -5,6 +5,7 @@ import { useParams, useRouter } from "next/navigation";
 import { useAuthContext } from "@/lib/context/AuthContext";
 import { calculateGross } from "@/lib/asaasFees";
 import LoadingOverlay from "@/components/LoadingOverlay";
+import { useToast } from "@/lib/context/ToastContext";
 
 interface Categoria {
   id: string;
@@ -27,6 +28,7 @@ export default function EditarProdutoPage() {
   const { id } = useParams<{ id: string }>();
   const { user: ctxUser, isLoggedIn } = useAuthContext();
   const router = useRouter();
+  const { showSuccess, showError } = useToast();
   const getAuth = useCallback(() => {
     const token =
       typeof window !== "undefined" ? localStorage.getItem("pb_token") : null;
@@ -214,16 +216,24 @@ export default function EditarProdutoPage() {
     console.log("-------------------------------");
 
     const { token, user } = getAuth();
-    const res = await fetch(`/admin/api/produtos/${id}`, {
-      method: "PUT",
-      body: formData,
-      headers: {
-        Authorization: `Bearer ${token}`,
-        "X-PB-User": JSON.stringify(user),
-      },
-    });
-    if (res.ok) {
-      router.push("/admin/produtos");
+    try {
+      const res = await fetch(`/admin/api/produtos/${id}`, {
+        method: "PUT",
+        body: formData,
+        headers: {
+          Authorization: `Bearer ${token}`,
+          "X-PB-User": JSON.stringify(user),
+        },
+      });
+      if (res.ok) {
+        showSuccess("Produto atualizado");
+        router.push("/admin/produtos");
+      } else {
+        showError("Erro ao atualizar produto");
+      }
+    } catch (err) {
+      console.error("Erro ao atualizar produto:", err);
+      showError("Erro ao atualizar produto");
     }
   }
 

--- a/app/admin/produtos/novo/ModalProduto.tsx
+++ b/app/admin/produtos/novo/ModalProduto.tsx
@@ -4,6 +4,7 @@ import { useEffect, useRef, useCallback, useState } from "react";
 import { useAuthContext } from "@/lib/context/AuthContext";
 import { calculateGross } from "@/lib/asaasFees";
 import ModalCategoria from "../categorias/ModalCategoria";
+import { useToast } from "@/lib/context/ToastContext";
 
 export interface ModalProdutoProps<T extends Record<string, unknown>> {
   open: boolean;
@@ -54,6 +55,7 @@ export function ModalProduto<T extends Record<string, unknown>>({
     initial.categoria || ""
   );
   const { isLoggedIn, user: ctxUser } = useAuthContext();
+  const { showSuccess, showError } = useToast();
   const getAuth = useCallback(() => {
     const token =
       typeof window !== "undefined" ? localStorage.getItem("pb_token") : null;
@@ -138,8 +140,10 @@ export function ModalProduto<T extends Record<string, unknown>>({
       if (res.ok) {
         setCategorias((prev) => [...prev, data]);
         setSelectedCategoria(data.id);
+        showSuccess("Categoria criada");
       } else {
         console.error(data);
+        showError("Erro ao criar categoria");
       }
     } finally {
       setCategoriaModalOpen(false);

--- a/app/admin/produtos/page.tsx
+++ b/app/admin/produtos/page.tsx
@@ -6,6 +6,7 @@ import { useAuthContext } from "@/lib/context/AuthContext";
 import Link from "next/link";
 import type { Produto } from "@/types";
 import { ModalProduto } from "./novo/ModalProduto";
+import { useToast } from "@/lib/context/ToastContext";
 
 function slugify(str: string) {
   return str
@@ -22,6 +23,7 @@ const PRODUTOS_POR_PAGINA = 10;
 export default function AdminProdutosPage() {
   const { user: ctxUser, isLoggedIn } = useAuthContext();
   const router = useRouter();
+  const { showSuccess, showError } = useToast();
   const getAuth = useCallback(() => {
     const token =
       typeof window !== "undefined" ? localStorage.getItem("pb_token") : null;
@@ -114,13 +116,16 @@ export default function AdminProdutosPage() {
       if (!res.ok) {
         const data = await res.json().catch(() => ({}));
         console.error("Falha ao criar produto", res.status, data);
+        showError("Erro ao criar produto");
         return;
       }
       const data = await res.json();
       console.log("Produto criado:", data);
       setProdutos((prev) => [data, ...prev]);
+      showSuccess("Produto criado");
     } catch (err) {
       console.error("Erro ao criar produto:", err);
+      showError("Erro ao criar produto");
     }
 
     setModalOpen(false);

--- a/app/loja/checkout/page.tsx
+++ b/app/loja/checkout/page.tsx
@@ -26,6 +26,7 @@ function CheckoutContent() {
 
   const router = useRouter();
   const { isLoggedIn, user, tenantId } = useAuthContext();
+  const { showError } = useToast();
   const pb = useMemo(() => createPocketBase(), []);
 
   const [nome, setNome] = useState(user?.nome || "");

--- a/app/loja/cliente/page.tsx
+++ b/app/loja/cliente/page.tsx
@@ -6,7 +6,6 @@ import type { Inscricao, Pedido } from "@/types";
 
 export default function AreaCliente() {
   const { user, pb, authChecked } = useAuthGuard(["usuario"]);
-  const { showSuccess, showError } = useToast();
   const [inscricoes, setInscricoes] = useState<Inscricao[]>([]);
   const [pedidos, setPedidos] = useState<Pedido[]>([]);
 


### PR DESCRIPTION
## Summary
- add Toast usage in product CRUD pages
- enable toast feedback when creating categories from product modal
- fix lint issues in checkout and customer pages

## Testing
- `npm run lint`
- `npm run build` *(fails: Duplicate identifier 'canal')*

------
https://chatgpt.com/codex/tasks/task_e_68536068a7b8832c85c07a8162d29ea1