### PR TITLE
Fix hydration and hooks

### DIFF
--- a/app/admin/campos/page.tsx
+++ b/app/admin/campos/page.tsx
@@ -19,24 +19,29 @@ export default function GerenciarCamposPage() {
   const [loading, setLoading] = useState(false)
   const [camposCarregados, setCamposCarregados] = useState(false)
   const router = useRouter()
-  const { user, pb, authChecked } = useAuthGuard(['coordenador'])
-
-  if (!authChecked) return null
+  const { authChecked } = useAuthGuard(['coordenador'])
 
   const token =
     typeof window !== 'undefined' ? localStorage.getItem('pb_token') : null
   const userRaw =
     typeof window !== 'undefined' ? localStorage.getItem('pb_user') : null
-  const user = userRaw ? JSON.parse(userRaw) : null
+  const storedUser = userRaw ? JSON.parse(userRaw) : null
 
   useEffect(() => {
-    if (!token || !user || user.role !== 'coordenador') {
+    if (!authChecked) return
+    if (!token || !storedUser || storedUser.role !== 'coordenador') {
       router.replace('/login')
     }
-  }, [token, user, router])
+  }, [token, storedUser, router, authChecked])
 
   useEffect(() => {
-    if (!token || !user || user.role !== 'coordenador' || camposCarregados)
+    if (
+      !authChecked ||
+      !token ||
+      !storedUser ||
+      storedUser.role !== 'coordenador' ||
+      camposCarregados
+    )
       return
 
     const carregarCampos = async () => {
@@ -45,7 +50,7 @@ export default function GerenciarCamposPage() {
           method: 'GET',
           headers: {
             Authorization: `Bearer ${token}`,
-            'X-PB-User': JSON.stringify(user),
+            'X-PB-User': JSON.stringify(storedUser),
           },
         })
 
@@ -76,7 +81,7 @@ export default function GerenciarCamposPage() {
     e.preventDefault()
     setLoading(true)
 
-    if (!token || !user || user.role !== 'coordenador') {
+    if (!token || !storedUser || storedUser.role !== 'coordenador') {
       showError('Usuário não autenticado.')
       setLoading(false)
       return
@@ -93,7 +98,7 @@ export default function GerenciarCamposPage() {
         headers: {
           'Content-Type': 'application/json',
           Authorization: `Bearer ${token}`,
-          'X-PB-User': JSON.stringify(user),
+          'X-PB-User': JSON.stringify(storedUser),
         },
         body: JSON.stringify({ nome }),
       })
@@ -120,13 +125,13 @@ export default function GerenciarCamposPage() {
   }
 
   const fetchCampos = async () => {
-    if (!token || !user || user.role !== 'coordenador') return
+    if (!token || !storedUser || storedUser.role !== 'coordenador') return
 
     try {
       const res = await fetch('/admin/api/campos', {
         headers: {
           Authorization: `Bearer ${token}`,
-          'X-PB-User': JSON.stringify(user),
+          'X-PB-User': JSON.stringify(storedUser),
         },
       })
       const data = await res.json()
@@ -201,7 +206,7 @@ export default function GerenciarCamposPage() {
   async function handleExcluirCampo(id: string) {
     try {
       setLoading(true)
-      if (!token || !user || user.role !== 'coordenador') {
+      if (!token || !storedUser || storedUser.role !== 'coordenador') {
         showError('Usuário não autenticado.')
         setLoading(false)
         return
@@ -210,7 +215,7 @@ export default function GerenciarCamposPage() {
         method: 'DELETE',
         headers: {
           Authorization: `Bearer ${token}`,
-          'X-PB-User': JSON.stringify(user),
+          'X-PB-User': JSON.stringify(storedUser),
         },
       })
       if (!res.ok) {
@@ -226,6 +231,8 @@ export default function GerenciarCamposPage() {
       setLoading(false)
     }
   }
+
+  if (!authChecked) return null
 
   return (
     <>

--- a/app/admin/clientes/page.tsx
+++ b/app/admin/clientes/page.tsx
@@ -14,7 +14,7 @@ export default function ClientesPage() {
   const pbClient = useMemo(() => createPocketBase(), [])
   const { tenantId } = useAuthContext()
   const { showError, showSuccess } = useToast()
-  const { user, pb, authChecked } = useAuthGuard(['coordenador', 'lider'])
+  const { authChecked } = useAuthGuard(['coordenador', 'lider'])
   const [clientes, setClientes] = useState<
     (Inscricao & { eventoId?: string })[]
   >([])
@@ -22,8 +22,6 @@ export default function ClientesPage() {
   const [clienteEmEdicao, setClienteEmEdicao] = useState<
     (Inscricao & { eventoId?: string }) | null
   >(null)
-
-  if (!authChecked) return null
 
   useEffect(() => {
     async function fetchClientes() {
@@ -51,6 +49,8 @@ export default function ClientesPage() {
 
     fetchClientes()
   }, [pbClient, tenantId, showError])
+
+  if (!authChecked) return null
 
   const salvarEdicao = async (
     atualizada: Partial<Inscricao & { eventoId?: string }>,

--- a/app/admin/configuracoes/page.tsx
+++ b/app/admin/configuracoes/page.tsx
@@ -78,7 +78,7 @@ export default function ConfiguracoesPage() {
   const { config, updateConfig } = useTenant()
   const { user: ctxUser } = useAuthContext()
   const { showSuccess, showError } = useToast()
-  const { user, pb, authChecked } = useAuthGuard(['coordenador'])
+  const { authChecked } = useAuthGuard(['coordenador'])
   const getAuth = useCallback(() => {
     const token =
       typeof window !== 'undefined' ? localStorage.getItem('pb_token') : null

--- a/app/admin/eventos/editar/[id]/page.tsx
+++ b/app/admin/eventos/editar/[id]/page.tsx
@@ -13,7 +13,7 @@ export default function EditarEventoPage() {
   const { id } = useParams<{ id: string }>()
   const { user: ctxUser, isLoggedIn } = useAuthContext()
   const { showSuccess, showError } = useToast()
-  const { user, pb, authChecked } = useAuthGuard(['coordenador'])
+  const { authChecked } = useAuthGuard(['coordenador'])
   const getAuth = useCallback(() => {
     const token =
       typeof window !== 'undefined' ? localStorage.getItem('pb_token') : null
@@ -31,8 +31,6 @@ export default function EditarEventoPage() {
   const [selectedProdutos, setSelectedProdutos] = useState<string[]>([])
   const [produtoModalOpen, setProdutoModalOpen] = useState(false)
 
-  if (!authChecked) return null
-
   function toggleProduto(id: string) {
     setSelectedProdutos((prev) =>
       prev.includes(id) ? prev.filter((p) => p !== id) : [...prev, id],
@@ -40,13 +38,15 @@ export default function EditarEventoPage() {
   }
 
   useEffect(() => {
+    if (!authChecked) return
     const { token, user } = getAuth()
     if (!isLoggedIn || !token || !user || user.role !== 'coordenador') {
       router.replace('/login')
     }
-  }, [isLoggedIn, router, getAuth])
+  }, [isLoggedIn, router, getAuth, authChecked])
 
   useEffect(() => {
+    if (!authChecked) return
     const { token, user } = getAuth()
     if (!isLoggedIn || !token || !user || user.role !== 'coordenador') return
     fetch(`/admin/api/eventos/${id}`, {
@@ -74,9 +74,10 @@ export default function EditarEventoPage() {
         setSelectedProdutos(arr)
       })
       .finally(() => setLoading(false))
-  }, [id, isLoggedIn, getAuth])
+  }, [id, isLoggedIn, getAuth, authChecked])
 
   useEffect(() => {
+    if (!authChecked) return
     const { token, user } = getAuth()
     if (!isLoggedIn || !token || !user || user.role !== 'coordenador') return
     fetch('/admin/api/produtos', {
@@ -90,7 +91,7 @@ export default function EditarEventoPage() {
         setProdutos(Array.isArray(data) ? data : (data.items ?? []))
       })
       .catch(() => setProdutos([]))
-  }, [isLoggedIn, getAuth])
+  }, [isLoggedIn, getAuth, authChecked])
 
   async function handleNovoProduto(form: Produto) {
     const formData = new FormData()
@@ -180,6 +181,8 @@ export default function EditarEventoPage() {
       showError('Falha ao salvar evento')
     }
   }
+
+  if (!authChecked) return null
 
   return (
     <>

--- a/app/admin/eventos/novo/page.tsx
+++ b/app/admin/eventos/novo/page.tsx
@@ -13,7 +13,7 @@ export default function NovoEventoPage() {
   const { user: ctxUser, isLoggedIn } = useAuthContext()
   const { showSuccess, showError } = useToast()
   const router = useRouter()
-  const { user, pb, authChecked } = useAuthGuard(['coordenador'])
+  const { authChecked } = useAuthGuard(['coordenador'])
   const getAuth = useCallback(() => {
     const token =
       typeof window !== 'undefined' ? localStorage.getItem('pb_token') : null
@@ -28,8 +28,6 @@ export default function NovoEventoPage() {
   const [selectedProdutos, setSelectedProdutos] = useState<string[]>([])
   const [produtoModalOpen, setProdutoModalOpen] = useState(false)
 
-  if (!authChecked) return null
-
   function toggleProduto(id: string) {
     setSelectedProdutos((prev) =>
       prev.includes(id) ? prev.filter((p) => p !== id) : [...prev, id],
@@ -37,13 +35,15 @@ export default function NovoEventoPage() {
   }
 
   useEffect(() => {
+    if (!authChecked) return
     const { token, user } = getAuth()
     if (!isLoggedIn || !token || !user || user.role !== 'coordenador') {
       router.replace('/login')
     }
-  }, [isLoggedIn, router, getAuth])
+  }, [isLoggedIn, router, getAuth, authChecked])
 
   useEffect(() => {
+    if (!authChecked) return
     const { token, user } = getAuth()
     if (!isLoggedIn || !token || !user || user.role !== 'coordenador') return
     fetch('/admin/api/produtos', {
@@ -57,7 +57,7 @@ export default function NovoEventoPage() {
         setProdutos(Array.isArray(data) ? data : (data.items ?? []))
       })
       .catch(() => setProdutos([]))
-  }, [isLoggedIn, getAuth])
+  }, [isLoggedIn, getAuth, authChecked])
 
   async function handleNovoProduto(form: Produto) {
     const formData = new FormData()
@@ -143,6 +143,8 @@ export default function NovoEventoPage() {
       showError('Falha ao salvar evento')
     }
   }
+
+  if (!authChecked) return null
 
   return (
     <>

--- a/app/admin/eventos/page.tsx
+++ b/app/admin/eventos/page.tsx
@@ -18,7 +18,7 @@ interface Evento {
 export default function AdminEventosPage() {
   const { user: ctxUser, isLoggedIn } = useAuthContext()
   const router = useRouter()
-  const { user, pb, authChecked } = useAuthGuard(['coordenador'])
+  const { authChecked } = useAuthGuard(['coordenador'])
   const getAuth = useCallback(() => {
     const token =
       typeof window !== 'undefined' ? localStorage.getItem('pb_token') : null
@@ -30,16 +30,16 @@ export default function AdminEventosPage() {
 
   const [eventos, setEventos] = useState<Evento[]>([])
 
-  if (!authChecked) return null
-
   useEffect(() => {
+    if (!authChecked) return
     const { token, user } = getAuth()
     if (!isLoggedIn || !token || !user || user.role !== 'coordenador') {
       router.replace('/login')
     }
-  }, [isLoggedIn, router, getAuth])
+  }, [isLoggedIn, router, getAuth, authChecked])
 
   useEffect(() => {
+    if (!authChecked) return
     const { token, user } = getAuth()
     if (!isLoggedIn || !token || !user || user.role !== 'coordenador') return
 
@@ -59,7 +59,7 @@ export default function AdminEventosPage() {
     }
 
     fetchEventos()
-  }, [isLoggedIn, getAuth])
+  }, [isLoggedIn, getAuth, authChecked])
 
   async function handleDelete(id: string) {
     if (!confirm('Confirma excluir?')) return
@@ -73,6 +73,8 @@ export default function AdminEventosPage() {
     })
     setEventos((prev) => prev.filter((e) => e.id !== id))
   }
+
+  if (!authChecked) return null
 
   return (
     <main className="max-w-4xl mx-auto px-4 py-8">

--- a/app/admin/financeiro/page.tsx
+++ b/app/admin/financeiro/page.tsx
@@ -13,14 +13,13 @@ interface Statistics {
 export default function FinanceiroPage() {
   const { tenantId, isLoggedIn } = useAuthContext()
   const router = useRouter()
-  const { user, pb, authChecked } = useAuthGuard(['coordenador', 'lider'])
+  const { authChecked } = useAuthGuard(['coordenador', 'lider'])
   const [saldoDisponivel, setSaldoDisponivel] = useState<number | null>(null)
   const [aLiberar, setALiberar] = useState<number | null>(null)
   const [loading, setLoading] = useState(false)
 
-  if (!authChecked) return null
-
   useEffect(() => {
+    if (!authChecked) return
     if (!isLoggedIn) {
       router.replace('/login')
       return
@@ -48,7 +47,10 @@ export default function FinanceiroPage() {
       }
     }
     fetchSaldo()
-  }, [tenantId, isLoggedIn, router])
+
+  }, [tenantId, isLoggedIn, router, authChecked])
+
+  if (!authChecked) return null
 
   return (
     <main className="max-w-4xl mx-auto px-4 py-8">

--- a/app/admin/financeiro/saldo/page.tsx
+++ b/app/admin/financeiro/saldo/page.tsx
@@ -24,15 +24,14 @@ interface ExtratoItem {
 export default function SaldoPage() {
   const { isLoggedIn } = useAuthContext()
   const router = useRouter()
-  const { user, pb, authChecked } = useAuthGuard(['coordenador', 'lider'])
+  const { authChecked } = useAuthGuard(['coordenador', 'lider'])
   const [saldoDisponivel, setSaldoDisponivel] = useState<number | null>(null)
   const [aLiberar, setALiberar] = useState<number | null>(null)
   const [extrato, setExtrato] = useState<ExtratoItem[]>([])
   const [loading, setLoading] = useState(false)
 
-  if (!authChecked) return null
-
   useEffect(() => {
+    if (!authChecked) return
     if (!isLoggedIn) {
       router.replace('/login')
       return
@@ -64,7 +63,7 @@ export default function SaldoPage() {
       }
     }
     fetchData()
-  }, [isLoggedIn, router])
+  }, [isLoggedIn, router, authChecked])
 
   const exportXLSM = () => {
     const worksheet = XLSX.utils.json_to_sheet(extrato)
@@ -87,6 +86,8 @@ export default function SaldoPage() {
     })
     doc.save('extrato.pdf')
   }
+
+  if (!authChecked) return null
 
   return (
     <main className="max-w-5xl mx-auto px-4 py-8">

--- a/app/admin/financeiro/transferencias/page.tsx
+++ b/app/admin/financeiro/transferencias/page.tsx
@@ -13,10 +13,8 @@ export default function TransferenciasPage() {
   const { isLoggedIn } = useAuthContext()
   const router = useRouter()
   const { showSuccess, showError } = useToast()
-  const { user, pb, authChecked } = useAuthGuard(['coordenador', 'lider'])
+  const { authChecked } = useAuthGuard(['coordenador', 'lider'])
   const [openAccountModal, setOpenAccountModal] = useState(false)
-
-  if (!authChecked) return null
 
   async function handleTransfer(
     destino: string,
@@ -52,10 +50,11 @@ export default function TransferenciasPage() {
   }
 
   useEffect(() => {
+    if (!authChecked) return
     if (!isLoggedIn) router.replace('/login')
-  }, [isLoggedIn, router])
+  }, [isLoggedIn, router, authChecked])
 
-  if (!isLoggedIn) return null
+  if (!authChecked || !isLoggedIn) return null
 
   return (
     <main className="max-w-lg mx-auto px-4 py-8">

--- a/app/admin/posts/editar/[slug]/page.tsx
+++ b/app/admin/posts/editar/[slug]/page.tsx
@@ -25,9 +25,7 @@ export default function EditarPostPage() {
 
   const { user: ctxUser, isLoggedIn } = useAuthContext()
   const router = useRouter()
-  const { user, pb, authChecked } = useAuthGuard(['coordenador'])
-
-  if (!authChecked) return null
+  const { authChecked } = useAuthGuard(['coordenador'])
 
   useEffect(() => {
     if (!isLoggedIn || !user) {
@@ -59,6 +57,8 @@ export default function EditarPostPage() {
       )
       .catch((err) => console.error('Erro ao carregar post:', err))
   }, [slug])
+
+  if (!authChecked) return null
 
   if (preview) {
     const words = conteudo.split(/\s+/).length

--- a/app/admin/posts/novo/page.tsx
+++ b/app/admin/posts/novo/page.tsx
@@ -9,19 +9,20 @@ import { useAuthGuard } from '@/lib/hooks/useAuthGuard'
 export default function NovoPostPage() {
   const { user: ctxUser, isLoggedIn } = useAuthContext()
   const router = useRouter()
-  const { user, pb, authChecked } = useAuthGuard(['coordenador'])
+  const { authChecked } = useAuthGuard(['coordenador'])
   const [conteudo, setConteudo] = useState('')
   const [preview, setPreview] = useState(false)
   const [thumbnail, setThumbnail] = useState('')
   const [keywords, setKeywords] = useState('')
 
-  if (!authChecked) return null
-
   useEffect(() => {
-    if (!isLoggedIn || !user) {
+    if (!authChecked) return
+    if (!isLoggedIn) {
       router.replace('/login')
     }
-  }, [isLoggedIn, user, router])
+  }, [isLoggedIn, router, authChecked])
+
+  if (!authChecked) return null
 
   if (preview) {
     return (

--- a/app/admin/posts/page.tsx
+++ b/app/admin/posts/page.tsx
@@ -17,17 +17,16 @@ const POSTS_PER_PAGE = 10
 export default function AdminPostsPage() {
   const { user: ctxUser, isLoggedIn } = useAuthContext()
   const router = useRouter()
-  const { user, pb, authChecked } = useAuthGuard(['coordenador'])
+  const { authChecked } = useAuthGuard(['coordenador'])
   const [posts, setPosts] = useState<Post[]>([])
   const [page, setPage] = useState(1)
 
-  if (!authChecked) return null
-
   useEffect(() => {
-    if (!isLoggedIn || !user) {
+    if (!authChecked) return
+    if (!isLoggedIn) {
       router.replace('/login')
     }
-  }, [isLoggedIn, user, router])
+  }, [isLoggedIn, router, authChecked])
 
   useEffect(() => {
     getPostsClientPB()
@@ -42,6 +41,8 @@ export default function AdminPostsPage() {
     (page - 1) * POSTS_PER_PAGE,
     page * POSTS_PER_PAGE,
   )
+
+  if (!authChecked) return null
 
   return (
     <main className="max-w-4xl mx-auto px-4 py-8">

--- a/app/admin/produtos/categorias/page.tsx
+++ b/app/admin/produtos/categorias/page.tsx
@@ -17,7 +17,7 @@ export default function CategoriasAdminPage() {
   const { user: ctxUser, isLoggedIn } = useAuthContext()
   const { showSuccess, showError } = useToast()
   const router = useRouter()
-  const { user, pb, authChecked } = useAuthGuard(['coordenador'])
+  const { authChecked } = useAuthGuard(['coordenador'])
   const getAuth = useCallback(() => {
     const token =
       typeof window !== 'undefined' ? localStorage.getItem('pb_token') : null
@@ -30,16 +30,16 @@ export default function CategoriasAdminPage() {
   const [editCategoria, setEditCategoria] = useState<Categoria | null>(null)
   const [modalOpen, setModalOpen] = useState(false)
 
-  if (!authChecked) return null
-
   useEffect(() => {
+    if (!authChecked) return
     const { token, user } = getAuth()
     if (!isLoggedIn || !token || !user || user.role !== 'coordenador') {
       router.replace('/login')
     }
-  }, [isLoggedIn, router, getAuth])
+  }, [isLoggedIn, router, getAuth, authChecked])
 
   useEffect(() => {
+    if (!authChecked) return
     const { token, user } = getAuth()
     if (!isLoggedIn || !token || !user || user.role !== 'coordenador') return
     fetch('/admin/api/categorias', {
@@ -56,7 +56,7 @@ export default function CategoriasAdminPage() {
         console.error('Erro ao carregar categorias:', err)
         setCategorias([])
       })
-  }, [isLoggedIn, getAuth])
+  }, [isLoggedIn, getAuth, authChecked])
 
   async function handleSave(form: { nome: string }) {
     const { token, user } = getAuth()
@@ -126,6 +126,8 @@ export default function CategoriasAdminPage() {
       showError('Erro ao excluir categoria')
     }
   }
+
+  if (!authChecked) return null
 
   return (
     <main className="max-w-4xl mx-auto px-4 py-8">

--- a/app/admin/produtos/editar/[id]/page.tsx
+++ b/app/admin/produtos/editar/[id]/page.tsx
@@ -30,7 +30,7 @@ export default function EditarProdutoPage() {
   const { user: ctxUser, isLoggedIn } = useAuthContext()
   const router = useRouter()
   const { showSuccess, showError } = useToast()
-  const { user, pb, authChecked } = useAuthGuard(['coordenador'])
+  const { authChecked } = useAuthGuard(['coordenador'])
   const getAuth = useCallback(() => {
     const token =
       typeof window !== 'undefined' ? localStorage.getItem('pb_token') : null
@@ -52,20 +52,20 @@ export default function EditarProdutoPage() {
     calculateGross(Number(initial?.preco ?? 0), 'pix', 1).gross,
   )
 
-  if (!authChecked) return null
-
   useEffect(() => {
     setValorCliente(calculateGross(Number(initial?.preco ?? 0), 'pix', 1).gross)
   }, [initial?.preco])
 
   useEffect(() => {
+    if (!authChecked) return
     const { token, user } = getAuth()
     if (!isLoggedIn || !token || !user || user.role !== 'coordenador') {
       router.replace('/login')
     }
-  }, [isLoggedIn, router, getAuth])
+  }, [isLoggedIn, router, getAuth, authChecked])
 
   useEffect(() => {
+    if (!authChecked) return
     const { token, user } = getAuth()
     if (!isLoggedIn || !token || !user || user.role !== 'coordenador') return
     fetch('/admin/api/categorias', {
@@ -139,7 +139,7 @@ export default function EditarProdutoPage() {
         )
       })
       .finally(() => setLoading(false))
-  }, [id, isLoggedIn, router, getAuth])
+  }, [id, isLoggedIn, router, getAuth, authChecked])
 
   useEffect(() => {
     if (initial?.cores && typeof initial.cores === 'string') {
@@ -254,6 +254,8 @@ export default function EditarProdutoPage() {
   function removeCor(hex: string) {
     setCores(cores.filter((c) => c !== hex))
   }
+
+  if (!authChecked) return null
 
   return (
     <main className="max-w-xl mx-auto px-4 py-8">

--- a/app/admin/produtos/page.tsx
+++ b/app/admin/produtos/page.tsx
@@ -25,7 +25,7 @@ export default function AdminProdutosPage() {
   const { user: ctxUser, isLoggedIn } = useAuthContext()
   const router = useRouter()
   const { showSuccess, showError } = useToast()
-  const { user, pb, authChecked } = useAuthGuard(['coordenador'])
+  const { authChecked } = useAuthGuard(['coordenador'])
   const getAuth = useCallback(() => {
     const token =
       typeof window !== 'undefined' ? localStorage.getItem('pb_token') : null
@@ -39,16 +39,16 @@ export default function AdminProdutosPage() {
   const [modalOpen, setModalOpen] = useState(false)
   const pathname = usePathname()
 
-  if (!authChecked) return null
-
   useEffect(() => {
+    if (!authChecked) return
     const { token, user } = getAuth()
     if (!isLoggedIn || !token || !user || user.role !== 'coordenador') {
       router.replace('/login')
     }
-  }, [isLoggedIn, router, getAuth])
+  }, [isLoggedIn, router, getAuth, authChecked])
 
   useEffect(() => {
+    if (!authChecked) return
     const { token, user } = getAuth()
     if (!isLoggedIn || !token || !user || user.role !== 'coordenador') return
 
@@ -67,7 +67,7 @@ export default function AdminProdutosPage() {
       }
     }
     fetchProdutos()
-  }, [isLoggedIn, getAuth])
+  }, [isLoggedIn, getAuth, authChecked])
 
   const totalPages = Math.ceil(produtos.length / PRODUTOS_POR_PAGINA)
   const paginated = produtos.slice(
@@ -135,6 +135,8 @@ export default function AdminProdutosPage() {
     setModalOpen(false)
     setPage(1)
   }
+
+  if (!authChecked) return null
 
   return (
     <main className="max-w-4xl mx-auto px-4 py-8">

--- a/app/admin/usuarios/novo/page.tsx
+++ b/app/admin/usuarios/novo/page.tsx
@@ -27,7 +27,7 @@ function formatCpf(value: string) {
 
 export default function NovoUsuarioPage() {
   const { showError, showSuccess } = useToast()
-  const { user, pb, authChecked } = useAuthGuard(['coordenador'])
+  const { authChecked } = useAuthGuard(['coordenador'])
   const [nome, setNome] = useState('')
   const [email, setEmail] = useState('')
   const [senha, setSenha] = useState('')
@@ -38,9 +38,8 @@ export default function NovoUsuarioPage() {
   const [campoId, setCampoId] = useState('')
   const [campos, setCampos] = useState<Campo[]>([])
 
-  if (!authChecked) return null
-
   useEffect(() => {
+    if (!authChecked) return
     const token = localStorage.getItem('pb_token')
     const user = localStorage.getItem('pb_user')
 
@@ -53,7 +52,7 @@ export default function NovoUsuarioPage() {
       .then((res) => res.json())
       .then((data) => setCampos(data))
       .catch(() => showError('Erro ao carregar os campos.'))
-  }, [showError])
+  }, [showError, authChecked])
 
   async function handleSubmit(e: React.FormEvent) {
     e.preventDefault()
@@ -97,6 +96,8 @@ export default function NovoUsuarioPage() {
       showError('Erro: ' + (data?.error || 'Erro desconhecido'))
     }
   }
+
+  if (!authChecked) return null
 
   return (
     <main className="max-w-xl mx-auto px-4 py-8">

--- a/app/admin/usuarios/page.tsx
+++ b/app/admin/usuarios/page.tsx
@@ -21,15 +21,14 @@ interface Usuario {
 
 export default function UsuariosPage() {
   const { showError } = useToast()
-  const { user, pb, authChecked } = useAuthGuard(['coordenador'])
+  const { authChecked } = useAuthGuard(['coordenador'])
   const [usuarios, setUsuarios] = useState<Usuario[]>([])
   const [loading, setLoading] = useState(true)
   const [eventos, setEventos] = useState<Evento[]>([])
   const [eventoId, setEventoId] = useState('')
 
-  if (!authChecked) return null
-
   useEffect(() => {
+    if (!authChecked) return
     async function fetchUsuarios() {
       try {
         const token = localStorage.getItem('pb_token')
@@ -59,9 +58,10 @@ export default function UsuariosPage() {
     }
 
     fetchUsuarios()
-  }, [showError])
+  }, [showError, authChecked])
 
   useEffect(() => {
+    if (!authChecked) return
     async function fetchEventos() {
       try {
         const token = localStorage.getItem('pb_token')
@@ -85,7 +85,9 @@ export default function UsuariosPage() {
     }
 
     fetchEventos()
-  }, [])
+  }, [authChecked])
+
+  if (!authChecked) return null
 
   return (
     <main className="max-w-6xl mx-auto px-4 py-8">

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,5 +1,6 @@
 // app/layout.tsx
 import './globals.css'
+import type { CSSProperties } from 'react'
 import { AuthProvider } from '@/lib/context/AuthContext'
 import { ThemeProvider } from '@/lib/context/ThemeContext'
 import { ToastProvider } from '@/lib/context/ToastContext'
@@ -29,13 +30,22 @@ export default async function RootLayout({
 }) {
   const cfg = await fetchTenantConfig()
   const shades = generatePrimaryShades(cfg.primaryColor)
-  const preload = `window.__TENANT_CONFIG__=${JSON.stringify(cfg)};(function(){const s=document.documentElement.style;s.setProperty('--font-body','${cfg.font}');s.setProperty('--font-heading','${cfg.font}');s.setProperty('--logo-url','${cfg.logoUrl}');s.setProperty('--accent','${cfg.primaryColor}');s.setProperty('--accent-900','${shades['900']}');${Object.entries(
-    shades,
-  )
-    .map(([k, v]) => `s.setProperty('--primary-${k}','${v}');`)
-    .join('')}})();`
+
+  const htmlStyle = {
+    '--font-body': cfg.font,
+    '--font-heading': cfg.font,
+    '--logo-url': cfg.logoUrl,
+    '--accent': cfg.primaryColor,
+    '--accent-900': shades['900'],
+    ...Object.fromEntries(
+      Object.entries(shades).map(([k, v]) => [`--primary-${k}`, v]),
+    ),
+  } as CSSProperties
+
+  const preload = `window.__TENANT_CONFIG__=${JSON.stringify(cfg)};`
+
   return (
-    <html lang="pt-BR">
+    <html lang="pt-BR" style={htmlStyle}>
       <head>
         <script dangerouslySetInnerHTML={{ __html: preload }} />
       </head>

--- a/logs/ERR_LOG.md
+++ b/logs/ERR_LOG.md
@@ -163,3 +163,4 @@
 ## [2025-06-20] Corrigido erro 'Cannot read properties of undefined (reading 'replace')' em ConfiguracoesPage ajustando funcao isColorLight - dev - 3d07f5f
 
 ## [2025-06-20] Caminho incorreto dos testes de acessibilidade corrigido em package.json - dev - 01d4b28
+## [2025-06-20] Corrigido erro de hidratação e ordem de hooks em UsuariosPage e Layout - dev - 30c0f0f


### PR DESCRIPTION
## Summary
- avoid hydration mismatch by applying CSS vars on the server
- respect hooks order in UsuariosPage
- log the fix in ERR_LOG
- fix lint issues from unused vars and conditional hooks across admin pages

## Testing
- `npm run lint` *(fails: next not found)*
- `npm run build` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_6855dac401e8832c8dca7c368b52b2f5