### PR TITLE
Padroniza cadastro de eventos com página dedicada

### DIFF
--- a/app/admin/eventos/novo/page.tsx
+++ b/app/admin/eventos/novo/page.tsx
@@ -1,0 +1,211 @@
+"use client";
+
+import { useEffect, useState, useCallback } from "react";
+import { useRouter } from "next/navigation";
+import Link from "next/link";
+import { useAuthContext } from "@/lib/context/AuthContext";
+import type { Produto } from "@/types";
+import { ModalProduto } from "../../produtos/novo/ModalProduto";
+import { useToast } from "@/lib/context/ToastContext";
+
+export default function NovoEventoPage() {
+  const { user: ctxUser, isLoggedIn } = useAuthContext();
+  const { showSuccess, showError } = useToast();
+  const router = useRouter();
+  const getAuth = useCallback(() => {
+    const token = typeof window !== "undefined" ? localStorage.getItem("pb_token") : null;
+    const raw = typeof window !== "undefined" ? localStorage.getItem("pb_user") : null;
+    const user = raw ? JSON.parse(raw) : ctxUser;
+    return { token, user } as const;
+  }, [ctxUser]);
+
+  const [cobraInscricao, setCobraInscricao] = useState(false);
+  const [produtos, setProdutos] = useState<Produto[]>([]);
+  const [selectedProdutos, setSelectedProdutos] = useState<string[]>([]);
+  const [produtoModalOpen, setProdutoModalOpen] = useState(false);
+
+  function toggleProduto(id: string) {
+    setSelectedProdutos((prev) =>
+      prev.includes(id) ? prev.filter((p) => p !== id) : [...prev, id]
+    );
+  }
+
+  useEffect(() => {
+    const { token, user } = getAuth();
+    if (!isLoggedIn || !token || !user || user.role !== "coordenador") {
+      router.replace("/login");
+    }
+  }, [isLoggedIn, router, getAuth]);
+
+  useEffect(() => {
+    const { token, user } = getAuth();
+    if (!isLoggedIn || !token || !user || user.role !== "coordenador") return;
+    fetch("/admin/api/produtos", {
+      headers: {
+        Authorization: `Bearer ${token}`,
+        "X-PB-User": JSON.stringify(user),
+      },
+    })
+      .then((r) => r.json())
+      .then((data) => {
+        setProdutos(Array.isArray(data) ? data : data.items ?? []);
+      })
+      .catch(() => setProdutos([]));
+  }, [isLoggedIn, getAuth]);
+
+  async function handleNovoProduto(form: Produto) {
+    const formData = new FormData();
+    formData.set("nome", String(form.nome ?? ""));
+    formData.set("preco", String(form.preco ?? 0));
+    if (form.checkout_url) formData.set("checkout_url", String(form.checkout_url));
+    if (form.categoria) formData.set("categoria", String(form.categoria));
+    if (Array.isArray(form.tamanhos)) {
+      form.tamanhos.forEach((t) => formData.append("tamanhos", t));
+    }
+    if (Array.isArray(form.generos)) {
+      form.generos.forEach((g) => formData.append("generos", g));
+    }
+    if (form.descricao) formData.set("descricao", String(form.descricao));
+    if (form.detalhes) formData.set("detalhes", String(form.detalhes));
+    if (Array.isArray(form.cores)) {
+      formData.set("cores", (form.cores as string[]).join(","));
+    } else if (form.cores) {
+      formData.set("cores", String(form.cores));
+    }
+    formData.set("ativo", String(form.ativo ? "true" : "false"));
+    if (form.imagens && form.imagens instanceof FileList) {
+      Array.from(form.imagens).forEach((file) => formData.append("imagens", file));
+    }
+
+    const { token, user } = getAuth();
+    try {
+      const res = await fetch("/admin/api/produtos", {
+        method: "POST",
+        headers: {
+          Authorization: `Bearer ${token}`,
+          "X-PB-User": JSON.stringify(user),
+        },
+        body: formData,
+      });
+      if (!res.ok) return;
+      const data = await res.json();
+      setProdutos((prev) => [data, ...prev]);
+      setSelectedProdutos((prev) => [...prev, data.id]);
+    } catch (err) {
+      console.error("Erro ao criar produto:", err);
+    } finally {
+      setProdutoModalOpen(false);
+    }
+  }
+
+  async function handleSubmit(e: React.FormEvent) {
+    e.preventDefault();
+    const formElement = e.currentTarget as HTMLFormElement;
+    const formData = new FormData(formElement);
+    const imagemInput = formElement.querySelector<HTMLInputElement>("input[name='imagem']");
+    const files = imagemInput?.files;
+    formData.delete("imagem");
+    if (files && files.length > 0) {
+      formData.append("imagem", files[0]);
+    }
+    formData.delete("produtos");
+    selectedProdutos.forEach((p) => formData.append("produtos", p));
+    formData.set("cobra_inscricao", String(cobraInscricao));
+    const { token, user } = getAuth();
+    try {
+      const res = await fetch("/admin/api/eventos", {
+        method: "POST",
+        body: formData,
+        headers: {
+          Authorization: `Bearer ${token}`,
+          "X-PB-User": JSON.stringify(user),
+        },
+      });
+      if (res.ok) {
+        showSuccess("Evento salvo com sucesso");
+        router.push("/admin/eventos");
+      } else {
+        showError("Falha ao salvar evento");
+      }
+    } catch (err) {
+      console.error("Erro ao salvar evento:", err);
+      showError("Falha ao salvar evento");
+    }
+  }
+
+  return (
+    <>
+      <main className="max-w-xl mx-auto px-4 py-8">
+        <h1 className="text-2xl font-bold mb-4" style={{ fontFamily: "var(--font-heading)" }}>
+          Novo Evento
+        </h1>
+        <form onSubmit={handleSubmit} className="space-y-4">
+          <input className="input-base" name="titulo" placeholder="Título" maxLength={30} required />
+          <textarea className="input-base" name="descricao" rows={2} maxLength={150} required />
+          <input className="input-base" name="data" type="date" required />
+          <input className="input-base" name="cidade" required />
+          <input type="file" name="imagem" accept="image/*" className="input-base" />
+          <select name="status" defaultValue="em breve" className="input-base" required>
+            <option value="em breve">Em breve</option>
+            <option value="realizado">Realizado</option>
+          </select>
+          <div className="flex items-center gap-2">
+            <input
+              type="checkbox"
+              name="cobra_inscricao"
+              id="cobra_inscricao"
+              className="checkbox-base"
+              checked={cobraInscricao}
+              onChange={(e) => setCobraInscricao(e.target.checked)}
+            />
+            <label htmlFor="cobra_inscricao" className="text-sm font-medium">
+              Realizar cobrança?
+            </label>
+          </div>
+          {cobraInscricao && (
+            <div>
+              <label className="label-base">Produtos para inscrição</label>
+              <div className="flex flex-col gap-2">
+                {produtos.map((p) => (
+                  <label className="checkbox-label" key={p.id}>
+                    <input
+                      type="checkbox"
+                      name="produtos"
+                      value={p.id}
+                      checked={selectedProdutos.includes(p.id)}
+                      onChange={() => toggleProduto(p.id)}
+                      className="checkbox-base"
+                    />
+                    {p.nome}
+                  </label>
+                ))}
+                <button
+                  type="button"
+                  className="btn btn-secondary w-fit"
+                  onClick={() => setProdutoModalOpen(true)}
+                >
+                  + Produto
+                </button>
+              </div>
+            </div>
+          )}
+          <div className="flex gap-2">
+            <button type="submit" className="btn btn-primary flex-1">
+              Salvar
+            </button>
+            <Link href="/admin/eventos" className="btn flex-1">
+              Cancelar
+            </Link>
+          </div>
+        </form>
+      </main>
+      {produtoModalOpen && (
+        <ModalProduto
+          open={produtoModalOpen}
+          onClose={() => setProdutoModalOpen(false)}
+          onSubmit={handleNovoProduto}
+        />
+      )}
+    </>
+  );
+}

--- a/app/admin/eventos/page.tsx
+++ b/app/admin/eventos/page.tsx
@@ -4,9 +4,7 @@ import { useEffect, useState, useCallback } from "react";
 import Link from "next/link";
 import { useRouter } from "next/navigation";
 import { useAuthContext } from "@/lib/context/AuthContext";
-import { ModalEvento } from "./novo/ModalEvento";
 import { formatDate } from "@/utils/formatDate";
-import { useToast } from "@/lib/context/ToastContext";
 
 interface Evento {
   id: string;
@@ -18,7 +16,6 @@ interface Evento {
 
 export default function AdminEventosPage() {
   const { user: ctxUser, isLoggedIn } = useAuthContext();
-  const { showSuccess, showError } = useToast();
   const router = useRouter();
   const getAuth = useCallback(() => {
     const token = typeof window !== "undefined" ? localStorage.getItem("pb_token") : null;
@@ -28,7 +25,6 @@ export default function AdminEventosPage() {
   }, [ctxUser]);
 
   const [eventos, setEventos] = useState<Evento[]>([]);
-  const [modalOpen, setModalOpen] = useState(false);
 
   useEffect(() => {
     const { token, user } = getAuth();
@@ -59,52 +55,6 @@ export default function AdminEventosPage() {
     fetchEventos();
   }, [isLoggedIn, getAuth]);
 
-  async function handleNovoEvento(form: Record<string, unknown>) {
-    const { token, user } = getAuth();
-    if (!isLoggedIn || !user || user.role !== "coordenador") return;
-    const formData = new FormData();
-    if (form.titulo) formData.set("titulo", String(form.titulo));
-    if (form.descricao) formData.set("descricao", String(form.descricao));
-    if (form.data) formData.set("data", String(form.data));
-    if (form.cidade) formData.set("cidade", String(form.cidade));
-    if (form.status) formData.set("status", String(form.status));
-    if (form.imagem instanceof File) {
-      formData.append("imagem", form.imagem);
-    }
-    if (form.cobra_inscricao !== undefined) {
-      formData.set(
-        "cobra_inscricao",
-        String(form.cobra_inscricao as boolean)
-      );
-    }
-    if (Array.isArray(form.produtos)) {
-      (form.produtos as string[]).forEach((p) => formData.append("produtos", p));
-    }
-    try {
-      const res = await fetch("/admin/api/eventos", {
-        method: "POST",
-        headers: {
-          Authorization: `Bearer ${token}`,
-          "X-PB-User": JSON.stringify(user),
-        },
-        body: formData,
-      });
-      if (res.ok) {
-        const data = await res.json();
-        setEventos((prev) => [data, ...prev]);
-        showSuccess("Evento salvo com sucesso");
-      } else {
-        const data = await res.json().catch(() => ({}));
-        console.error("Falha ao criar evento", data);
-        showError("Falha ao salvar evento");
-      }
-    } catch (err) {
-      console.error("Erro ao criar evento:", err);
-      showError("Falha ao salvar evento");
-    } finally {
-      setModalOpen(false);
-    }
-  }
 
   async function handleDelete(id: string) {
     if (!confirm("Confirma excluir?")) return;
@@ -125,17 +75,10 @@ export default function AdminEventosPage() {
         <h2 className="text-2xl font-bold" style={{ fontFamily: "var(--font-heading)" }}>
           Eventos
         </h2>
-        <button className="btn btn-primary" onClick={() => setModalOpen(true)}>
+        <Link href="/admin/eventos/novo" className="btn btn-primary">
           + Novo Evento
-        </button>
+        </Link>
       </div>
-      {modalOpen && (
-        <ModalEvento
-          open={modalOpen}
-          onClose={() => setModalOpen(false)}
-          onSubmit={handleNovoEvento}
-        />
-      )}
       <div className="overflow-x-auto rounded border shadow-sm bg-neutral-50 dark:bg-neutral-900 border-neutral-200 dark:border-neutral-700">
         <table className="table-base">
           <thead>


### PR DESCRIPTION
## Summary
- cria `/admin/eventos/novo` como página de cadastro
- remove modal e linka botão da lista para a nova página

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_685365a03044832c8b19e9abc0aecb0e