### PR TITLE
fix: ajustar tipos de props nas páginas

### DIFF
--- a/app/loja/categorias/[slug]/page.tsx
+++ b/app/loja/categorias/[slug]/page.tsx
@@ -19,9 +19,9 @@ interface Params {
 export default async function CategoriaDetalhe({
   params,
 }: {
-  params: Params;
+  params: Promise<Params>;
 }) {
-  const { slug } = params;
+  const { slug } = await params;
   const pb = createPocketBase();
   const tenantId = await getTenantFromHost();
 

--- a/app/loja/checkout/page.tsx
+++ b/app/loja/checkout/page.tsx
@@ -15,7 +15,7 @@ import {
 } from "@/lib/constants";
 import { useMemo } from "react";
 import createPocketBase from "@/lib/pocketbase";
-import type { Pedido } from "@/types";
+import type { Pedido, Produto } from "@/types";
 
 function formatCurrency(n: number) {
   return `R$ ${n.toFixed(2).replace(".", ",")}`;

--- a/app/loja/eventos/[id]/page.tsx
+++ b/app/loja/eventos/[id]/page.tsx
@@ -28,9 +28,9 @@ async function getEvento(id: string): Promise<Evento | null> {
 export default async function EventoDetalhePage({
   params,
 }: {
-  params: { id: string };
+  params: Promise<{ id: string }>;
 }) {
-  const { id } = params;
+  const { id } = await params;
   const evento = await getEvento(id);
 
   if (!evento) {


### PR DESCRIPTION
## Summary
- corrigir tipagem para `PageProps` nas páginas de categoria e evento
- importar tipo `Produto` em checkout

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6854636bd134832ca6c995cca38c3227