### PR TITLE
Fix paymentMethod usage in admin

### DIFF
--- a/__tests__/inscricoesPage.test.tsx
+++ b/__tests__/inscricoesPage.test.tsx
@@ -1,35 +1,77 @@
 /* @vitest-environment jsdom */
-import { render, screen } from '@testing-library/react'
+import { render, screen, fireEvent } from '@testing-library/react'
 import { vi } from 'vitest'
 import ListaInscricoesPage from '@/app/admin/inscricoes/page'
 
 const pbMock = {
   autoCancellation: vi.fn(),
-  collection: vi.fn((name: string) => ({
-    getFullList: vi.fn().mockResolvedValue(
-      name === 'inscricoes'
-        ? [
-            {
-              id: '1',
-              nome: 'Fulano',
-              telefone: '999999',
-              cpf: '123',
-              evento: 'evt1',
-              status: 'pendente',
-              created: '2025-01-01',
-              expand: {
-                campo: { nome: 'Campo 1', id: 'c1' },
-                evento: { titulo: 'Congresso Teste' },
-                pedido: { id: 'p1', status: 'pago', valor: 10 },
-              },
+  collection: vi.fn((name: string) => {
+    if (name === 'inscricoes') {
+      return {
+        getFullList: vi.fn().mockResolvedValue([
+          {
+            id: '1',
+            nome: 'Fulano',
+            telefone: '999999',
+            cpf: '123',
+            evento: 'evt1',
+            status: 'pendente',
+            created: '2025-01-01',
+            produto: 'Prod',
+            tamanho: 'P',
+            genero: 'm',
+            email: 'f@e.com',
+            paymentMethod: 'pix',
+            installments: 2,
+            criado_por: 'u1',
+            expand: {
+              campo: { nome: 'Campo 1', id: 'c1', responsavel: 'r1' },
+              evento: { titulo: 'Congresso Teste' },
+              pedido: { id: 'p1', status: 'pago', valor: 10 },
             },
-          ]
-        : name === 'eventos'
-        ? [{ id: 'evt1', titulo: 'Congresso Teste' }]
-        : []
-    ),
-  })),
-};
+          },
+        ]),
+        getOne: vi.fn().mockResolvedValue({
+          id: '1',
+          nome: 'Fulano',
+          telefone: '999999',
+          cpf: '123',
+          evento: 'evt1',
+          status: 'pendente',
+          created: '2025-01-01',
+          produto: 'Prod',
+          tamanho: 'P',
+          genero: 'm',
+          email: 'f@e.com',
+          paymentMethod: 'pix',
+          installments: 2,
+          criado_por: 'u1',
+          expand: {
+            campo: { nome: 'Campo 1', id: 'c1', responsavel: 'r1' },
+          },
+        }),
+        update: vi.fn().mockResolvedValue({}),
+      }
+    }
+    if (name === 'eventos') {
+      return {
+        getFullList: vi.fn().mockResolvedValue([{ id: 'evt1', titulo: 'Congresso Teste' }]),
+        getOne: vi.fn().mockResolvedValue({ id: 'evt1', expand: { produtos: [] } }),
+      }
+    }
+    if (name === 'produtos') {
+      return {
+        getFirstListItem: vi.fn().mockResolvedValue({ nome: 'Prod', preco: 10, tamanhos: ['P'], generos: ['m'] }),
+      }
+    }
+    if (name === 'pedidos') {
+      return {
+        create: vi.fn().mockResolvedValue({ id: 'ped1', valor: 10 }),
+      }
+    }
+    return {}
+  }),
+}
 
 vi.mock('@/lib/hooks/useAuthGuard', () => ({
   useAuthGuard: () => ({
@@ -61,4 +103,36 @@ vi.mock('@/app/admin/components/TooltipIcon', () => ({
 test('exibe titulo do evento na tabela', async () => {
   render(<ListaInscricoesPage />)
   expect(await screen.findByText('Congresso Teste')).toBeInTheDocument()
+})
+
+test('envia paymentMethod e installments ao confirmar', async () => {
+  const fetchMock = vi
+    .fn()
+    .mockResolvedValueOnce({
+      ok: true,
+      json: () => Promise.resolve({ url: 'pay' }),
+    })
+    .mockResolvedValue({ ok: true })
+  global.fetch = fetchMock as unknown as typeof fetch
+
+  const { container } = render(<ListaInscricoesPage />)
+
+  await screen.findByText('Fulano')
+  const btn = container.querySelector('button.text-green-600') as HTMLButtonElement
+  fireEvent.click(btn)
+
+  await vi.waitFor(() => {
+    expect(fetchMock).toHaveBeenCalledWith(
+      '/admin/api/asaas/',
+      expect.objectContaining({
+        body: expect.stringContaining('"paymentMethod":"pix"'),
+      })
+    )
+    expect(fetchMock).toHaveBeenCalledWith(
+      '/admin/api/asaas/',
+      expect.objectContaining({
+        body: expect.stringContaining('"installments":2'),
+      })
+    )
+  })
 })

--- a/app/admin/inscricoes/page.tsx
+++ b/app/admin/inscricoes/page.tsx
@@ -11,6 +11,7 @@ import TooltipIcon from "../components/TooltipIcon";
 import { useToast } from "@/lib/context/ToastContext";
 import { useAuthGuard } from "@/lib/hooks/useAuthGuard";
 import { logInfo } from "@/lib/logger";
+import type { PaymentMethod } from "@/lib/asaasFees";
 import type { Evento, Inscricao as InscricaoRecord, Pedido, Produto } from "@/types";
 
 const statusBadge = {
@@ -241,14 +242,19 @@ export default function ListaInscricoesPage() {
       });
 
       // 🔹 4. Gerar link de pagamento via API do Asaas
+      const insc = inscricao as InscricaoRecord & {
+        paymentMethod?: PaymentMethod;
+        installments?: number;
+      };
+
       const res = await fetch("/admin/api/asaas/", {
         method: "POST",
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify({
           pedidoId: pedido.id,
           valorBruto: pedido.valor,
-          paymentMethod: "boleto",
-          installments: 1,
+          paymentMethod: insc.paymentMethod ?? "boleto",
+          installments: insc.installments ?? 1,
         }),
       });
 


### PR DESCRIPTION
## Summary
- forward paymentMethod and installments from inscricao to payment API
- test that admin confirmation sends these values

## Testing
- `npm run lint`
- `npm run build`
- `npx vitest run __tests__/inscricoesPage.test.tsx` *(fails: No test files found)*

------
https://chatgpt.com/codex/tasks/task_e_68537836f74c832c84e992514a4b3049