### PR TITLE
Add spinner on sign-up submit

### DIFF
--- a/app/components/SignUpForm.tsx
+++ b/app/components/SignUpForm.tsx
@@ -5,6 +5,7 @@ import { useAuthContext } from "@/lib/context/AuthContext";
 import { useToast } from "@/lib/context/ToastContext";
 import type { ClientResponseError } from "pocketbase";
 import createPocketBase from "@/lib/pocketbase"; // ajuste para seu caminho real
+import Spinner from "@/components/Spinner";
 
 const VIA_CEP_URL =
   process.env.NEXT_PUBLIC_VIA_CEP_URL || "https://viacep.com.br/ws";
@@ -261,7 +262,14 @@ export default function SignUpForm({
               loading ? "opacity-50" : ""
             }`}
           >
-            {loading ? "Enviando..." : "Criar conta"}
+            {loading ? (
+              <span className="flex items-center justify-center gap-2">
+                <Spinner className="w-4 h-4" />
+                Enviando...
+              </span>
+            ) : (
+              "Criar conta"
+            )}
           </button>
 
           {children && (

--- a/components/Spinner.tsx
+++ b/components/Spinner.tsx
@@ -1,0 +1,13 @@
+"use client";
+
+interface SpinnerProps {
+  className?: string;
+}
+
+export default function Spinner({ className }: SpinnerProps) {
+  return (
+    <span
+      className={`border-2 border-current border-t-transparent rounded-full animate-spin ${className ?? ""}`}
+    />
+  );
+}


### PR DESCRIPTION
## Summary
- add a reusable `Spinner` component
- show spinner and loading text in the sign-up submit button

## Testing
- `npx next lint` *(fails: 'showSuccess' and 'showError' unused in app/loja/cliente/page.tsx)*
- `npm run build` *(fails to compile: same lint errors as above)*

------
https://chatgpt.com/codex/tasks/task_e_685361bd77f8832c8137fae961eff08a