### PR TITLE
Replace form inputs with FormField components

### DIFF
--- a/app/admin/perfil/components/ModalEditarPerfil.tsx
+++ b/app/admin/perfil/components/ModalEditarPerfil.tsx
@@ -6,6 +6,7 @@ import * as Dialog from '@radix-ui/react-dialog'
 import { useAuthContext } from '@/lib/context/AuthContext'
 import createPocketBase from '@/lib/pocketbase'
 import { useToast } from '@/lib/context/ToastContext'
+import { FormField, TextField, InputWithMask } from '@/components'
 
 export default function ModalEditarPerfil({
   onClose,
@@ -85,89 +86,119 @@ export default function ModalEditarPerfil({
                     </h3>
                   </Dialog.Title>
 
-                  <input
-                    type="text"
-                    placeholder="Nome completo"
-                    className={inputStyle}
-                    value={String(nome)}
-                    onChange={(e) => setNome(e.target.value)}
-                  />
+                  <FormField label="Nome completo" htmlFor="perfil-nome">
+                    <TextField
+                      id="perfil-nome"
+                      type="text"
+                      placeholder="Nome completo"
+                      className={inputStyle}
+                      value={String(nome)}
+                      onChange={(e) => setNome(e.target.value)}
+                    />
+                  </FormField>
 
-                  <input
-                    type="text"
-                    placeholder="Telefone"
-                    className={inputStyle}
-                    value={String(telefone)}
-                    onChange={(e) => setTelefone(e.target.value)}
-                  />
+                  <FormField label="Telefone" htmlFor="perfil-telefone">
+                    <InputWithMask
+                      id="perfil-telefone"
+                      type="text"
+                      mask="telefone"
+                      placeholder="Telefone"
+                      className={inputStyle}
+                      value={String(telefone)}
+                      onChange={(e) => setTelefone(e.target.value)}
+                    />
+                  </FormField>
 
-                  <input
-                    type="text"
-                    placeholder="CPF"
-                    className={inputStyle}
-                    value={String(cpf)}
-                    onChange={(e) => setCpf(e.target.value)}
-                  />
+                  <FormField label="CPF" htmlFor="perfil-cpf">
+                    <InputWithMask
+                      id="perfil-cpf"
+                      type="text"
+                      mask="cpf"
+                      placeholder="CPF"
+                      className={inputStyle}
+                      value={String(cpf)}
+                      onChange={(e) => setCpf(e.target.value)}
+                    />
+                  </FormField>
 
-                  <input
-                    type="date"
-                    className={inputStyle}
-                    value={String(dataNascimento)}
-                    onChange={(e) => setDataNascimento(e.target.value)}
-                  />
+                  <FormField label="Data de nascimento" htmlFor="perfil-data">
+                    <TextField
+                      id="perfil-data"
+                      type="date"
+                      className={inputStyle}
+                      value={String(dataNascimento)}
+                      onChange={(e) => setDataNascimento(e.target.value)}
+                    />
+                  </FormField>
 
-                  <input
-                    type="text"
-                    placeholder="Endereço"
-                    className={inputStyle}
-                    value={String(endereco)}
-                    onChange={(e) => setEndereco(e.target.value)}
-                  />
+                  <FormField label="Endereço" htmlFor="perfil-endereco">
+                    <TextField
+                      id="perfil-endereco"
+                      type="text"
+                      placeholder="Endereço"
+                      className={inputStyle}
+                      value={String(endereco)}
+                      onChange={(e) => setEndereco(e.target.value)}
+                    />
+                  </FormField>
 
-                  <input
-                    type="text"
-                    placeholder="Número"
-                    className={inputStyle}
-                    value={String(numero)}
-                    onChange={(e) => setNumero(e.target.value)}
-                  />
+                  <FormField label="Número" htmlFor="perfil-numero">
+                    <TextField
+                      id="perfil-numero"
+                      type="text"
+                      placeholder="Número"
+                      className={inputStyle}
+                      value={String(numero)}
+                      onChange={(e) => setNumero(e.target.value)}
+                    />
+                  </FormField>
 
-                  <input
-                    type="text"
-                    placeholder="Estado"
-                    className={inputStyle}
-                    value={String(estado)}
-                    onChange={(e) => setEstado(e.target.value)}
-                  />
+                  <FormField label="Estado" htmlFor="perfil-estado">
+                    <TextField
+                      id="perfil-estado"
+                      type="text"
+                      placeholder="Estado"
+                      className={inputStyle}
+                      value={String(estado)}
+                      onChange={(e) => setEstado(e.target.value)}
+                    />
+                  </FormField>
 
-                  <input
-                    type="text"
-                    placeholder="CEP"
-                    className={inputStyle}
-                    value={String(cep)}
-                    onChange={(e) => setCep(e.target.value)}
-                  />
+                  <FormField label="CEP" htmlFor="perfil-cep">
+                    <TextField
+                      id="perfil-cep"
+                      type="text"
+                      placeholder="CEP"
+                      className={inputStyle}
+                      value={String(cep)}
+                      onChange={(e) => setCep(e.target.value)}
+                    />
+                  </FormField>
 
-                  <input
-                    type="text"
-                    placeholder="Cidade"
-                    className={inputStyle}
-                    value={String(cidade)}
-                    onChange={(e) => setCidade(e.target.value)}
-                  />
+                  <FormField label="Cidade" htmlFor="perfil-cidade">
+                    <TextField
+                      id="perfil-cidade"
+                      type="text"
+                      placeholder="Cidade"
+                      className={inputStyle}
+                      value={String(cidade)}
+                      onChange={(e) => setCidade(e.target.value)}
+                    />
+                  </FormField>
 
-                  <div>
-                    <input
+                  <FormField label="E-mail" htmlFor="perfil-email" className="opacity-60">
+                    <TextField
+                      id="perfil-email"
                       type="email"
                       disabled
                       value={String(user?.email || '')}
-                      className={`${inputStyle} opacity-60 cursor-not-allowed`}
+                      className={`${inputStyle} cursor-not-allowed`}
                     />
                     <p className="text-xs text-zinc-500 dark:text-zinc-400 mt-1">
                       O e-mail não pode ser alterado. Para mudanças, entre em
                       contato com o suporte.
                     </p>
-                  </div>
+                  </FormField>
 
                   <div className="flex justify-end gap-2 pt-2">
                     <button

--- a/app/components/SignUpForm.tsx
+++ b/app/components/SignUpForm.tsx
@@ -6,6 +6,7 @@ import { useToast } from '@/lib/context/ToastContext'
 import type { ClientResponseError } from 'pocketbase'
 import createPocketBase from '@/lib/pocketbase' // ajuste para seu caminho real
 import Spinner from '@/components/atoms/Spinner'
+import { FormField, TextField, InputWithMask } from '@/components'
 
 const VIA_CEP_URL =
   process.env.NEXT_PUBLIC_VIA_CEP_URL || 'https://viacep.com.br/ws'
@@ -142,45 +143,62 @@ export default function SignUpForm({
           </h2>
 
           <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
-            <input
-              type="text"
-              placeholder="Nome completo"
-              value={nome}
-              onChange={(e) => setNome(e.target.value)}
-              className="input-base w-full rounded-md px-4 py-2"
-              required
-            />
-            <input
-              type="email"
-              placeholder="E-mail"
-              value={email}
-              onChange={(e) => setEmail(e.target.value)}
-              className="input-base w-full rounded-md px-4 py-2"
-              required
-            />
-            <input
-              type="text"
-              placeholder="Telefone"
-              value={telefone}
-              onChange={(e) => setTelefone(e.target.value)}
-              className="input-base w-full rounded-md px-4 py-2"
-              required
-            />
-            <input
-              type="text"
-              placeholder="CPF"
-              value={cpf}
-              onChange={(e) => setCpf(e.target.value)}
-              className="input-base w-full rounded-md px-4 py-2"
-              required
-            />
-            <input
-              type="date"
-              value={dataNascimento}
-              onChange={(e) => setDataNascimento(e.target.value)}
-              className="input-base w-full rounded-md px-4 py-2"
-              required
-            />
+            <FormField label="Nome completo" htmlFor="signup-nome">
+              <TextField
+                id="signup-nome"
+                type="text"
+                placeholder="Nome completo"
+                value={nome}
+                onChange={(e) => setNome(e.target.value)}
+                className="w-full rounded-md px-4 py-2"
+                required
+              />
+            </FormField>
+            <FormField label="E-mail" htmlFor="signup-email">
+              <TextField
+                id="signup-email"
+                type="email"
+                placeholder="E-mail"
+                value={email}
+                onChange={(e) => setEmail(e.target.value)}
+                className="w-full rounded-md px-4 py-2"
+                required
+              />
+            </FormField>
+            <FormField label="Telefone" htmlFor="signup-telefone">
+              <InputWithMask
+                id="signup-telefone"
+                type="text"
+                mask="telefone"
+                placeholder="Telefone"
+                value={telefone}
+                onChange={(e) => setTelefone(e.target.value)}
+                className="w-full rounded-md px-4 py-2"
+                required
+              />
+            </FormField>
+            <FormField label="CPF" htmlFor="signup-cpf">
+              <InputWithMask
+                id="signup-cpf"
+                type="text"
+                mask="cpf"
+                placeholder="CPF"
+                value={cpf}
+                onChange={(e) => setCpf(e.target.value)}
+                className="w-full rounded-md px-4 py-2"
+                required
+              />
+            </FormField>
+            <FormField label="Data de nascimento" htmlFor="signup-data">
+              <TextField
+                id="signup-data"
+                type="date"
+                value={dataNascimento}
+                onChange={(e) => setDataNascimento(e.target.value)}
+                className="w-full rounded-md px-4 py-2"
+                required
+              />
+            </FormField>
             <select
               value={campo}
               onChange={(e) => setCampo(e.target.value)}
@@ -194,65 +212,86 @@ export default function SignUpForm({
                 </option>
               ))}
             </select>
-            <input
-              type="text"
-              placeholder="CEP"
-              value={cep}
-              onChange={(e) => setCep(e.target.value)}
-              className="input-base w-full rounded-md px-4 py-2"
-              required
-            />
-            <input
-              type="text"
-              placeholder="Endereço"
-              value={endereco}
-              onChange={(e) => setEndereco(e.target.value)}
-              className="input-base w-full rounded-md px-4 py-2"
-              required
-            />
-            <input
-              type="text"
-              placeholder="Número"
-              value={numero}
-              onChange={(e) => setNumero(e.target.value)}
-              className="input-base w-full rounded-md px-4 py-2"
-              required
-            />
-            <input
-              type="text"
-              placeholder="Cidade"
-              value={cidade}
-              onChange={(e) => setCidade(e.target.value)}
-              className="input-base w-full rounded-md px-4 py-2"
-              required
-            />
-            <input
-              type="text"
-              placeholder="Estado"
-              value={estado}
-              onChange={(e) => setEstado(e.target.value)}
-              className="input-base w-full rounded-md px-4 py-2"
-              required
-            />
+            <FormField label="CEP" htmlFor="signup-cep">
+              <TextField
+                id="signup-cep"
+                type="text"
+                placeholder="CEP"
+                value={cep}
+                onChange={(e) => setCep(e.target.value)}
+                className="w-full rounded-md px-4 py-2"
+                required
+              />
+            </FormField>
+            <FormField label="Endereço" htmlFor="signup-endereco">
+              <TextField
+                id="signup-endereco"
+                type="text"
+                placeholder="Endereço"
+                value={endereco}
+                onChange={(e) => setEndereco(e.target.value)}
+                className="w-full rounded-md px-4 py-2"
+                required
+              />
+            </FormField>
+            <FormField label="Número" htmlFor="signup-numero">
+              <TextField
+                id="signup-numero"
+                type="text"
+                placeholder="Número"
+                value={numero}
+                onChange={(e) => setNumero(e.target.value)}
+                className="w-full rounded-md px-4 py-2"
+                required
+              />
+            </FormField>
+            <FormField label="Cidade" htmlFor="signup-cidade">
+              <TextField
+                id="signup-cidade"
+                type="text"
+                placeholder="Cidade"
+                value={cidade}
+                onChange={(e) => setCidade(e.target.value)}
+                className="w-full rounded-md px-4 py-2"
+                required
+              />
+            </FormField>
+            <FormField label="Estado" htmlFor="signup-estado">
+              <TextField
+                id="signup-estado"
+                type="text"
+                placeholder="Estado"
+                value={estado}
+                onChange={(e) => setEstado(e.target.value)}
+                className="w-full rounded-md px-4 py-2"
+                required
+              />
+            </FormField>
           </div>
 
           <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
-            <input
-              type="password"
-              placeholder="Senha"
-              value={senha}
-              onChange={(e) => setSenha(e.target.value)}
-              className="input-base w-full rounded-md px-4 py-2"
-              required
-            />
-            <input
-              type="password"
-              placeholder="Confirme a senha"
-              value={senhaConfirm}
-              onChange={(e) => setSenhaConfirm(e.target.value)}
-              className="input-base w-full rounded-md px-4 py-2"
-              required
-            />
+            <FormField label="Senha" htmlFor="signup-senha">
+              <TextField
+                id="signup-senha"
+                type="password"
+                placeholder="Senha"
+                value={senha}
+                onChange={(e) => setSenha(e.target.value)}
+                className="w-full rounded-md px-4 py-2"
+                required
+              />
+            </FormField>
+            <FormField label="Confirme a senha" htmlFor="signup-confirm">
+              <TextField
+                id="signup-confirm"
+                type="password"
+                placeholder="Confirme a senha"
+                value={senhaConfirm}
+                onChange={(e) => setSenhaConfirm(e.target.value)}
+                className="w-full rounded-md px-4 py-2"
+                required
+              />
+            </FormField>
           </div>
 
           <button

--- a/logs/DOC_LOG.md
+++ b/logs/DOC_LOG.md
@@ -311,3 +311,5 @@
 ## [2025-06-20] Validação de tenant adicionada nas rotas de API e testes atualizados. Lint e build executados.
 
 ## [2025-07-13] Adicionado script format:write e CI verificando Prettier apenas nos arquivos alterados.
+
+## [2025-06-20] Atualizacao de formularios para usar FormField e TextField. - Lint: falhou (next not found) - Build: falhou (next not found)

--- a/stories/ModalEditarPerfil.stories.tsx
+++ b/stories/ModalEditarPerfil.stories.tsx
@@ -29,5 +29,6 @@ export const Default: Story = {
   play: async ({ canvasElement }) => {
     const canvas = within(canvasElement)
     await expect(canvas.getByText(/Editar Perfil/i)).toBeInTheDocument()
+    await expect(canvas.getByLabelText(/nome completo/i)).toBeInTheDocument()
   },
 }

--- a/stories/SignUpForm.stories.tsx
+++ b/stories/SignUpForm.stories.tsx
@@ -27,7 +27,8 @@ export const Default: Story = {
   play: async ({ canvasElement }) => {
     const canvas = within(canvasElement)
     await expect(
-      canvas.getByRole('button', { name: /cadastrar/i }),
+      canvas.getByRole('button', { name: /criar conta/i }),
     ).toBeInTheDocument()
+    await expect(canvas.getByLabelText(/nome completo/i)).toBeInTheDocument()
   },
 }


### PR DESCRIPTION
## Summary
- refactor SignUpForm and ModalEditarPerfil to use `FormField`, `TextField` and `InputWithMask`
- update stories to check new labels
- log lint/build failures in DOC_LOG

## Testing
- `npm run lint` *(fails: next not found)*
- `npm run build` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_68559fe9bee0832ca43adc5d4c133ca1