### PR TITLE
Refactor AppConfigProvider to TenantProvider

### DIFF
--- a/.storybook/preview.tsx
+++ b/.storybook/preview.tsx
@@ -1,14 +1,14 @@
 import '../app/globals.css';
-import { AppConfigProvider } from '../lib/context/AppConfigContext';
+import { TenantProvider } from '../lib/context/TenantContext';
 
 import type { Preview } from '@storybook/nextjs'
 
 const preview: Preview = {
   decorators: [
     (Story) => (
-      <AppConfigProvider>
+      <TenantProvider>
         <Story />
-      </AppConfigProvider>
+      </TenantProvider>
     ),
   ],
   parameters: {

--- a/__tests__/InscricaoPage.test.tsx
+++ b/__tests__/InscricaoPage.test.tsx
@@ -8,8 +8,8 @@ vi.mock('next/navigation', () => ({
   useParams: () => ({ liderId: 'lid1', eventoId: 'ev1' })
 }));
 
-vi.mock('@/lib/context/AppConfigContext', () => ({
-  useAppConfig: () => ({ config: { confirmaInscricoes: true } }),
+vi.mock('@/lib/context/TenantContext', () => ({
+  useTenant: () => ({ config: { confirmaInscricoes: true } }),
 }));
 
 describe('InscricaoPage', () => {

--- a/__tests__/appConfigSSR.test.ts
+++ b/__tests__/appConfigSSR.test.ts
@@ -1,14 +1,14 @@
 import * as React from 'react'
 import { describe, it, expect } from 'vitest'
 import { renderToString } from 'react-dom/server'
-import { AppConfigProvider } from '../lib/context/AppConfigContext'
+import { TenantProvider } from '../lib/context/TenantContext'
 
-describe('AppConfigProvider SSR', () => {
+describe('TenantProvider SSR', () => {
   it('renders without crashing in a server environment', () => {
     const render = () =>
       renderToString(
         React.createElement(
-          AppConfigProvider,
+          TenantProvider,
           null,
           React.createElement('div', null, 'SSR')
         )

--- a/__tests__/headerLinks.test.tsx
+++ b/__tests__/headerLinks.test.tsx
@@ -25,8 +25,8 @@ vi.mock('@/lib/context/ThemeContext', () => ({
   useTheme: () => ({ theme: 'light', toggleTheme: vi.fn() }),
 }));
 
-vi.mock('@/lib/context/AppConfigContext', () => ({
-  useAppConfig: () => ({
+vi.mock('@/lib/context/TenantContext', () => ({
+  useTenant: () => ({
     config: { logoUrl: '', font: '', primaryColor: '', confirmaInscricoes: true },
   }),
 }));

--- a/app/admin/components/Header.tsx
+++ b/app/admin/components/Header.tsx
@@ -20,7 +20,7 @@ import {
 import * as Popover from "@radix-ui/react-popover";
 import { motion, AnimatePresence } from "framer-motion";
 import { useTheme } from "@/lib/context/ThemeContext";
-import { useAppConfig } from "@/lib/context/AppConfigContext";
+import { useTenant } from "@/lib/context/TenantContext";
 import RedefinirSenhaModal from "./RedefinirSenhaModal";
 
 const getNavLinks = (role?: string) => {
@@ -48,7 +48,7 @@ export default function Header() {
   const [gerenciamentoAberto, setGerenciamentoAberto] = useState(false);
   const [mostrarModalSenha, setMostrarModalSenha] = useState(false);
   const { theme, toggleTheme } = useTheme();
-  const { config } = useAppConfig();
+  const { config } = useTenant();
 
   const navLinks = getNavLinks(user?.role);
 

--- a/app/admin/configuracoes/page.tsx
+++ b/app/admin/configuracoes/page.tsx
@@ -1,6 +1,6 @@
 "use client";
 import { useState, useRef, ChangeEvent, useCallback } from "react";
-import { useAppConfig } from "@/lib/context/AppConfigContext";
+import { useTenant } from "@/lib/context/TenantContext";
 import { useAuthContext } from "@/lib/context/AuthContext";
 import { useToast } from "@/lib/context/ToastContext";
 import Image from "next/image";
@@ -74,7 +74,7 @@ const fontes = [
 ];
 
 export default function ConfiguracoesPage() {
-  const { config, updateConfig } = useAppConfig();
+  const { config, updateConfig } = useTenant();
   const { user: ctxUser } = useAuthContext();
   const { showSuccess, showError } = useToast();
   const getAuth = useCallback(() => {

--- a/app/components/Header.tsx
+++ b/app/components/Header.tsx
@@ -7,7 +7,7 @@ import CartButton from "./CartButton";
 import Link from "next/link";
 import Image from "next/image";
 import { useAuthContext } from "@/lib/context/AuthContext";
-import { useAppConfig } from "@/lib/context/AppConfigContext";
+import { useTenant } from "@/lib/context/TenantContext";
 
 type UserRole = "visitante" | "usuario" | "lider" | "coordenador";
 
@@ -23,7 +23,7 @@ export default function Header() {
   const [adminOpen, setAdminOpen] = useState(false);
   const [clientOpen, setClientOpen] = useState(false);
   const { user, isLoggedIn, logout } = useAuthContext();
-  const { config } = useAppConfig();
+  const { config } = useTenant();
   const adminMenuRef = useRef<HTMLUListElement>(null);
   const clientMenuRef = useRef<HTMLUListElement>(null);
 

--- a/app/inscricoes/[liderId]/[eventoId]/page.tsx
+++ b/app/inscricoes/[liderId]/[eventoId]/page.tsx
@@ -6,7 +6,7 @@ import Link from "next/link";
 import { logInfo } from "@/lib/logger";
 import { useToast } from "@/lib/context/ToastContext";
 import { calculateGross, type PaymentMethod } from "@/lib/asaasFees";
-import { useAppConfig } from "@/lib/context/AppConfigContext";
+import { useTenant } from "@/lib/context/TenantContext";
 import Spinner from "@/components/Spinner";
 import { Check } from "lucide-react";
 
@@ -41,7 +41,7 @@ export default function InscricaoPage() {
   const eventoId = params.eventoId as string;
 
   const { showError, showSuccess } = useToast();
-  const { config } = useAppConfig();
+  const { config } = useTenant();
 
   const [produtos, setProdutos] = useState<Produto[]>([]);
 

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -3,7 +3,7 @@ import "./globals.css";
 import { AuthProvider } from "@/lib/context/AuthContext";
 import { ThemeProvider } from "@/lib/context/ThemeContext";
 import { ToastProvider } from "@/lib/context/ToastContext";
-import { AppConfigProvider } from "@/lib/context/AppConfigContext";
+import { TenantProvider } from "@/lib/context/TenantContext";
 import { CartProvider } from "@/lib/context/CartContext";
 
 export const metadata = {
@@ -28,7 +28,7 @@ export default function RootLayout({
   return (
     <html lang="pt-BR">
       <body className="font-sans antialiased">
-        <AppConfigProvider>
+        <TenantProvider>
           <ThemeProvider>
             <AuthProvider>
               <CartProvider>
@@ -36,7 +36,7 @@ export default function RootLayout({
               </CartProvider>
             </AuthProvider>
           </ThemeProvider>
-        </AppConfigProvider>
+        </TenantProvider>
       </body>
     </html>
   );

--- a/docs/design-system.md
+++ b/docs/design-system.md
@@ -186,7 +186,7 @@ Execute `npm run storybook` para iniciar a interface e validar os componentes. Q
 
 ## Personalização
 
-O portal permite ajustar fonte, cor primária e logotipo dinamicamente. As configurações são gerenciadas pelo `AppConfigProvider` (`lib/context/AppConfigContext.tsx`).
+O portal permite ajustar fonte, cor primária e logotipo dinamicamente. As configurações são gerenciadas pelo `TenantProvider` (`lib/context/TenantContext.tsx`).
 Ao montar, o provedor executa a seguinte sequência:
 
 1. tenta ler as configurações armazenadas no `localStorage`. Se existirem e ainda estiverem válidas, elas são usadas diretamente;
@@ -197,4 +197,4 @@ Quando `updateConfig` é chamado, os dados são enviados para essa mesma rota e 
 
 As personalizações são persistidas nos campos `logo_url`, `cor_primary`, `font` e `confirma_inscricoes` da coleção `clientes_config`, evitando perda de dados entre dispositivos.
 
-Além de definir `--accent`, o provedor gera uma paleta HSL e expõe as variáveis `--primary-50` … `--primary-900`. Essas variáveis são mapeadas para classes Tailwind (`bg-primary-*`, `text-primary-*`), eliminando a necessidade de usar `bg-[var(--primary-600)]` ou `text-[var(--primary-500)]`.
+Além de definir `--accent` e `--logo-url`, o provedor gera uma paleta HSL e expõe as variáveis `--primary-50` … `--primary-900`. Essas variáveis são mapeadas para classes Tailwind (`bg-primary-*`, `text-primary-*`), eliminando a necessidade de usar `bg-[var(--primary-600)]` ou `text-[var(--primary-500)]`.

--- a/lib/context/TenantContext.tsx
+++ b/lib/context/TenantContext.tsx
@@ -6,32 +6,32 @@ import createPocketBase from "@/lib/pocketbase";
 
 const STALE_TIME = 1000 * 60 * 60; // 1 hour
 
-export type AppConfig = {
+export type TenantConfig = {
   font: string;
   primaryColor: string;
   logoUrl: string;
   confirmaInscricoes: boolean;
 };
 
-const defaultConfig: AppConfig = {
+const defaultConfig: TenantConfig = {
   font: "var(--font-geist)",
   primaryColor: "#7c3aed",
   logoUrl: "/img/logo_umadeus_branco.png",
   confirmaInscricoes: false,
 };
 
-type AppConfigContextType = {
-  config: AppConfig;
-  updateConfig: (cfg: Partial<AppConfig>) => void;
+type TenantContextType = {
+  config: TenantConfig;
+  updateConfig: (cfg: Partial<TenantConfig>) => void;
 };
 
-const AppConfigContext = createContext<AppConfigContextType>({
+const TenantContext = createContext<TenantContextType>({
   config: defaultConfig,
   updateConfig: () => {},
 });
 
-export function AppConfigProvider({ children }: { children: React.ReactNode }) {
-  const [config, setConfig] = useState<AppConfig>(defaultConfig);
+export function TenantProvider({ children }: { children: React.ReactNode }) {
+  const [config, setConfig] = useState<TenantConfig>(defaultConfig);
   const [configId, setConfigId] = useState<string | null>(null);
 
   useEffect(() => {
@@ -47,7 +47,7 @@ export function AppConfigProvider({ children }: { children: React.ReactNode }) {
             const cliente = await pb
               .collection("clientes_config")
               .getFirstListItem(`cliente='${tenantId}'`);
-            const cfg: AppConfig = {
+            const cfg: TenantConfig = {
               font: cliente.font || defaultConfig.font,
               primaryColor: cliente.cor_primary || defaultConfig.primaryColor,
               logoUrl: cliente.logo_url || defaultConfig.logoUrl,
@@ -94,7 +94,7 @@ export function AppConfigProvider({ children }: { children: React.ReactNode }) {
               const cliente = await pb
                 .collection("clientes_config")
                 .getFirstListItem(`cliente='${tenantId}'`);
-              const cfg: AppConfig = {
+              const cfg: TenantConfig = {
                 font: cliente.font || defaultConfig.font,
                 primaryColor: cliente.cor_primary || defaultConfig.primaryColor,
                 logoUrl: cliente.logo_url || defaultConfig.logoUrl,
@@ -171,6 +171,7 @@ export function AppConfigProvider({ children }: { children: React.ReactNode }) {
     localStorage.setItem("app_config_time", Date.now().toString());
     document.documentElement.style.setProperty("--font-body", config.font);
     document.documentElement.style.setProperty("--font-heading", config.font);
+    document.documentElement.style.setProperty("--logo-url", config.logoUrl);
     document.documentElement.style.setProperty("--accent", config.primaryColor);
     const shades = generatePrimaryShades(config.primaryColor);
     document.documentElement.style.setProperty("--accent-900", shades["900"]);
@@ -179,7 +180,7 @@ export function AppConfigProvider({ children }: { children: React.ReactNode }) {
     });
   }, [config]);
 
-  const updateConfig = (cfg: Partial<AppConfig>) => {
+  const updateConfig = (cfg: Partial<TenantConfig>) => {
     const newCfg = { ...config, ...cfg };
     setConfig(newCfg);
 
@@ -207,12 +208,12 @@ export function AppConfigProvider({ children }: { children: React.ReactNode }) {
   };
 
   return (
-    <AppConfigContext.Provider value={{ config, updateConfig }}>
+    <TenantContext.Provider value={{ config, updateConfig }}>
       {children}
-    </AppConfigContext.Provider>
+    </TenantContext.Provider>
   );
 }
 
-export function useAppConfig() {
-  return useContext(AppConfigContext);
+export function useTenant() {
+  return useContext(TenantContext);
 }

--- a/logs/DOC_LOG.md
+++ b/logs/DOC_LOG.md
@@ -165,3 +165,4 @@
 ## [2025-06-20] Inventário de componentes adicionado em docs/components_inventory.yaml. - Lint: falhou (next not found) - Build: falhou (next not found)
 ## [2025-06-20] Criado components_analysis.yaml listando duplicacoes e lacunas no design system.
 ## [2025-06-20] Componentes base Button, TextField, FormField e InputWithMask criados. ModalProduto passou a usar Button e TextField. Lint e build executados.
+## [2025-06-21] AppConfigProvider renomeado para TenantProvider com variável `--logo-url`. Design system atualizado. - Lint: falhou (next not found) - Build: falhou (next not found)


### PR DESCRIPTION
## Summary
- rename `AppConfigContext.tsx` to `TenantContext.tsx`
- expose CSS variable `--logo-url` alongside primary shades
- update all imports to use `TenantProvider` and `useTenant`
- adjust Storybook and tests for the new context
- document TenantProvider usage
- log documentation update

## Testing
- `npm run lint` *(fails: next not found)*
- `npm run build` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_68557dadd570832cb68a1b4338528ee3