### PR TITLE
Apply auth guard on admin pages

### DIFF
--- a/app/admin/campos/page.tsx
+++ b/app/admin/campos/page.tsx
@@ -4,6 +4,7 @@ import { useEffect, useState } from 'react'
 import { useToast } from '@/lib/context/ToastContext'
 import { useRouter } from 'next/navigation'
 import Spinner from '@/components/atoms/Spinner'
+import { useAuthGuard } from '@/lib/hooks/useAuthGuard'
 
 interface Campo {
   id: string
@@ -18,6 +19,9 @@ export default function GerenciarCamposPage() {
   const [loading, setLoading] = useState(false)
   const [camposCarregados, setCamposCarregados] = useState(false)
   const router = useRouter()
+  const { user, pb, authChecked } = useAuthGuard(['coordenador'])
+
+  if (!authChecked) return null
 
   const token =
     typeof window !== 'undefined' ? localStorage.getItem('pb_token') : null

--- a/app/admin/configuracoes/page.tsx
+++ b/app/admin/configuracoes/page.tsx
@@ -6,6 +6,7 @@ import { useToast } from '@/lib/context/ToastContext'
 import Image from 'next/image'
 import { Check } from 'lucide-react'
 import ToggleSwitch from '@/components/atoms/ToggleSwitch'
+import { useAuthGuard } from '@/lib/hooks/useAuthGuard'
 
 // Lista de tons proibidos (branco, quase branco, preto, quase preto)
 const BLOCKED_COLORS = [
@@ -77,6 +78,7 @@ export default function ConfiguracoesPage() {
   const { config, updateConfig } = useTenant()
   const { user: ctxUser } = useAuthContext()
   const { showSuccess, showError } = useToast()
+  const { user, pb, authChecked } = useAuthGuard(['coordenador'])
   const getAuth = useCallback(() => {
     const token =
       typeof window !== 'undefined' ? localStorage.getItem('pb_token') : null
@@ -93,6 +95,8 @@ export default function ConfiguracoesPage() {
   )
   const [error, setError] = useState('')
   const fileRef = useRef<HTMLInputElement>(null)
+
+  if (!authChecked) return null
 
   // Preview dinâmico
   if (typeof window !== 'undefined') {

--- a/app/admin/eventos/editar/[id]/page.tsx
+++ b/app/admin/eventos/editar/[id]/page.tsx
@@ -7,11 +7,13 @@ import LoadingOverlay from '@/components/organisms/LoadingOverlay'
 import type { Produto } from '@/types'
 import { ModalProduto } from '../../../produtos/novo/ModalProduto'
 import { useToast } from '@/lib/context/ToastContext'
+import { useAuthGuard } from '@/lib/hooks/useAuthGuard'
 
 export default function EditarEventoPage() {
   const { id } = useParams<{ id: string }>()
   const { user: ctxUser, isLoggedIn } = useAuthContext()
   const { showSuccess, showError } = useToast()
+  const { user, pb, authChecked } = useAuthGuard(['coordenador'])
   const getAuth = useCallback(() => {
     const token =
       typeof window !== 'undefined' ? localStorage.getItem('pb_token') : null
@@ -28,6 +30,8 @@ export default function EditarEventoPage() {
   const [produtos, setProdutos] = useState<Produto[]>([])
   const [selectedProdutos, setSelectedProdutos] = useState<string[]>([])
   const [produtoModalOpen, setProdutoModalOpen] = useState(false)
+
+  if (!authChecked) return null
 
   function toggleProduto(id: string) {
     setSelectedProdutos((prev) =>

--- a/app/admin/eventos/novo/page.tsx
+++ b/app/admin/eventos/novo/page.tsx
@@ -7,11 +7,13 @@ import { useAuthContext } from '@/lib/context/AuthContext'
 import type { Produto } from '@/types'
 import { ModalProduto } from '../../produtos/novo/ModalProduto'
 import { useToast } from '@/lib/context/ToastContext'
+import { useAuthGuard } from '@/lib/hooks/useAuthGuard'
 
 export default function NovoEventoPage() {
   const { user: ctxUser, isLoggedIn } = useAuthContext()
   const { showSuccess, showError } = useToast()
   const router = useRouter()
+  const { user, pb, authChecked } = useAuthGuard(['coordenador'])
   const getAuth = useCallback(() => {
     const token =
       typeof window !== 'undefined' ? localStorage.getItem('pb_token') : null
@@ -25,6 +27,8 @@ export default function NovoEventoPage() {
   const [produtos, setProdutos] = useState<Produto[]>([])
   const [selectedProdutos, setSelectedProdutos] = useState<string[]>([])
   const [produtoModalOpen, setProdutoModalOpen] = useState(false)
+
+  if (!authChecked) return null
 
   function toggleProduto(id: string) {
     setSelectedProdutos((prev) =>

--- a/app/admin/eventos/page.tsx
+++ b/app/admin/eventos/page.tsx
@@ -5,6 +5,7 @@ import Link from 'next/link'
 import { useRouter } from 'next/navigation'
 import { useAuthContext } from '@/lib/context/AuthContext'
 import { formatDate } from '@/utils/formatDate'
+import { useAuthGuard } from '@/lib/hooks/useAuthGuard'
 
 interface Evento {
   id: string
@@ -17,6 +18,7 @@ interface Evento {
 export default function AdminEventosPage() {
   const { user: ctxUser, isLoggedIn } = useAuthContext()
   const router = useRouter()
+  const { user, pb, authChecked } = useAuthGuard(['coordenador'])
   const getAuth = useCallback(() => {
     const token =
       typeof window !== 'undefined' ? localStorage.getItem('pb_token') : null
@@ -27,6 +29,8 @@ export default function AdminEventosPage() {
   }, [ctxUser])
 
   const [eventos, setEventos] = useState<Evento[]>([])
+
+  if (!authChecked) return null
 
   useEffect(() => {
     const { token, user } = getAuth()

--- a/app/admin/financeiro/page.tsx
+++ b/app/admin/financeiro/page.tsx
@@ -4,6 +4,7 @@ import { useRouter } from 'next/navigation'
 import { useEffect, useState } from 'react'
 import LoadingOverlay from '@/components/organisms/LoadingOverlay'
 import { useAuthContext } from '@/lib/context/AuthContext'
+import { useAuthGuard } from '@/lib/hooks/useAuthGuard'
 
 interface Statistics {
   netValue: number
@@ -12,9 +13,12 @@ interface Statistics {
 export default function FinanceiroPage() {
   const { tenantId, isLoggedIn } = useAuthContext()
   const router = useRouter()
+  const { user, pb, authChecked } = useAuthGuard(['coordenador', 'lider'])
   const [saldoDisponivel, setSaldoDisponivel] = useState<number | null>(null)
   const [aLiberar, setALiberar] = useState<number | null>(null)
   const [loading, setLoading] = useState(false)
+
+  if (!authChecked) return null
 
   useEffect(() => {
     if (!isLoggedIn) {

--- a/app/admin/financeiro/saldo/page.tsx
+++ b/app/admin/financeiro/saldo/page.tsx
@@ -7,6 +7,7 @@ import { saveAs } from 'file-saver'
 import LoadingOverlay from '@/components/organisms/LoadingOverlay'
 import * as XLSX from 'xlsx'
 import jsPDF from 'jspdf'
+import { useAuthGuard } from '@/lib/hooks/useAuthGuard'
 
 interface Statistics {
   netValue: number
@@ -23,10 +24,13 @@ interface ExtratoItem {
 export default function SaldoPage() {
   const { isLoggedIn } = useAuthContext()
   const router = useRouter()
+  const { user, pb, authChecked } = useAuthGuard(['coordenador', 'lider'])
   const [saldoDisponivel, setSaldoDisponivel] = useState<number | null>(null)
   const [aLiberar, setALiberar] = useState<number | null>(null)
   const [extrato, setExtrato] = useState<ExtratoItem[]>([])
   const [loading, setLoading] = useState(false)
+
+  if (!authChecked) return null
 
   useEffect(() => {
     if (!isLoggedIn) {

--- a/app/admin/financeiro/transferencias/page.tsx
+++ b/app/admin/financeiro/transferencias/page.tsx
@@ -7,12 +7,16 @@ import { useToast } from '@/lib/context/ToastContext'
 import TransferenciaForm from '@/app/admin/financeiro/transferencias/components/TransferenciaForm'
 import BankAccountModal from '@/app/admin/financeiro/transferencias/modals/BankAccountModal'
 import type { PixKeyRecord } from '@/lib/bankAccounts'
+import { useAuthGuard } from '@/lib/hooks/useAuthGuard'
 
 export default function TransferenciasPage() {
   const { isLoggedIn } = useAuthContext()
   const router = useRouter()
   const { showSuccess, showError } = useToast()
+  const { user, pb, authChecked } = useAuthGuard(['coordenador', 'lider'])
   const [openAccountModal, setOpenAccountModal] = useState(false)
+
+  if (!authChecked) return null
 
   async function handleTransfer(
     destino: string,

--- a/app/admin/posts/editar/[slug]/page.tsx
+++ b/app/admin/posts/editar/[slug]/page.tsx
@@ -9,6 +9,7 @@ import Footer from '@/components/templates/Footer'
 import Image from 'next/image'
 import { Clock } from 'lucide-react'
 import { isExternalUrl } from '@/utils/isExternalUrl'
+import { useAuthGuard } from '@/lib/hooks/useAuthGuard'
 
 export default function EditarPostPage() {
   const { slug } = useParams<{ slug: string }>()
@@ -22,8 +23,11 @@ export default function EditarPostPage() {
   const [thumbnail, setThumbnail] = useState('')
   const [keywords, setKeywords] = useState('')
 
-  const { user, isLoggedIn } = useAuthContext()
+  const { user: ctxUser, isLoggedIn } = useAuthContext()
   const router = useRouter()
+  const { user, pb, authChecked } = useAuthGuard(['coordenador'])
+
+  if (!authChecked) return null
 
   useEffect(() => {
     if (!isLoggedIn || !user) {

--- a/app/admin/posts/novo/page.tsx
+++ b/app/admin/posts/novo/page.tsx
@@ -4,14 +4,18 @@ import { useEffect, useState } from 'react'
 import { useRouter } from 'next/navigation'
 import { useAuthContext } from '@/lib/context/AuthContext'
 import PostContentEditor from '../components/PostContentEditor'
+import { useAuthGuard } from '@/lib/hooks/useAuthGuard'
 
 export default function NovoPostPage() {
-  const { user, isLoggedIn } = useAuthContext()
+  const { user: ctxUser, isLoggedIn } = useAuthContext()
   const router = useRouter()
+  const { user, pb, authChecked } = useAuthGuard(['coordenador'])
   const [conteudo, setConteudo] = useState('')
   const [preview, setPreview] = useState(false)
   const [thumbnail, setThumbnail] = useState('')
   const [keywords, setKeywords] = useState('')
+
+  if (!authChecked) return null
 
   useEffect(() => {
     if (!isLoggedIn || !user) {

--- a/app/admin/posts/page.tsx
+++ b/app/admin/posts/page.tsx
@@ -8,16 +8,20 @@ import {
   getPostsClientPB,
   type PostClientRecord,
 } from '@/lib/posts/getPostsClientPB'
+import { useAuthGuard } from '@/lib/hooks/useAuthGuard'
 
 type Post = PostClientRecord
 
 const POSTS_PER_PAGE = 10
 
 export default function AdminPostsPage() {
-  const { user, isLoggedIn } = useAuthContext()
+  const { user: ctxUser, isLoggedIn } = useAuthContext()
   const router = useRouter()
+  const { user, pb, authChecked } = useAuthGuard(['coordenador'])
   const [posts, setPosts] = useState<Post[]>([])
   const [page, setPage] = useState(1)
+
+  if (!authChecked) return null
 
   useEffect(() => {
     if (!isLoggedIn || !user) {

--- a/app/admin/produtos/categorias/page.tsx
+++ b/app/admin/produtos/categorias/page.tsx
@@ -5,6 +5,7 @@ import { useRouter } from 'next/navigation'
 import { useAuthContext } from '@/lib/context/AuthContext'
 import ModalCategoria from './ModalCategoria'
 import { useToast } from '@/lib/context/ToastContext'
+import { useAuthGuard } from '@/lib/hooks/useAuthGuard'
 
 interface Categoria {
   id: string
@@ -16,6 +17,7 @@ export default function CategoriasAdminPage() {
   const { user: ctxUser, isLoggedIn } = useAuthContext()
   const { showSuccess, showError } = useToast()
   const router = useRouter()
+  const { user, pb, authChecked } = useAuthGuard(['coordenador'])
   const getAuth = useCallback(() => {
     const token =
       typeof window !== 'undefined' ? localStorage.getItem('pb_token') : null
@@ -27,6 +29,8 @@ export default function CategoriasAdminPage() {
   const [categorias, setCategorias] = useState<Categoria[]>([])
   const [editCategoria, setEditCategoria] = useState<Categoria | null>(null)
   const [modalOpen, setModalOpen] = useState(false)
+
+  if (!authChecked) return null
 
   useEffect(() => {
     const { token, user } = getAuth()

--- a/app/admin/produtos/editar/[id]/page.tsx
+++ b/app/admin/produtos/editar/[id]/page.tsx
@@ -6,6 +6,7 @@ import { useAuthContext } from '@/lib/context/AuthContext'
 import { calculateGross } from '@/lib/asaasFees'
 import LoadingOverlay from '@/components/organisms/LoadingOverlay'
 import { useToast } from '@/lib/context/ToastContext'
+import { useAuthGuard } from '@/lib/hooks/useAuthGuard'
 
 interface Categoria {
   id: string
@@ -29,6 +30,7 @@ export default function EditarProdutoPage() {
   const { user: ctxUser, isLoggedIn } = useAuthContext()
   const router = useRouter()
   const { showSuccess, showError } = useToast()
+  const { user, pb, authChecked } = useAuthGuard(['coordenador'])
   const getAuth = useCallback(() => {
     const token =
       typeof window !== 'undefined' ? localStorage.getItem('pb_token') : null
@@ -49,6 +51,8 @@ export default function EditarProdutoPage() {
   const [valorCliente, setValorCliente] = useState(
     calculateGross(Number(initial?.preco ?? 0), 'pix', 1).gross,
   )
+
+  if (!authChecked) return null
 
   useEffect(() => {
     setValorCliente(calculateGross(Number(initial?.preco ?? 0), 'pix', 1).gross)

--- a/app/admin/produtos/page.tsx
+++ b/app/admin/produtos/page.tsx
@@ -7,6 +7,7 @@ import Link from 'next/link'
 import type { Produto } from '@/types'
 import { ModalProduto } from './novo/ModalProduto'
 import { useToast } from '@/lib/context/ToastContext'
+import { useAuthGuard } from '@/lib/hooks/useAuthGuard'
 
 function slugify(str: string) {
   return str
@@ -24,6 +25,7 @@ export default function AdminProdutosPage() {
   const { user: ctxUser, isLoggedIn } = useAuthContext()
   const router = useRouter()
   const { showSuccess, showError } = useToast()
+  const { user, pb, authChecked } = useAuthGuard(['coordenador'])
   const getAuth = useCallback(() => {
     const token =
       typeof window !== 'undefined' ? localStorage.getItem('pb_token') : null
@@ -36,6 +38,8 @@ export default function AdminProdutosPage() {
   const [page, setPage] = useState(1)
   const [modalOpen, setModalOpen] = useState(false)
   const pathname = usePathname()
+
+  if (!authChecked) return null
 
   useEffect(() => {
     const { token, user } = getAuth()

--- a/app/admin/usuarios/novo/page.tsx
+++ b/app/admin/usuarios/novo/page.tsx
@@ -2,6 +2,7 @@
 
 import { useState, useEffect } from 'react'
 import { useToast } from '@/lib/context/ToastContext'
+import { useAuthGuard } from '@/lib/hooks/useAuthGuard'
 
 interface Campo {
   id: string
@@ -26,6 +27,7 @@ function formatCpf(value: string) {
 
 export default function NovoUsuarioPage() {
   const { showError, showSuccess } = useToast()
+  const { user, pb, authChecked } = useAuthGuard(['coordenador'])
   const [nome, setNome] = useState('')
   const [email, setEmail] = useState('')
   const [senha, setSenha] = useState('')
@@ -35,6 +37,8 @@ export default function NovoUsuarioPage() {
   const [role, setRole] = useState('usuario')
   const [campoId, setCampoId] = useState('')
   const [campos, setCampos] = useState<Campo[]>([])
+
+  if (!authChecked) return null
 
   useEffect(() => {
     const token = localStorage.getItem('pb_token')

--- a/app/admin/usuarios/page.tsx
+++ b/app/admin/usuarios/page.tsx
@@ -5,6 +5,7 @@ import { useToast } from '@/lib/context/ToastContext'
 import Link from 'next/link'
 import type { Evento } from '@/types'
 import LoadingOverlay from '@/components/organisms/LoadingOverlay'
+import { useAuthGuard } from '@/lib/hooks/useAuthGuard'
 
 interface Usuario {
   id: string
@@ -20,10 +21,13 @@ interface Usuario {
 
 export default function UsuariosPage() {
   const { showError } = useToast()
+  const { user, pb, authChecked } = useAuthGuard(['coordenador'])
   const [usuarios, setUsuarios] = useState<Usuario[]>([])
   const [loading, setLoading] = useState(true)
   const [eventos, setEventos] = useState<Evento[]>([])
   const [eventoId, setEventoId] = useState('')
+
+  if (!authChecked) return null
 
   useEffect(() => {
     async function fetchUsuarios() {


### PR DESCRIPTION
## Summary
- add `useAuthGuard` to admin pages for permission check

## Testing
- `npm run lint` *(fails: next not found)*
- `npm run build` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_6855d3288910832cb4d60d35303aff9d