### PR TITLE
Update tenant validation for produtos and campos routes

### DIFF
--- a/__tests__/api/produtoSlugRoute.test.ts
+++ b/__tests__/api/produtoSlugRoute.test.ts
@@ -1,11 +1,11 @@
 import { describe, it, expect, vi } from 'vitest'
-import { GET } from '../../app/api/campos/route'
+import { GET } from '../../app/api/produtos/[slug]/route'
 import { NextRequest } from 'next/server'
 
-const getFullListMock = vi.fn().mockResolvedValue([{ id: '1', nome: 'Campo' }])
 vi.mock('../../lib/pocketbase', () => ({
   default: vi.fn(() => ({
-    collection: () => ({ getFullList: getFullListMock }),
+    collection: () => ({ getFirstListItem: vi.fn() }),
+    files: { getURL: vi.fn() },
   })),
 }))
 
@@ -13,9 +13,10 @@ vi.mock('../../lib/getTenantFromHost', () => ({
   getTenantFromHost: vi.fn().mockResolvedValue(null),
 }))
 
-describe('GET /api/campos', () => {
+describe('GET /api/produtos/[slug]', () => {
   it('retorna 400 quando tenant não informado', async () => {
-    const req = new Request('http://test')
+    const req = new Request('http://test/produtos/p')
+    ;(req as any).nextUrl = new URL('http://test/produtos/p')
     const res = await GET(req as unknown as NextRequest)
     expect(res.status).toBe(400)
     const body = await res.json()

--- a/__tests__/api/produtosRoute.test.ts
+++ b/__tests__/api/produtosRoute.test.ts
@@ -33,13 +33,13 @@ describe('GET /api/produtos', () => {
     expect(body).toEqual([])
   })
 
-  it('retorna 404 quando domínio não configurado', async () => {
+  it('retorna 400 quando tenant não informado', async () => {
     getTenantFromHostMock.mockResolvedValueOnce(null)
     const req = new Request('http://test')
     ;(req as any).nextUrl = new URL('http://test')
     const res = await GET(req as unknown as NextRequest)
-    expect(res.status).toBe(404)
+    expect(res.status).toBe(400)
     const body = await res.json()
-    expect(body.error).toBe('Domínio não configurado')
+    expect(body.error).toBe('Tenant não informado')
   })
 })

--- a/app/api/campos/route.ts
+++ b/app/api/campos/route.ts
@@ -10,10 +10,7 @@ export async function GET() {
   const tenantId = await getTenantFromHost()
 
   if (!tenantId) {
-    return NextResponse.json(
-      { error: 'Domínio não configurado' },
-      { status: 404 },
-    )
+    return NextResponse.json({ error: 'Tenant não informado' }, { status: 400 })
   }
 
   try {
@@ -54,6 +51,10 @@ export async function POST(req: NextRequest) {
     (user && (user as { cliente?: string }).cliente) ||
     (await getTenantFromHost())
 
+  if (!tenantId) {
+    return NextResponse.json({ error: 'Tenant não informado' }, { status: 400 })
+  }
+
   try {
     const { nome } = await req.json()
     logInfo('📥 Requisição para criar campo recebida')
@@ -64,7 +65,7 @@ export async function POST(req: NextRequest) {
 
     const campo = await pbSafe
       .collection('campos')
-      .create({ nome, ...(tenantId ? { cliente: tenantId } : {}) })
+      .create({ nome, cliente: tenantId })
 
     logInfo('✅ Campo criado com sucesso')
 

--- a/app/api/produtos/[slug]/route.ts
+++ b/app/api/produtos/[slug]/route.ts
@@ -8,10 +8,7 @@ export async function GET(req: NextRequest) {
   const tenantId = await getTenantFromHost()
 
   if (!tenantId) {
-    return NextResponse.json(
-      { error: 'Domínio não configurado' },
-      { status: 404 },
-    )
+    return NextResponse.json({ error: 'Tenant não informado' }, { status: 400 })
   }
   const slug = req.nextUrl.pathname.split('/').pop() ?? ''
   const filter = `slug = '${slug}' && cliente='${tenantId}'`

--- a/app/api/produtos/route.ts
+++ b/app/api/produtos/route.ts
@@ -9,10 +9,7 @@ export async function GET(req: NextRequest) {
   const tenantId = await getTenantFromHost()
 
   if (!tenantId) {
-    return NextResponse.json(
-      { error: 'Domínio não configurado' },
-      { status: 404 },
-    )
+    return NextResponse.json({ error: 'Tenant não informado' }, { status: 400 })
   }
 
   try {

--- a/logs/DOC_LOG.md
+++ b/logs/DOC_LOG.md
@@ -313,3 +313,5 @@
 ## [2025-07-13] Adicionado script format:write e CI verificando Prettier apenas nos arquivos alterados.
 
 ## [2025-06-20] Atualizacao de formularios para usar FormField e TextField. - Lint: falhou (next not found) - Build: falhou (next not found)
+
+## [2025-07-14] Ajustada validação de tenant nas rotas de campos e produtos retornando erro 400 quando ausente; testes atualizados.


### PR DESCRIPTION
## Summary
- enforce tenant validation on `/api/campos` and `/api/produtos` routes
- return `Tenant não informado` when tenant header/host is missing
- require tenant on campos POST
- add tests for missing tenant on `/api/produtos/[slug]`
- log documentation change

## Testing
- `npm run lint`
- `npm run build`
- `npx vitest run`

------
https://chatgpt.com/codex/tasks/task_e_6855ccc561b4832ca7d25eeb723e29f6