### PR TITLE
Fix checkout split validation

### DIFF
--- a/lib/asaas.ts
+++ b/lib/asaas.ts
@@ -80,12 +80,16 @@ export async function createCheckout(
     params.paymentMethod,
     params.installments,
   );
-  let margin = initialMargin;
+  let margin = Number(initialMargin.toFixed(2));
 
   // Evita erro do Asaas quando o split excede o valor da cobrança
-  if (margin > gross) {
-    margin = Number(gross.toFixed(2));
+  if (margin >= gross) {
+    margin = Number((gross - 0.01).toFixed(2));
   }
+
+  console.info("✅ Parsed valorBruto:", parsedValor);
+  console.info("✅ Valor bruto calculado:", gross);
+  console.info("✅ Split calculado:", margin);
 
   const isInstallmentCredit =
     params.paymentMethod === "credito" && params.installments > 1;

--- a/lib/asaas.ts
+++ b/lib/asaas.ts
@@ -68,12 +68,24 @@ export async function createCheckout(
     params.usuarioId,
     params.inscricaoId
   );
-  const parsedValor = Number(params.valorBruto);
-  const { gross, margin } = calculateGross(
+  // Aceita valores em string com vírgula ou ponto
+  const parsedValor = Number(String(params.valorBruto).replace(/,/g, "."));
+
+  if (Number.isNaN(parsedValor)) {
+    throw new Error("valorBruto inválido");
+  }
+
+  const { gross, margin: initialMargin } = calculateGross(
     parsedValor,
     params.paymentMethod,
     params.installments,
   );
+  let margin = initialMargin;
+
+  // Evita erro do Asaas quando o split excede o valor da cobrança
+  if (margin > gross) {
+    margin = Number(gross.toFixed(2));
+  }
 
   const isInstallmentCredit =
     params.paymentMethod === "credito" && params.installments > 1;

--- a/logs/DOC_LOG.md
+++ b/logs/DOC_LOG.md
@@ -152,3 +152,4 @@
 
 ## [2025-07-08] Pedidos agora são removidos se a integração com o Asaas falhar. README atualizado explicando que o pedido só é salvo após receber o link de pagamento. Lint e build executados.
 ## [2025-06-19] Adicionada exibição de toasts ao salvar configurações. - Lint: falhou (next not found) - Build: falhou (next not found)
+## [2025-07-09] Ajustado parsing de valorBruto e validação do split em lib/asaas.ts. Lint e build executados.

--- a/logs/DOC_LOG.md
+++ b/logs/DOC_LOG.md
@@ -153,3 +153,4 @@
 ## [2025-07-08] Pedidos agora são removidos se a integração com o Asaas falhar. README atualizado explicando que o pedido só é salvo após receber o link de pagamento. Lint e build executados.
 ## [2025-06-19] Adicionada exibição de toasts ao salvar configurações. - Lint: falhou (next not found) - Build: falhou (next not found)
 ## [2025-07-09] Ajustado parsing de valorBruto e validação do split em lib/asaas.ts. Lint e build executados.
+## [2025-07-09] Registrado valorBruto, gross e split nos logs e ajustado limite do split para sempre ser inferior ao total. Lint e build executados.

--- a/logs/DOC_LOG.md
+++ b/logs/DOC_LOG.md
@@ -154,3 +154,4 @@
 ## [2025-06-19] Adicionada exibição de toasts ao salvar configurações. - Lint: falhou (next not found) - Build: falhou (next not found)
 ## [2025-07-09] Ajustado parsing de valorBruto e validação do split em lib/asaas.ts. Lint e build executados.
 ## [2025-07-09] Registrado valorBruto, gross e split nos logs e ajustado limite do split para sempre ser inferior ao total. Lint e build executados.
+## [2025-07-09] Corrigido cálculo do split na rota de checkout considerando o valor líquido pós-taxas. Lint e build executados.

--- a/logs/DOC_LOG.md
+++ b/logs/DOC_LOG.md
@@ -155,3 +155,5 @@
 ## [2025-07-09] Ajustado parsing de valorBruto e validação do split em lib/asaas.ts. Lint e build executados.
 ## [2025-07-09] Registrado valorBruto, gross e split nos logs e ajustado limite do split para sempre ser inferior ao total. Lint e build executados.
 ## [2025-07-09] Corrigido cálculo do split na rota de checkout considerando o valor líquido pós-taxas. Lint e build executados.
+
+## [2025-07-09] Ajuste automatico do split no checkout ao detectar limite informado pelo Asaas. Lint e build executados.

--- a/logs/ERR_LOG.md
+++ b/logs/ERR_LOG.md
@@ -154,3 +154,4 @@
 ## [2025-06-19] Erro ao atualizar configuracoes: ClientResponseError 400: Failed to update record. - development
 ## [2025-07-09] Erro no checkout: {"errors":[{"code":"invalid_object","description":"O valor total do Split excede o valor a receber"}]} - development
 
+## [2025-07-09] Resolvido erro de Split no checkout ajustando o valor automaticamente quando a API retorna o limite. Commit: 4285c3777ccd95b6024d424a54fe5528118646a4

--- a/logs/ERR_LOG.md
+++ b/logs/ERR_LOG.md
@@ -152,4 +152,5 @@
 
 ## [2025-06-18] Erro no checkout: Error: {"errors":[{"code":"invalid_object","description":"O campo successUrl é inválido."},{"code":"invalid_object","description":"O campo cancelUrl é inválido."},{"code":"invalid_object","description":"O campo expiredUrl é inválido."}]} - development
 ## [2025-06-19] Erro ao atualizar configuracoes: ClientResponseError 400: Failed to update record. - development
+## [2025-07-09] Erro no checkout: {"errors":[{"code":"invalid_object","description":"O valor total do Split excede o valor a receber"}]} - development
 


### PR DESCRIPTION
## Summary
- sanitize valorBruto to allow comma-separated strings
- ensure split amount never exceeds charge value
- log update for docs

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_685441fffa4c832caafddd2b70c9a5b7