### PR TITLE
Update event edit image handling

### DIFF
--- a/app/admin/api/eventos/[id]/route.ts
+++ b/app/admin/api/eventos/[id]/route.ts
@@ -15,7 +15,9 @@ export async function GET(req: NextRequest) {
     const evento = await pb.collection("eventos").getOne(id, {
       expand: "produtos",
     });
-    return NextResponse.json(evento, { status: 200 });
+    const imagemUrl =
+      evento.imagem ? pb.files.getURL(evento, evento.imagem) : undefined;
+    return NextResponse.json({ ...evento, imagemUrl }, { status: 200 });
   } catch (err) {
     await logConciliacaoErro(`Erro ao obter evento: ${String(err)}`);
     return NextResponse.json({ error: "Erro ao obter" }, { status: 500 });

--- a/app/admin/eventos/editar/[id]/page.tsx
+++ b/app/admin/eventos/editar/[id]/page.tsx
@@ -59,7 +59,7 @@ export default function EditarEventoPage() {
           cidade: data.cidade,
           status: data.status,
         });
-        setExistingImage(data.imagem || null);
+        setExistingImage(data.imagemUrl || null);
         setCobraInscricao(Boolean(data.cobra_inscricao));
         const arr = Array.isArray(data.produtos)
           ? (data.produtos as string[])
@@ -150,8 +150,6 @@ export default function EditarEventoPage() {
     formData.delete("imagem");
     if (files && files.length > 0) {
       formData.append("imagem", files[0]);
-    } else if (existingImage) {
-      formData.append("imagem", existingImage);
     }
     formData.delete("produtos");
     selectedProdutos.forEach((p) => formData.append("produtos", p));
@@ -222,6 +220,13 @@ export default function EditarEventoPage() {
             accept="image/*"
             className="input-base"
           />
+          {existingImage && (
+            <img
+              src={existingImage}
+              alt="Imagem atual"
+              className="w-full max-h-56 object-cover"
+            />
+          )}
           <select
             name="status"
             defaultValue={String(initial.status)}


### PR DESCRIPTION
## Summary
- include imagemUrl when fetching an evento
- show existing image preview in admin edit
- only submit new image file when selected

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68545935bef8832c867de3e9f80cb5f5