### PR TITLE
Fix redirect state on empty cart checkout

### DIFF
--- a/app/loja/checkout/page.tsx
+++ b/app/loja/checkout/page.tsx
@@ -248,6 +248,15 @@ function CheckoutContent() {
   };
 
   if (itens.length === 0) {
+    if (redirecting) {
+      return (
+        <LoadingOverlay
+          show
+          text="Encaminhando para a área de pagamento..."
+        />
+      );
+    }
+
     return (
       <main className="flex flex-col items-center justify-center min-h-[60vh]">
         <h1 className="text-2xl font-semibold mb-4 tracking-tight">


### PR DESCRIPTION
## Summary
- show loading overlay when checkout is redirecting and cart is empty

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6854533c0f9c832c9023bc84591592d1