### PR TITLE
Implement dynamic metadata for blog and store

### DIFF
--- a/app/blog/layout.tsx
+++ b/app/blog/layout.tsx
@@ -1,11 +1,6 @@
 import '../globals.css'
 import LayoutWrapper from '@/components/templates/LayoutWrapper'
 
-export const metadata = {
-  title: 'UMADEUS Blog',
-  description: 'Artigos e notícias da UMADEUS',
-}
-
 export default function BlogLayout({
   children,
 }: {

--- a/app/blog/page.tsx
+++ b/app/blog/page.tsx
@@ -1,6 +1,37 @@
 import { Suspense } from 'react'
 import BlogClient from './BlogClient'
 import LoadingOverlay from '@/components/organisms/LoadingOverlay'
+import type { Metadata } from 'next'
+import { getPostsFromPB } from '@/lib/posts/getPostsFromPB'
+import { isExternalUrl } from '@/utils/isExternalUrl'
+
+export async function generateMetadata(): Promise<Metadata> {
+  const posts = await getPostsFromPB()
+  if (!posts.length) {
+    return {
+      title: 'Blog',
+      description: 'Artigos e notícias',
+    }
+  }
+  const first = posts[0]
+  const siteUrl = process.env.NEXT_PUBLIC_SITE_URL || 'https://m24saude.com.br'
+  const image = first.thumbnail
+    ? isExternalUrl(first.thumbnail)
+      ? first.thumbnail
+      : `${siteUrl}${first.thumbnail}`
+    : '/img/og-default.jpg'
+  const title = `Blog - ${first.title}`
+  const description = first.summary || ''
+  return {
+    title,
+    description,
+    openGraph: {
+      title,
+      description,
+      images: [image],
+    },
+  }
+}
 
 export default function BlogPage() {
   return (

--- a/app/loja/layout.tsx
+++ b/app/loja/layout.tsx
@@ -1,11 +1,6 @@
 import '../globals.css'
 import LayoutWrapper from '@/components/templates/LayoutWrapper'
 
-export const metadata = {
-  title: 'UMADEUS',
-  description: 'Site oficial da UMADEUS – Produtos e Eventos',
-}
-
 export default function RootLayout({
   children,
 }: {

--- a/app/loja/page.tsx
+++ b/app/loja/page.tsx
@@ -5,6 +5,38 @@ import Link from 'next/link'
 import { useEffect, useState } from 'react'
 import createPocketBase from '@/lib/pocketbase'
 import { calculateGross } from '@/lib/asaasFees'
+import type { Metadata } from 'next'
+import { getTenantFromHost } from '@/lib/getTenantFromHost'
+
+export async function generateMetadata(): Promise<Metadata> {
+  const pb = createPocketBase()
+  const tenantId = await getTenantFromHost()
+  const list = await pb.collection('produtos').getList(1, 1, {
+    filter: tenantId ? `ativo = true && cliente='${tenantId}'` : 'ativo = true',
+    sort: '-created',
+  })
+  const produto = list.items[0]
+  if (!produto) {
+    return {
+      title: 'Loja',
+      description: 'Produtos e eventos',
+    }
+  }
+  const imagem = produto.imagens && produto.imagens.length
+    ? pb.files.getURL(produto, produto.imagens[0])
+    : '/img/og-default.jpg'
+  const title = `Loja - ${produto.nome}`
+  const description = produto.descricao || ''
+  return {
+    title,
+    description,
+    openGraph: {
+      title,
+      description,
+      images: [imagem],
+    },
+  }
+}
 
 interface Produto {
   id: string

--- a/app/loja/produtos/[slug]/page.tsx
+++ b/app/loja/produtos/[slug]/page.tsx
@@ -4,6 +4,40 @@ import { useParams } from 'next/navigation'
 import Link from 'next/link'
 import { Suspense } from 'react'
 import LoadingOverlay from '@/components/organisms/LoadingOverlay'
+import type { Metadata } from 'next'
+import { getProductBySlug } from '@/lib/products/getProductBySlug'
+
+interface Params {
+  slug: string
+}
+
+export async function generateMetadata({
+  params,
+}: {
+  params: Params
+}): Promise<Metadata> {
+  const produto = await getProductBySlug(params.slug)
+  if (!produto) {
+    return {
+      title: 'Produto não encontrado',
+      description: 'Detalhes não disponíveis',
+    }
+  }
+  const imagem = Array.isArray(produto.imagens)
+    ? produto.imagens[0]
+    : typeof produto.imagens === 'object'
+      ? Object.values(produto.imagens)[0]?.[0]
+      : produto.imagem || '/img/og-default.jpg'
+  return {
+    title: produto.nome,
+    description: produto.descricao || '',
+    openGraph: {
+      title: produto.nome,
+      description: produto.descricao || '',
+      images: [imagem],
+    },
+  }
+}
 
 import ProdutoInterativo from './ProdutoInterativo'
 import type { Produto as ProdutoBase } from '@/types'

--- a/lib/products/getProductBySlug.ts
+++ b/lib/products/getProductBySlug.ts
@@ -1,0 +1,22 @@
+import createPocketBase from '@/lib/pocketbase'
+import { getTenantFromHost } from '@/lib/getTenantFromHost'
+import type { Produto } from '@/types'
+
+export async function getProductBySlug(slug: string): Promise<Produto | null> {
+  const pb = createPocketBase()
+  const tenantId = await getTenantFromHost()
+  try {
+    const prod = await pb
+      .collection('produtos')
+      .getFirstListItem<Produto>(`slug='${slug}' && cliente='${tenantId}'`)
+    const imagens = Array.isArray(prod.imagens)
+      ? (prod.imagens || []).map((img) => pb.files.getURL(prod, img))
+      : Object.fromEntries(
+          Object.entries((prod.imagens ?? {}) as Record<string, string[]>)
+            .map(([g, arr]) => [g, arr.map((img) => pb.files.getURL(prod, img))])
+        )
+    return { ...prod, imagens }
+  } catch {
+    return null
+  }
+}

--- a/logs/DOC_LOG.md
+++ b/logs/DOC_LOG.md
@@ -319,3 +319,5 @@
 ## [2025-07-14] Componentes Header, Footer e LayoutWrapper movidos para `components/templates`. Inventário atualizado.
 
 ## [2025-06-20] README orienta executar `npm install` antes de `npm run lint` ou `npm run build`. Workflow CI passa a instalar dependências antes dos scripts. Lint e build executados.
+
+## [2025-07-15] Metadata dinamico nas rotas publicas da loja e do blog com generateMetadata.


### PR DESCRIPTION
## Summary
- drop static metadata from loja and blog layouts
- add generateMetadata to blog index page
- add generateMetadata to loja pages
- fetch product details via helper `getProductBySlug`
- log documentation update

## Testing
- `npm run lint` *(fails: next not found)*
- `npm run build` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_6855d330a794832ca7a8419847f04651