### PR TITLE
Add email field to Inscricao type

### DIFF
--- a/app/admin/inscricoes/page.tsx
+++ b/app/admin/inscricoes/page.tsx
@@ -26,6 +26,7 @@ type Inscricao = {
   id: string;
   nome: string;
   telefone: string;
+  email?: string;
   cpf: string;
   /** Título do evento para exibição */
   evento: string;


### PR DESCRIPTION
## Summary
- include optional `email` field on local `Inscricao` type used in admin inscriptions page
- run lint and build to confirm no issues

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_685374373538832c828c4bfd26f46234