### PR TITLE
Add tenant preload docs

### DIFF
--- a/docs/design-system.md
+++ b/docs/design-system.md
@@ -198,3 +198,9 @@ Quando `updateConfig` é chamado, os dados são enviados para essa mesma rota e 
 As personalizações são persistidas nos campos `logo_url`, `cor_primary`, `font` e `confirma_inscricoes` da coleção `clientes_config`, evitando perda de dados entre dispositivos.
 
 Além de definir `--accent` e `--logo-url`, o provedor gera uma paleta HSL e expõe as variáveis `--primary-50` … `--primary-900`. Essas variáveis são mapeadas para classes Tailwind (`bg-primary-*`, `text-primary-*`), eliminando a necessidade de usar `bg-[var(--primary-600)]` ou `text-[var(--primary-500)]`.
+
+### SSR e Preload de Configuracoes
+
+Para evitar flashes de estilo no carregamento, o `app/layout.tsx` insere as variáveis CSS diretamente na tag `<html>` e serializa o objeto `window.__TENANT_CONFIG__`. Esse preload é executado antes da primeira pintura e garante que o `TenantProvider` utilize as mesmas cores e fontes durante a hidratação.
+
+O valor carregado vem da função `fetchTenantConfig`, que depende do cabeçalho `x-tenant-id` inserido pelo [`middleware.ts`](../middleware.ts). Assim cada cliente recebe o tema correto já na resposta do servidor.

--- a/logs/DOC_LOG.md
+++ b/logs/DOC_LOG.md
@@ -321,3 +321,5 @@
 ## [2025-06-20] README orienta executar `npm install` antes de `npm run lint` ou `npm run build`. Workflow CI passa a instalar dependências antes dos scripts. Lint e build executados.
 
 ## [2025-07-15] Metadata dinamico nas rotas publicas da loja e do blog com generateMetadata.
+
+## [2025-06-20] Adicionada seção sobre SSR e preload no design system, explicando `window.__TENANT_CONFIG__` e o cabeçalho `x-tenant-id`. Impacto: documentação mais completa.


### PR DESCRIPTION
## Summary
- describe SSR and window.__TENANT_CONFIG__ preload in design system docs
- reference middleware.ts that sets the `x-tenant-id` header
- log documentation update

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6855eb6baf94832cb86b2d8987d8d511