### PR TITLE
Configure vitest setup

### DIFF
--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -15,5 +15,6 @@ export default defineConfig({
     include: ['__tests__/**/*.{test.ts,test.tsx}'],
     environment: 'jsdom',
     globals: true,
+    setupFiles: './vitest.setup.ts',
   },
 })

--- a/vitest.setup.ts
+++ b/vitest.setup.ts
@@ -1,0 +1,3 @@
+import { expect } from 'vitest'
+import matchers from '@testing-library/jest-dom/matchers'
+expect.extend(matchers)


### PR DESCRIPTION
## Summary
- add custom vitest setup file with jest-dom matchers
- register vitest.setup.ts in vitest config

## Testing
- `npm run lint`
- `npm run build`
- `npm run test:ci` *(fails: Cannot convert undefined or null to object)*

------
https://chatgpt.com/codex/tasks/task_e_6855ea883ea4832cba3204bb4f499980