### PR TITLE
Add dynamic theme stories

### DIFF
--- a/stories/FormField.stories.tsx
+++ b/stories/FormField.stories.tsx
@@ -1,0 +1,39 @@
+import type { Meta, StoryObj } from '@storybook/nextjs';
+import { FormField } from '../components/molecules/FormField';
+import { TextField } from '../components/atoms/TextField';
+import { TenantProvider } from '../lib/context/TenantContext';
+
+const meta = {
+  title: 'Design System/FormField',
+  component: FormField,
+  tags: ['autodocs'],
+  args: { label: 'Nome', htmlFor: 'nome' },
+} satisfies Meta<typeof FormField>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {
+  render: (args) => (
+    <FormField {...args}>
+      <TextField id="nome" />
+    </FormField>
+  ),
+};
+
+export const TemaDinamico: Story = {
+  render: (args) => (
+    <div className="space-y-4">
+      <TenantProvider initialConfig={{ primaryColor: '#2563eb', font: 'var(--font-geist)', logoUrl: '/img/logo_umadeus_branco.png', confirmaInscricoes: false }}>
+        <FormField {...args}>
+          <TextField id="nome1" />
+        </FormField>
+      </TenantProvider>
+      <TenantProvider initialConfig={{ primaryColor: '#dc2626', font: 'var(--font-geist)', logoUrl: '/img/logo_umadeus_branco.png', confirmaInscricoes: false }}>
+        <FormField {...args}>
+          <TextField id="nome2" />
+        </FormField>
+      </TenantProvider>
+    </div>
+  ),
+};

--- a/stories/InputWithMask.stories.tsx
+++ b/stories/InputWithMask.stories.tsx
@@ -1,0 +1,44 @@
+import type { Meta, StoryObj } from '@storybook/nextjs';
+import { useState } from 'react';
+import { InputWithMask } from '../components/molecules/InputWithMask';
+import { TenantProvider } from '../lib/context/TenantContext';
+
+const meta = {
+  title: 'Design System/InputWithMask',
+  component: InputWithMask,
+  tags: ['autodocs'],
+  args: { mask: 'cpf' },
+} satisfies Meta<typeof InputWithMask>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const CPF: Story = {
+  args: { mask: 'cpf' },
+  render: (args) => {
+    const [value, setValue] = useState('');
+    return <InputWithMask {...args} value={value} onChange={(e) => setValue(e.target.value)} />;
+  },
+};
+
+export const Telefone: Story = {
+  args: { mask: 'telefone' },
+  render: (args) => {
+    const [value, setValue] = useState('');
+    return <InputWithMask {...args} value={value} onChange={(e) => setValue(e.target.value)} />;
+  },
+};
+
+export const TemaDinamico: Story = {
+  args: { mask: 'cpf' },
+  render: (args) => (
+    <div className="space-y-4">
+      <TenantProvider initialConfig={{ primaryColor: '#2563eb', font: 'var(--font-geist)', logoUrl: '/img/logo_umadeus_branco.png', confirmaInscricoes: false }}>
+        <InputWithMask {...args} />
+      </TenantProvider>
+      <TenantProvider initialConfig={{ primaryColor: '#dc2626', font: 'var(--font-geist)', logoUrl: '/img/logo_umadeus_branco.png', confirmaInscricoes: false }}>
+        <InputWithMask {...args} />
+      </TenantProvider>
+    </div>
+  ),
+};

--- a/stories/TextField.stories.tsx
+++ b/stories/TextField.stories.tsx
@@ -1,0 +1,28 @@
+import type { Meta, StoryObj } from '@storybook/nextjs';
+import { TextField } from '../components/atoms/TextField';
+import { TenantProvider } from '../lib/context/TenantContext';
+
+const meta = {
+  title: 'Design System/TextField',
+  component: TextField,
+  tags: ['autodocs'],
+  args: { placeholder: 'Digite aqui' },
+} satisfies Meta<typeof TextField>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {};
+
+export const TemaDinamico: Story = {
+  render: (args) => (
+    <div className="space-y-4">
+      <TenantProvider initialConfig={{ primaryColor: '#2563eb', font: 'var(--font-geist)', logoUrl: '/img/logo_umadeus_branco.png', confirmaInscricoes: false }}>
+        <TextField {...args} />
+      </TenantProvider>
+      <TenantProvider initialConfig={{ primaryColor: '#dc2626', font: 'var(--font-geist)', logoUrl: '/img/logo_umadeus_branco.png', confirmaInscricoes: false }}>
+        <TextField {...args} />
+      </TenantProvider>
+    </div>
+  ),
+};

--- a/stories/ToggleSwitch.stories.tsx
+++ b/stories/ToggleSwitch.stories.tsx
@@ -1,0 +1,34 @@
+import type { Meta, StoryObj } from '@storybook/nextjs';
+import { useState } from 'react';
+import ToggleSwitch from '../components/ToggleSwitch';
+import { TenantProvider } from '../lib/context/TenantContext';
+
+const meta = {
+  title: 'Design System/ToggleSwitch',
+  component: ToggleSwitch,
+  tags: ['autodocs'],
+  args: { checked: false, label: 'Ativo' },
+} satisfies Meta<typeof ToggleSwitch>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {
+  render: (args) => {
+    const [checked, setChecked] = useState(args.checked);
+    return <ToggleSwitch {...args} checked={checked} onChange={setChecked} />;
+  },
+};
+
+export const TemaDinamico: Story = {
+  render: (args) => (
+    <div className="space-y-4">
+      <TenantProvider initialConfig={{ primaryColor: '#2563eb', font: 'var(--font-geist)', logoUrl: '/img/logo_umadeus_branco.png', confirmaInscricoes: false }}>
+        <ToggleSwitch {...args} onChange={() => {}} />
+      </TenantProvider>
+      <TenantProvider initialConfig={{ primaryColor: '#dc2626', font: 'var(--font-geist)', logoUrl: '/img/logo_umadeus_branco.png', confirmaInscricoes: false }}>
+        <ToggleSwitch {...args} onChange={() => {}} />
+      </TenantProvider>
+    </div>
+  ),
+};


### PR DESCRIPTION
## Summary
- add missing stories for FormField, InputWithMask, TextField and ToggleSwitch
- include `TemaDinamico` examples showing tenant variations

## Testing
- `npm run lint` *(fails: next not found)*
- `npm run build` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_685584f7bfc0832cb7c115840c70cba2