### PR TITLE
Implement toast feedback in Configuracoes

### DIFF
--- a/logs/DOC_LOG.md
+++ b/logs/DOC_LOG.md
@@ -151,3 +151,4 @@
 ## [2025-06-19] Coleção `compras` removida e campo `canal` adicionado ao tipo Pedido. Impacto: simplificação dos registros de vendas.
 
 ## [2025-07-08] Pedidos agora são removidos se a integração com o Asaas falhar. README atualizado explicando que o pedido só é salvo após receber o link de pagamento. Lint e build executados.
+## [2025-06-19] Adicionada exibição de toasts ao salvar configurações. - Lint: falhou (next not found) - Build: falhou (next not found)


### PR DESCRIPTION
## Summary
- show toast success/error when saving configurações
- log manual testing

## Testing
- `npm run lint` *(fails: next not found)*
- `npm run build` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_68537ca24398832c80d003265d9fd420