### PR TITLE
Fix color check on ConfiguracoesPage

### DIFF
--- a/app/admin/configuracoes/page.tsx
+++ b/app/admin/configuracoes/page.tsx
@@ -50,7 +50,8 @@ function isBlockedColor(hex: string) {
 }
 
 // Checa se cor é clara, para ajuste de texto no botão
-function isColorLight(hex: string) {
+function isColorLight(hex?: string) {
+  if (!hex) return false;
   const c = hex.replace("#", "");
   let r = 0,
     g = 0,

--- a/logs/ERR_LOG.md
+++ b/logs/ERR_LOG.md
@@ -156,3 +156,4 @@
 
 ## [2025-07-09] Resolvido erro de Split no checkout ajustando o valor automaticamente quando a API retorna o limite. Commit: 4285c3777ccd95b6024d424a54fe5528118646a4
 ## [2025-07-11] Corrigida tipagem da página de post do blog que quebrava build - dev - 82aa56e
+## [2025-06-20] Corrigido erro 'Cannot read properties of undefined (reading 'replace')' em ConfiguracoesPage ajustando funcao isColorLight - dev - 3d07f5f


### PR DESCRIPTION
## Summary
- prevent crash when color is undefined in `isColorLight`
- log the fix in `ERR_LOG.md`

## Testing
- `npm run lint`
- `npm run build` *(fails: File '/workspace/admin-panel-umadeus/components/templates/index.ts' is not a module)*

------
https://chatgpt.com/codex/tasks/task_e_68558a555fa8832caafd72649a79df83