### PR TITLE
Fix vitest React handling and mocks

### DIFF
--- a/__tests__/CarrinhoPreco.test.tsx
+++ b/__tests__/CarrinhoPreco.test.tsx
@@ -1,4 +1,5 @@
 /* @vitest-environment jsdom */
+import React from 'react'
 import { render, screen } from '@testing-library/react'
 import { vi, describe, it, expect } from 'vitest'
 import CarrinhoPage from '@/app/loja/carrinho/page'

--- a/__tests__/EventosPage.test.tsx
+++ b/__tests__/EventosPage.test.tsx
@@ -1,4 +1,5 @@
 /* @vitest-environment jsdom */
+import React from 'react'
 import { render, screen, fireEvent } from '@testing-library/react'
 import { vi } from 'vitest'
 import EventosPage from '@/app/loja/eventos/page'

--- a/__tests__/InscricaoPage.test.tsx
+++ b/__tests__/InscricaoPage.test.tsx
@@ -1,4 +1,5 @@
 /* @vitest-environment jsdom */
+import React from 'react'
 import { describe, it, expect, vi } from 'vitest'
 import { render, screen } from '@testing-library/react'
 import InscricaoPage from '@/app/inscricoes/[liderId]/[eventoId]/page'

--- a/__tests__/ProdutoPage.test.tsx
+++ b/__tests__/ProdutoPage.test.tsx
@@ -1,4 +1,5 @@
 /* @vitest-environment jsdom */
+import React from 'react'
 import { render, screen } from '@testing-library/react'
 import { vi } from 'vitest'
 import ProdutoDetalhe from '@/app/loja/produtos/[slug]/page'

--- a/__tests__/ProdutosFiltradosPreco.test.tsx
+++ b/__tests__/ProdutosFiltradosPreco.test.tsx
@@ -1,4 +1,5 @@
 /* @vitest-environment jsdom */
+import React from 'react'
 import { render, screen } from '@testing-library/react'
 import { describe, it, expect, vi } from 'vitest'
 import ProdutosFiltrados from '@/app/loja/produtos/ProdutosFiltrados'

--- a/__tests__/TransferenciaForm.test.tsx
+++ b/__tests__/TransferenciaForm.test.tsx
@@ -1,4 +1,5 @@
 /* @vitest-environment jsdom */
+import React from 'react'
 import { describe, it, expect, vi, expectTypeOf } from 'vitest'
 import { render, screen, fireEvent } from '@testing-library/react'
 import type {
@@ -15,17 +16,19 @@ vi.mock('../lib/context/AuthContext', () => ({
   useAuthContext: () => ({ tenantId: 'cli1' }),
 }))
 
-const contasMock: ClienteContaBancariaRecord[] = [
-  { id: '1', accountName: 'Conta 1', ownerName: 'Fulano' },
-  { id: '2', accountName: 'Conta 2', ownerName: 'Beltrano' },
-]
-const pixMock: PixKeyRecord[] = [
-  { id: '3', pixAddressKey: 'a@b.com', pixAddressKeyType: 'email' },
-]
-vi.mock('../lib/bankAccounts', () => ({
-  getBankAccountsByTenant: vi.fn().mockResolvedValue(contasMock),
-  getPixKeysByTenant: vi.fn().mockResolvedValue(pixMock),
-}))
+let contasMock: ClienteContaBancariaRecord[]
+let pixMock: PixKeyRecord[]
+vi.mock('../lib/bankAccounts', () => {
+  contasMock = [
+    { id: '1', accountName: 'Conta 1', ownerName: 'Fulano' },
+    { id: '2', accountName: 'Conta 2', ownerName: 'Beltrano' },
+  ]
+  pixMock = [{ id: '3', pixAddressKey: 'a@b.com', pixAddressKeyType: 'email' }]
+  return {
+    getBankAccountsByTenant: vi.fn().mockResolvedValue(contasMock),
+    getPixKeysByTenant: vi.fn().mockResolvedValue(pixMock),
+  }
+})
 
 describe('TransferenciaForm', () => {
   it('renderiza contas bancarias e chaves pix', async () => {

--- a/__tests__/TransferenciasPage.test.tsx
+++ b/__tests__/TransferenciasPage.test.tsx
@@ -1,4 +1,5 @@
 /* @vitest-environment jsdom */
+import React from 'react'
 import { render, screen, fireEvent } from '@testing-library/react'
 import { describe, it, expect, vi } from 'vitest'
 import TransferenciasPage from '@/app/admin/financeiro/transferencias/page'

--- a/__tests__/a11y/button.a11y.test.tsx
+++ b/__tests__/a11y/button.a11y.test.tsx
@@ -1,4 +1,5 @@
 /* @vitest-environment jsdom */
+import React from 'react'
 import { render } from '@testing-library/react'
 import { axe, toHaveNoViolations } from 'jest-axe'
 import { Button } from '@/components/atoms/Button'

--- a/__tests__/bankAccountModal.test.tsx
+++ b/__tests__/bankAccountModal.test.tsx
@@ -1,4 +1,5 @@
 /* @vitest-environment jsdom */
+import React from 'react'
 import { describe, it, expect, vi, beforeEach } from 'vitest'
 import { render, screen, fireEvent } from '@testing-library/react'
 import BankAccountModal from '@/app/admin/financeiro/transferencias/modals/BankAccountModal'
@@ -7,15 +8,20 @@ vi.mock('../lib/hooks/usePocketBase', () => ({
   default: () => ({ authStore: { model: { id: 'u1', cliente: 'cli1' } } }),
 }))
 
-const createBankAccount = vi.fn()
-const createPixKey = vi.fn()
-const searchBanks = vi.fn().mockResolvedValue([])
+let createBankAccount: ReturnType<typeof vi.fn>
+let createPixKey: ReturnType<typeof vi.fn>
+let searchBanks: ReturnType<typeof vi.fn>
 
-vi.mock('../lib/bankAccounts', () => ({
-  searchBanks,
-  createBankAccount,
-  createPixKey,
-}))
+vi.mock('../lib/bankAccounts', () => {
+  createBankAccount = vi.fn()
+  createPixKey = vi.fn()
+  searchBanks = vi.fn().mockResolvedValue([])
+  return {
+    searchBanks,
+    createBankAccount,
+    createPixKey,
+  }
+})
 
 function fillBasicFields(container: HTMLElement, cpf: string, birth: string) {
   fireEvent.change(screen.getByPlaceholderText('Nome do titular'), {

--- a/__tests__/headerLinks.test.tsx
+++ b/__tests__/headerLinks.test.tsx
@@ -1,4 +1,5 @@
 /* @vitest-environment jsdom */
+import React from 'react'
 import { render, screen, fireEvent } from '@testing-library/react'
 import { vi } from 'vitest'
 import Header from '@/components/templates/HeaderAdmin'

--- a/__tests__/inscricoesPage.test.tsx
+++ b/__tests__/inscricoesPage.test.tsx
@@ -1,4 +1,5 @@
 /* @vitest-environment jsdom */
+import React from 'react'
 import { render, screen, fireEvent } from '@testing-library/react'
 import { vi } from 'vitest'
 import ListaInscricoesPage from '@/app/admin/inscricoes/page'

--- a/__tests__/lojaCheckout.test.tsx
+++ b/__tests__/lojaCheckout.test.tsx
@@ -1,4 +1,5 @@
 /* @vitest-environment jsdom */
+import React from 'react'
 import { render, screen, fireEvent } from '@testing-library/react'
 import { vi } from 'vitest'
 import CheckoutPage from '@/app/loja/checkout/page'

--- a/__tests__/serverLogger.test.ts
+++ b/__tests__/serverLogger.test.ts
@@ -1,7 +1,10 @@
 import { describe, it, expect, vi, afterEach } from 'vitest'
 import path from 'path'
 
-vi.mock('fs/promises', () => ({ appendFile: vi.fn() }))
+vi.mock('fs/promises', async (importOriginal) => {
+  const actual = await importOriginal()
+  return { ...actual, appendFile: vi.fn() }
+})
 
 import { logConciliacaoErro } from '../lib/server/logger'
 import { appendFile } from 'fs/promises'

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,8 +1,10 @@
 // vitest.config.ts
 import { defineConfig } from 'vitest/config'
+import react from '@vitejs/plugin-react'
 import path from 'path'
 
 export default defineConfig({
+  plugins: [react()],
   resolve: {
     alias: {
       // de '@/foo' para '<root>/foo'


### PR DESCRIPTION
## Summary
- add React plugin to vitest
- fix module mocks using hoisted factories
- import React in several test suites

## Testing
- `npm run lint`
- `npm run build`
- `npm run test:ci` *(fails: pb.collection is not a function)*

------
https://chatgpt.com/codex/tasks/task_e_6855d5afee00832c84ce68e82c4caa55