### PR TITLE
Make n8n webhook fire-and-forget

### DIFF
--- a/app/admin/inscricoes/componentes/ModalVisualizarPedido.tsx
+++ b/app/admin/inscricoes/componentes/ModalVisualizarPedido.tsx
@@ -4,6 +4,7 @@ import { X, Copy } from "lucide-react";
 import createPocketBase from "@/lib/pocketbase";
 import LoadingOverlay from "@/components/LoadingOverlay";
 import { useToast } from "@/lib/context/ToastContext";
+import { logInfo } from "@/lib/logger";
 
 interface Props {
   pedidoId: string;
@@ -62,7 +63,7 @@ export default function ModalVisualizarPedido({ pedidoId, onClose }: Props) {
       const { url } = await checkoutRes.json();
       setUrlPagamento(url);
 
-      await fetch("/admin/api/n8n", {
+      fetch("/admin/api/n8n", {
         method: "POST",
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify({
@@ -75,7 +76,9 @@ export default function ModalVisualizarPedido({ pedidoId, onClose }: Props) {
           valor: pedido.valor,
           url_pagamento: url,
         }),
-      });
+      }).catch((err) =>
+        logInfo("⚠️ Falha ao notificar o n8n", err)
+      );
 
       showSuccess("Link reenviado com sucesso!");
     } catch {

--- a/app/admin/inscricoes/page.tsx
+++ b/app/admin/inscricoes/page.tsx
@@ -10,6 +10,7 @@ import { CheckCircle, XCircle, Pencil, Trash2, Eye } from "lucide-react";
 import TooltipIcon from "../components/TooltipIcon";
 import { useToast } from "@/lib/context/ToastContext";
 import { useAuthGuard } from "@/lib/hooks/useAuthGuard";
+import { logInfo } from "@/lib/logger";
 import type { Evento, Inscricao as InscricaoRecord, Pedido, Produto } from "@/types";
 
 const statusBadge = {
@@ -277,8 +278,8 @@ export default function ListaInscricoesPage() {
         )
       );
 
-      // 🔹 6. Notificar via n8n webhook
-      await fetch("/admin/api/n8n", {
+      // 🔹 6. Notificar via n8n webhook de forma assíncrona
+      fetch("/admin/api/n8n", {
         method: "POST",
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify({
@@ -292,7 +293,9 @@ export default function ListaInscricoesPage() {
           valor: pedido.valor,
           url_pagamento: checkout.url,
         }),
-      });
+      }).catch((err) =>
+        logInfo("⚠️ Falha ao notificar o n8n", err)
+      );
 
       // 🔹 7. Mostrar sucesso visual
       showSuccess("Link de pagamento enviado com sucesso!");

--- a/app/inscricoes/[liderId]/[eventoId]/page.tsx
+++ b/app/inscricoes/[liderId]/[eventoId]/page.tsx
@@ -188,26 +188,21 @@ export default function InscricaoPage() {
         return;
       }
 
-      // 2. Envia notificação para o n8n
-      try {
-        await fetch("/admin/api/n8n", {
-          method: "POST",
-          headers: { "Content-Type": "application/json" },
-          body: JSON.stringify({
-            ...form,
-            liderId,
-            eventoId,
-            inscricaoId: result.inscricaoId,
-            paymentMethod,
-            installments,
-          }),
-        });
-      } catch (erro) {
-        logInfo(
-          "⚠️ Falha ao notificar o n8n (sem impacto no usuário)",
-          erro
-        );
-      }
+      // 2. Envia notificação para o n8n de forma assíncrona
+      fetch("/admin/api/n8n", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          ...form,
+          liderId,
+          eventoId,
+          inscricaoId: result.inscricaoId,
+          paymentMethod,
+          installments,
+        }),
+      }).catch((erro) =>
+        logInfo("⚠️ Falha ao notificar o n8n", erro)
+      );
 
       // 3. Redireciona se já houver link de pagamento
       if (result.link_pagamento) {


### PR DESCRIPTION
## Summary
- notify n8n webhook without awaiting response
- log info when n8n webhook fails

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68536721224c832c9d37772dd608bddc