### PR TITLE
Add multi-tenant variants to stories

### DIFF
--- a/logs/DOC_LOG.md
+++ b/logs/DOC_LOG.md
@@ -321,3 +321,5 @@
 ## [2025-06-20] README orienta executar `npm install` antes de `npm run lint` ou `npm run build`. Workflow CI passa a instalar dependências antes dos scripts. Lint e build executados.
 
 ## [2025-07-15] Metadata dinamico nas rotas publicas da loja e do blog com generateMetadata.
+
+## [2025-07-16] Adicionadas variantes TemaDinamico em todas as stories demonstrando configuracoes multi-tenant.

--- a/stories/AdminHeader.stories.tsx
+++ b/stories/AdminHeader.stories.tsx
@@ -1,3 +1,4 @@
+import { TenantProvider } from '../lib/context/TenantContext'
 import type { Meta, StoryObj } from '@storybook/nextjs'
 import { within, expect } from 'storybook/test'
 import Header from '../components/templates/HeaderAdmin'
@@ -27,4 +28,31 @@ export const Default: Story = {
     const canvas = within(canvasElement)
     await expect(canvas.getByRole('banner')).toBeInTheDocument()
   },
+}
+
+export const TemaDinamico: Story = {
+  render: (args) => (
+    <div className=\"space-y-4\">
+      <TenantProvider
+        initialConfig={{
+          primaryColor: '#2563eb',
+          font: 'var(--font-geist)',
+          logoUrl: '/img/logo_umadeus_branco.png',
+          confirmaInscricoes: false,
+        }}
+      >
+        <Header {...args} />
+      </TenantProvider>
+      <TenantProvider
+        initialConfig={{
+          primaryColor: '#dc2626',
+          font: 'var(--font-geist)',
+          logoUrl: '/img/logo_umadeus_branco.png',
+          confirmaInscricoes: false,
+        }}
+      >
+        <Header {...args} />
+      </TenantProvider>
+    </div>
+  ),
 }

--- a/stories/AuthModal.stories.tsx
+++ b/stories/AuthModal.stories.tsx
@@ -1,3 +1,4 @@
+import { TenantProvider } from '../lib/context/TenantContext'
 import type { Meta, StoryObj } from '@storybook/nextjs'
 import AuthModal from '../app/components/AuthModal'
 import { AuthProvider } from '../lib/context/AuthContext'
@@ -27,4 +28,31 @@ export const Default: Story = {
     open: true,
     onClose: () => {},
   },
+}
+
+export const TemaDinamico: Story = {
+  render: (args) => (
+    <div className=\"space-y-4\">
+      <TenantProvider
+        initialConfig={{
+          primaryColor: '#2563eb',
+          font: 'var(--font-geist)',
+          logoUrl: '/img/logo_umadeus_branco.png',
+          confirmaInscricoes: false,
+        }}
+      >
+        <AuthModal {...args} />
+      </TenantProvider>
+      <TenantProvider
+        initialConfig={{
+          primaryColor: '#dc2626',
+          font: 'var(--font-geist)',
+          logoUrl: '/img/logo_umadeus_branco.png',
+          confirmaInscricoes: false,
+        }}
+      >
+        <AuthModal {...args} />
+      </TenantProvider>
+    </div>
+  ),
 }

--- a/stories/BackToTopButton.stories.tsx
+++ b/stories/BackToTopButton.stories.tsx
@@ -1,3 +1,4 @@
+import { TenantProvider } from '../lib/context/TenantContext'
 import type { Meta, StoryObj } from '@storybook/nextjs'
 import { within, expect } from 'storybook/test'
 import BackToTopButton from '../app/admin/components/BackToTopButton'
@@ -24,4 +25,31 @@ export const Default: Story = {
       canvas.getByRole('button', { name: /voltar ao topo/i }),
     ).toBeInTheDocument()
   },
+}
+
+export const TemaDinamico: Story = {
+  render: (args) => (
+    <div className=\"space-y-4\">
+      <TenantProvider
+        initialConfig={{
+          primaryColor: '#2563eb',
+          font: 'var(--font-geist)',
+          logoUrl: '/img/logo_umadeus_branco.png',
+          confirmaInscricoes: false,
+        }}
+      >
+        <BackToTopButton {...args} />
+      </TenantProvider>
+      <TenantProvider
+        initialConfig={{
+          primaryColor: '#dc2626',
+          font: 'var(--font-geist)',
+          logoUrl: '/img/logo_umadeus_branco.png',
+          confirmaInscricoes: false,
+        }}
+      >
+        <BackToTopButton {...args} />
+      </TenantProvider>
+    </div>
+  ),
 }

--- a/stories/BankAccountModal.stories.tsx
+++ b/stories/BankAccountModal.stories.tsx
@@ -1,3 +1,4 @@
+import { TenantProvider } from '../lib/context/TenantContext'
 import type { Meta, StoryObj } from '@storybook/nextjs'
 import { within, expect, fn } from 'storybook/test'
 import BankAccountModal from '@/app/admin/financeiro/transferencias/modals/BankAccountModal'
@@ -32,4 +33,31 @@ export const Default: Story = {
     const canvas = within(canvasElement)
     await expect(canvas.getByText(/Adicionar Conta/i)).toBeInTheDocument()
   },
+}
+
+export const TemaDinamico: Story = {
+  render: (args) => (
+    <div className=\"space-y-4\">
+      <TenantProvider
+        initialConfig={{
+          primaryColor: '#2563eb',
+          font: 'var(--font-geist)',
+          logoUrl: '/img/logo_umadeus_branco.png',
+          confirmaInscricoes: false,
+        }}
+      >
+        <BankAccountModal {...args} />
+      </TenantProvider>
+      <TenantProvider
+        initialConfig={{
+          primaryColor: '#dc2626',
+          font: 'var(--font-geist)',
+          logoUrl: '/img/logo_umadeus_branco.png',
+          confirmaInscricoes: false,
+        }}
+      >
+        <BankAccountModal {...args} />
+      </TenantProvider>
+    </div>
+  ),
 }

--- a/stories/BlogHeroCarousel.stories.tsx
+++ b/stories/BlogHeroCarousel.stories.tsx
@@ -1,3 +1,4 @@
+import { TenantProvider } from '../lib/context/TenantContext'
 import type { Meta, StoryObj } from '@storybook/nextjs'
 import BlogHeroCarousel from '@/components/organisms/BlogHeroCarousel'
 import React, { useEffect } from 'react'
@@ -82,4 +83,31 @@ export const Default: Story = {
       </FetchWrapper>
     )
   },
+}
+
+export const TemaDinamico: Story = {
+  render: (args) => (
+    <div className=\"space-y-4\">
+      <TenantProvider
+        initialConfig={{
+          primaryColor: '#2563eb',
+          font: 'var(--font-geist)',
+          logoUrl: '/img/logo_umadeus_branco.png',
+          confirmaInscricoes: false,
+        }}
+      >
+        <BlogHeroCarousel {...args} />
+      </TenantProvider>
+      <TenantProvider
+        initialConfig={{
+          primaryColor: '#dc2626',
+          font: 'var(--font-geist)',
+          logoUrl: '/img/logo_umadeus_branco.png',
+          confirmaInscricoes: false,
+        }}
+      >
+        <BlogHeroCarousel {...args} />
+      </TenantProvider>
+    </div>
+  ),
 }

--- a/stories/BlogSidebar.stories.tsx
+++ b/stories/BlogSidebar.stories.tsx
@@ -1,3 +1,4 @@
+import { TenantProvider } from '../lib/context/TenantContext'
 import type { Meta, StoryObj } from '@storybook/nextjs'
 import BlogSidebar from '@/components/organisms/BlogSidebar'
 import React, { useEffect } from 'react'
@@ -74,4 +75,31 @@ export const Default: Story = {
       </FetchWrapper>
     )
   },
+}
+
+export const TemaDinamico: Story = {
+  render: (args) => (
+    <div className=\"space-y-4\">
+      <TenantProvider
+        initialConfig={{
+          primaryColor: '#2563eb',
+          font: 'var(--font-geist)',
+          logoUrl: '/img/logo_umadeus_branco.png',
+          confirmaInscricoes: false,
+        }}
+      >
+        <BlogSidebar {...args} />
+      </TenantProvider>
+      <TenantProvider
+        initialConfig={{
+          primaryColor: '#dc2626',
+          font: 'var(--font-geist)',
+          logoUrl: '/img/logo_umadeus_branco.png',
+          confirmaInscricoes: false,
+        }}
+      >
+        <BlogSidebar {...args} />
+      </TenantProvider>
+    </div>
+  ),
 }

--- a/stories/CartButton.stories.tsx
+++ b/stories/CartButton.stories.tsx
@@ -1,3 +1,4 @@
+import { TenantProvider } from '../lib/context/TenantContext'
 import type { Meta, StoryObj } from '@storybook/nextjs'
 import CartButton from '../app/components/CartButton'
 import { CartProvider } from '../lib/context/CartContext'
@@ -23,3 +24,30 @@ export default meta
 type Story = StoryObj<typeof meta>
 
 export const Default: Story = {}
+
+export const TemaDinamico: Story = {
+  render: (args) => (
+    <div className=\"space-y-4\">
+      <TenantProvider
+        initialConfig={{
+          primaryColor: '#2563eb',
+          font: 'var(--font-geist)',
+          logoUrl: '/img/logo_umadeus_branco.png',
+          confirmaInscricoes: false,
+        }}
+      >
+        <CartButton {...args} />
+      </TenantProvider>
+      <TenantProvider
+        initialConfig={{
+          primaryColor: '#dc2626',
+          font: 'var(--font-geist)',
+          logoUrl: '/img/logo_umadeus_branco.png',
+          confirmaInscricoes: false,
+        }}
+      >
+        <CartButton {...args} />
+      </TenantProvider>
+    </div>
+  ),
+}

--- a/stories/CartPreview.stories.tsx
+++ b/stories/CartPreview.stories.tsx
@@ -1,3 +1,4 @@
+import { TenantProvider } from '../lib/context/TenantContext'
 import type { Meta, StoryObj } from '@storybook/nextjs'
 import CartPreview from '../app/components/CartPreview'
 import { CartProvider } from '../lib/context/CartContext'
@@ -22,3 +23,30 @@ export default meta
 type Story = StoryObj<typeof meta>
 
 export const Default: Story = {}
+
+export const TemaDinamico: Story = {
+  render: (args) => (
+    <div className=\"space-y-4\">
+      <TenantProvider
+        initialConfig={{
+          primaryColor: '#2563eb',
+          font: 'var(--font-geist)',
+          logoUrl: '/img/logo_umadeus_branco.png',
+          confirmaInscricoes: false,
+        }}
+      >
+        <CartPreview {...args} />
+      </TenantProvider>
+      <TenantProvider
+        initialConfig={{
+          primaryColor: '#dc2626',
+          font: 'var(--font-geist)',
+          logoUrl: '/img/logo_umadeus_branco.png',
+          confirmaInscricoes: false,
+        }}
+      >
+        <CartPreview {...args} />
+      </TenantProvider>
+    </div>
+  ),
+}

--- a/stories/DashboardAnalytics.stories.tsx
+++ b/stories/DashboardAnalytics.stories.tsx
@@ -1,3 +1,4 @@
+import { TenantProvider } from '../lib/context/TenantContext'
 import type { Meta, StoryObj } from '@storybook/nextjs'
 import { within, expect } from 'storybook/test'
 import DashboardAnalytics from '../app/admin/components/DashboardAnalytics'
@@ -91,4 +92,31 @@ export const SemFinanceiro: Story = {
     ],
     mostrarFinanceiro: false,
   },
+}
+
+export const TemaDinamico: Story = {
+  render: (args) => (
+    <div className=\"space-y-4\">
+      <TenantProvider
+        initialConfig={{
+          primaryColor: '#2563eb',
+          font: 'var(--font-geist)',
+          logoUrl: '/img/logo_umadeus_branco.png',
+          confirmaInscricoes: false,
+        }}
+      >
+        <DashboardAnalytics {...args} />
+      </TenantProvider>
+      <TenantProvider
+        initialConfig={{
+          primaryColor: '#dc2626',
+          font: 'var(--font-geist)',
+          logoUrl: '/img/logo_umadeus_branco.png',
+          confirmaInscricoes: false,
+        }}
+      >
+        <DashboardAnalytics {...args} />
+      </TenantProvider>
+    </div>
+  ),
 }

--- a/stories/DashboardResumo.stories.tsx
+++ b/stories/DashboardResumo.stories.tsx
@@ -1,3 +1,4 @@
+import { TenantProvider } from '../lib/context/TenantContext'
 import type { Meta, StoryObj } from '@storybook/nextjs'
 import { within, expect, fn } from 'storybook/test'
 import DashboardResumo from '../app/admin/dashboard/components/DashboardResumo'
@@ -104,4 +105,31 @@ export const Default: Story = {
     const canvas = within(canvasElement)
     await expect(canvas.getByText(/Total de Inscrições/i)).toBeInTheDocument()
   },
+}
+
+export const TemaDinamico: Story = {
+  render: (args) => (
+    <div className=\"space-y-4\">
+      <TenantProvider
+        initialConfig={{
+          primaryColor: '#2563eb',
+          font: 'var(--font-geist)',
+          logoUrl: '/img/logo_umadeus_branco.png',
+          confirmaInscricoes: false,
+        }}
+      >
+        <DashboardResumo {...args} />
+      </TenantProvider>
+      <TenantProvider
+        initialConfig={{
+          primaryColor: '#dc2626',
+          font: 'var(--font-geist)',
+          logoUrl: '/img/logo_umadeus_branco.png',
+          confirmaInscricoes: false,
+        }}
+      >
+        <DashboardResumo {...args} />
+      </TenantProvider>
+    </div>
+  ),
 }

--- a/stories/Footer.stories.tsx
+++ b/stories/Footer.stories.tsx
@@ -1,3 +1,4 @@
+import { TenantProvider } from '../lib/context/TenantContext'
 import type { Meta, StoryObj } from '@storybook/nextjs'
 import { within, expect } from 'storybook/test'
 import Footer from '../components/templates/Footer'
@@ -27,4 +28,31 @@ export const Default: Story = {
     const canvas = within(canvasElement)
     await expect(canvas.getByText(/UMADEUS/i)).toBeInTheDocument()
   },
+}
+
+export const TemaDinamico: Story = {
+  render: (args) => (
+    <div className=\"space-y-4\">
+      <TenantProvider
+        initialConfig={{
+          primaryColor: '#2563eb',
+          font: 'var(--font-geist)',
+          logoUrl: '/img/logo_umadeus_branco.png',
+          confirmaInscricoes: false,
+        }}
+      >
+        <Footer {...args} />
+      </TenantProvider>
+      <TenantProvider
+        initialConfig={{
+          primaryColor: '#dc2626',
+          font: 'var(--font-geist)',
+          logoUrl: '/img/logo_umadeus_branco.png',
+          confirmaInscricoes: false,
+        }}
+      >
+        <Footer {...args} />
+      </TenantProvider>
+    </div>
+  ),
 }

--- a/stories/Header.stories.tsx
+++ b/stories/Header.stories.tsx
@@ -1,3 +1,4 @@
+import { TenantProvider } from '../lib/context/TenantContext'
 import type { Meta, StoryObj } from '@storybook/nextjs'
 import { within, expect } from 'storybook/test'
 import Header from '../components/templates/Header'
@@ -30,4 +31,31 @@ export const Visitor: Story = {
       canvas.getByRole('link', { name: /acessar sua conta/i }),
     ).toBeInTheDocument()
   },
+}
+
+export const TemaDinamico: Story = {
+  render: (args) => (
+    <div className=\"space-y-4\">
+      <TenantProvider
+        initialConfig={{
+          primaryColor: '#2563eb',
+          font: 'var(--font-geist)',
+          logoUrl: '/img/logo_umadeus_branco.png',
+          confirmaInscricoes: false,
+        }}
+      >
+        <Header {...args} />
+      </TenantProvider>
+      <TenantProvider
+        initialConfig={{
+          primaryColor: '#dc2626',
+          font: 'var(--font-geist)',
+          logoUrl: '/img/logo_umadeus_branco.png',
+          confirmaInscricoes: false,
+        }}
+      >
+        <Header {...args} />
+      </TenantProvider>
+    </div>
+  ),
 }

--- a/stories/LayoutWrapper.stories.tsx
+++ b/stories/LayoutWrapper.stories.tsx
@@ -1,3 +1,4 @@
+import { TenantProvider } from '../lib/context/TenantContext'
 import type { Meta, StoryObj } from '@storybook/nextjs'
 import { within, expect } from 'storybook/test'
 import LayoutWrapper from '../components/templates/LayoutWrapperAdmin'
@@ -38,4 +39,31 @@ export const Default: Story = {
     const canvas = within(canvasElement)
     await expect(canvas.getByText(args.children as string)).toBeInTheDocument()
   },
+}
+
+export const TemaDinamico: Story = {
+  render: (args) => (
+    <div className=\"space-y-4\">
+      <TenantProvider
+        initialConfig={{
+          primaryColor: '#2563eb',
+          font: 'var(--font-geist)',
+          logoUrl: '/img/logo_umadeus_branco.png',
+          confirmaInscricoes: false,
+        }}
+      >
+        <LayoutWrapper {...args} />
+      </TenantProvider>
+      <TenantProvider
+        initialConfig={{
+          primaryColor: '#dc2626',
+          font: 'var(--font-geist)',
+          logoUrl: '/img/logo_umadeus_branco.png',
+          confirmaInscricoes: false,
+        }}
+      >
+        <LayoutWrapper {...args} />
+      </TenantProvider>
+    </div>
+  ),
 }

--- a/stories/ListaClientes.stories.tsx
+++ b/stories/ListaClientes.stories.tsx
@@ -1,3 +1,4 @@
+import { TenantProvider } from '../lib/context/TenantContext'
 import type { Meta, StoryObj } from '@storybook/nextjs'
 import { within, expect, fn } from 'storybook/test'
 import ListaClientes from '../app/admin/clientes/components/ListaClientes'
@@ -50,4 +51,31 @@ export const Default: Story = {
     const canvas = within(canvasElement)
     await expect(canvas.getByText(/João da Silva/i)).toBeInTheDocument()
   },
+}
+
+export const TemaDinamico: Story = {
+  render: (args) => (
+    <div className=\"space-y-4\">
+      <TenantProvider
+        initialConfig={{
+          primaryColor: '#2563eb',
+          font: 'var(--font-geist)',
+          logoUrl: '/img/logo_umadeus_branco.png',
+          confirmaInscricoes: false,
+        }}
+      >
+        <ListaClientes {...args} />
+      </TenantProvider>
+      <TenantProvider
+        initialConfig={{
+          primaryColor: '#dc2626',
+          font: 'var(--font-geist)',
+          logoUrl: '/img/logo_umadeus_branco.png',
+          confirmaInscricoes: false,
+        }}
+      >
+        <ListaClientes {...args} />
+      </TenantProvider>
+    </div>
+  ),
 }

--- a/stories/LoadingOverlay.stories.tsx
+++ b/stories/LoadingOverlay.stories.tsx
@@ -1,3 +1,4 @@
+import { TenantProvider } from '../lib/context/TenantContext'
 import type { Meta, StoryObj } from '@storybook/nextjs'
 import { useState } from 'react'
 import { within, userEvent, expect } from 'storybook/test'
@@ -36,4 +37,31 @@ export const Default: Story = {
     await userEvent.click(toggle)
     await expect(canvas.getByText(args.text as string)).toBeInTheDocument()
   },
+}
+
+export const TemaDinamico: Story = {
+  render: (args) => (
+    <div className=\"space-y-4\">
+      <TenantProvider
+        initialConfig={{
+          primaryColor: '#2563eb',
+          font: 'var(--font-geist)',
+          logoUrl: '/img/logo_umadeus_branco.png',
+          confirmaInscricoes: false,
+        }}
+      >
+        <LoadingOverlay {...args} />
+      </TenantProvider>
+      <TenantProvider
+        initialConfig={{
+          primaryColor: '#dc2626',
+          font: 'var(--font-geist)',
+          logoUrl: '/img/logo_umadeus_branco.png',
+          confirmaInscricoes: false,
+        }}
+      >
+        <LoadingOverlay {...args} />
+      </TenantProvider>
+    </div>
+  ),
 }

--- a/stories/LoginForm.stories.tsx
+++ b/stories/LoginForm.stories.tsx
@@ -1,3 +1,4 @@
+import { TenantProvider } from '../lib/context/TenantContext'
 import type { Meta, StoryObj } from '@storybook/nextjs'
 import { within, expect } from 'storybook/test'
 import LoginForm from '../app/components/LoginForm'
@@ -29,4 +30,31 @@ export const Default: Story = {
       canvas.getByRole('button', { name: /entrar/i }),
     ).toBeInTheDocument()
   },
+}
+
+export const TemaDinamico: Story = {
+  render: (args) => (
+    <div className=\"space-y-4\">
+      <TenantProvider
+        initialConfig={{
+          primaryColor: '#2563eb',
+          font: 'var(--font-geist)',
+          logoUrl: '/img/logo_umadeus_branco.png',
+          confirmaInscricoes: false,
+        }}
+      >
+        <LoginForm {...args} />
+      </TenantProvider>
+      <TenantProvider
+        initialConfig={{
+          primaryColor: '#dc2626',
+          font: 'var(--font-geist)',
+          logoUrl: '/img/logo_umadeus_branco.png',
+          confirmaInscricoes: false,
+        }}
+      >
+        <LoginForm {...args} />
+      </TenantProvider>
+    </div>
+  ),
 }

--- a/stories/ModalAnimated.stories.tsx
+++ b/stories/ModalAnimated.stories.tsx
@@ -1,3 +1,4 @@
+import { TenantProvider } from '../lib/context/TenantContext'
 import type { Meta, StoryObj } from '@storybook/nextjs'
 import { useState } from 'react'
 import * as Dialog from '@radix-ui/react-dialog'
@@ -53,4 +54,31 @@ export const Default: Story = {
       canvas.queryByText(/Conteúdo do modal/i),
     ).not.toBeInTheDocument()
   },
+}
+
+export const TemaDinamico: Story = {
+  render: (args) => (
+    <div className=\"space-y-4\">
+      <TenantProvider
+        initialConfig={{
+          primaryColor: '#2563eb',
+          font: 'var(--font-geist)',
+          logoUrl: '/img/logo_umadeus_branco.png',
+          confirmaInscricoes: false,
+        }}
+      >
+        <ModalAnimated {...args} />
+      </TenantProvider>
+      <TenantProvider
+        initialConfig={{
+          primaryColor: '#dc2626',
+          font: 'var(--font-geist)',
+          logoUrl: '/img/logo_umadeus_branco.png',
+          confirmaInscricoes: false,
+        }}
+      >
+        <ModalAnimated {...args} />
+      </TenantProvider>
+    </div>
+  ),
 }

--- a/stories/ModalEditarPedido.stories.tsx
+++ b/stories/ModalEditarPedido.stories.tsx
@@ -1,3 +1,4 @@
+import { TenantProvider } from '../lib/context/TenantContext'
 import type { Meta, StoryObj } from '@storybook/nextjs'
 import { within, expect, fn } from 'storybook/test'
 import ModalEditarPedido from '../app/admin/pedidos/componentes/ModalEditarPedido'
@@ -42,4 +43,31 @@ export const Default: Story = {
     const canvas = within(canvasElement)
     await expect(canvas.getByText(/Editar Pedido/i)).toBeInTheDocument()
   },
+}
+
+export const TemaDinamico: Story = {
+  render: (args) => (
+    <div className=\"space-y-4\">
+      <TenantProvider
+        initialConfig={{
+          primaryColor: '#2563eb',
+          font: 'var(--font-geist)',
+          logoUrl: '/img/logo_umadeus_branco.png',
+          confirmaInscricoes: false,
+        }}
+      >
+        <ModalEditarPedido {...args} />
+      </TenantProvider>
+      <TenantProvider
+        initialConfig={{
+          primaryColor: '#dc2626',
+          font: 'var(--font-geist)',
+          logoUrl: '/img/logo_umadeus_branco.png',
+          confirmaInscricoes: false,
+        }}
+      >
+        <ModalEditarPedido {...args} />
+      </TenantProvider>
+    </div>
+  ),
 }

--- a/stories/ModalEditarPerfil.stories.tsx
+++ b/stories/ModalEditarPerfil.stories.tsx
@@ -1,3 +1,4 @@
+import { TenantProvider } from '../lib/context/TenantContext'
 import type { Meta, StoryObj } from '@storybook/nextjs'
 import { within, expect, fn } from 'storybook/test'
 import ModalEditarPerfil from '../app/admin/perfil/components/ModalEditarPerfil'
@@ -31,4 +32,31 @@ export const Default: Story = {
     await expect(canvas.getByText(/Editar Perfil/i)).toBeInTheDocument()
     await expect(canvas.getByLabelText(/nome completo/i)).toBeInTheDocument()
   },
+}
+
+export const TemaDinamico: Story = {
+  render: (args) => (
+    <div className=\"space-y-4\">
+      <TenantProvider
+        initialConfig={{
+          primaryColor: '#2563eb',
+          font: 'var(--font-geist)',
+          logoUrl: '/img/logo_umadeus_branco.png',
+          confirmaInscricoes: false,
+        }}
+      >
+        <ModalEditarPerfil {...args} />
+      </TenantProvider>
+      <TenantProvider
+        initialConfig={{
+          primaryColor: '#dc2626',
+          font: 'var(--font-geist)',
+          logoUrl: '/img/logo_umadeus_branco.png',
+          confirmaInscricoes: false,
+        }}
+      >
+        <ModalEditarPerfil {...args} />
+      </TenantProvider>
+    </div>
+  ),
 }

--- a/stories/ModalVisualizarPedido.stories.tsx
+++ b/stories/ModalVisualizarPedido.stories.tsx
@@ -1,3 +1,4 @@
+import { TenantProvider } from '../lib/context/TenantContext'
 import type { Meta, StoryObj } from '@storybook/nextjs'
 import { within, expect, fn } from 'storybook/test'
 import ModalVisualizarPedido from '../app/admin/inscricoes/componentes/ModalVisualizarPedido'
@@ -28,4 +29,31 @@ export const Default: Story = {
     const canvas = within(canvasElement)
     await expect(canvas.getByText(/Detalhes do Pedido/i)).toBeInTheDocument()
   },
+}
+
+export const TemaDinamico: Story = {
+  render: (args) => (
+    <div className=\"space-y-4\">
+      <TenantProvider
+        initialConfig={{
+          primaryColor: '#2563eb',
+          font: 'var(--font-geist)',
+          logoUrl: '/img/logo_umadeus_branco.png',
+          confirmaInscricoes: false,
+        }}
+      >
+        <ModalVisualizarPedido {...args} />
+      </TenantProvider>
+      <TenantProvider
+        initialConfig={{
+          primaryColor: '#dc2626',
+          font: 'var(--font-geist)',
+          logoUrl: '/img/logo_umadeus_branco.png',
+          confirmaInscricoes: false,
+        }}
+      >
+        <ModalVisualizarPedido {...args} />
+      </TenantProvider>
+    </div>
+  ),
 }

--- a/stories/NextPostButton.stories.tsx
+++ b/stories/NextPostButton.stories.tsx
@@ -1,3 +1,4 @@
+import { TenantProvider } from '../lib/context/TenantContext'
 import type { Meta, StoryObj } from '@storybook/nextjs'
 import NextPostButton from '@/components/molecules/NextPostButton'
 
@@ -17,3 +18,30 @@ export default meta
 type Story = StoryObj<typeof meta>
 
 export const Default: Story = {}
+
+export const TemaDinamico: Story = {
+  render: (args) => (
+    <div className=\"space-y-4\">
+      <TenantProvider
+        initialConfig={{
+          primaryColor: '#2563eb',
+          font: 'var(--font-geist)',
+          logoUrl: '/img/logo_umadeus_branco.png',
+          confirmaInscricoes: false,
+        }}
+      >
+        <NextPostButton {...args} />
+      </TenantProvider>
+      <TenantProvider
+        initialConfig={{
+          primaryColor: '#dc2626',
+          font: 'var(--font-geist)',
+          logoUrl: '/img/logo_umadeus_branco.png',
+          confirmaInscricoes: false,
+        }}
+      >
+        <NextPostButton {...args} />
+      </TenantProvider>
+    </div>
+  ),
+}

--- a/stories/NotificationBell.stories.tsx
+++ b/stories/NotificationBell.stories.tsx
@@ -1,3 +1,4 @@
+import { TenantProvider } from '../lib/context/TenantContext'
 import type { Meta, StoryObj } from '@storybook/nextjs'
 import { within, expect } from 'storybook/test'
 import NotificationBell from '../app/admin/components/NotificationBell'
@@ -29,4 +30,31 @@ export const Default: Story = {
       canvas.getByRole('button', { name: /notifica/i }),
     ).toBeInTheDocument()
   },
+}
+
+export const TemaDinamico: Story = {
+  render: (args) => (
+    <div className=\"space-y-4\">
+      <TenantProvider
+        initialConfig={{
+          primaryColor: '#2563eb',
+          font: 'var(--font-geist)',
+          logoUrl: '/img/logo_umadeus_branco.png',
+          confirmaInscricoes: false,
+        }}
+      >
+        <NotificationBell {...args} />
+      </TenantProvider>
+      <TenantProvider
+        initialConfig={{
+          primaryColor: '#dc2626',
+          font: 'var(--font-geist)',
+          logoUrl: '/img/logo_umadeus_branco.png',
+          confirmaInscricoes: false,
+        }}
+      >
+        <NotificationBell {...args} />
+      </TenantProvider>
+    </div>
+  ),
 }

--- a/stories/PostContentEditor.stories.tsx
+++ b/stories/PostContentEditor.stories.tsx
@@ -1,3 +1,4 @@
+import { TenantProvider } from '../lib/context/TenantContext'
 import type { Meta, StoryObj } from '@storybook/nextjs'
 import React, { useState } from 'react'
 import { fn } from 'storybook/test'
@@ -40,4 +41,31 @@ const Template = ({
 
 export const Default: Story = {
   render: (args) => <Template value={args.value} onChange={args.onChange} />,
+}
+
+export const TemaDinamico: Story = {
+  render: (args) => (
+    <div className=\"space-y-4\">
+      <TenantProvider
+        initialConfig={{
+          primaryColor: '#2563eb',
+          font: 'var(--font-geist)',
+          logoUrl: '/img/logo_umadeus_branco.png',
+          confirmaInscricoes: false,
+        }}
+      >
+        <PostContentEditor {...args} />
+      </TenantProvider>
+      <TenantProvider
+        initialConfig={{
+          primaryColor: '#dc2626',
+          font: 'var(--font-geist)',
+          logoUrl: '/img/logo_umadeus_branco.png',
+          confirmaInscricoes: false,
+        }}
+      >
+        <PostContentEditor {...args} />
+      </TenantProvider>
+    </div>
+  ),
 }

--- a/stories/PostPreviewToggle.stories.tsx
+++ b/stories/PostPreviewToggle.stories.tsx
@@ -1,3 +1,4 @@
+import { TenantProvider } from '../lib/context/TenantContext'
 import type { Meta, StoryObj } from '@storybook/nextjs'
 import { userEvent, within, expect } from 'storybook/test'
 import { useState } from 'react'
@@ -46,4 +47,31 @@ export const Default: Story = {
       canvas.getByRole('button', { name: /pré-visualizar/i }),
     ).toBeInTheDocument()
   },
+}
+
+export const TemaDinamico: Story = {
+  render: (args) => (
+    <div className=\"space-y-4\">
+      <TenantProvider
+        initialConfig={{
+          primaryColor: '#2563eb',
+          font: 'var(--font-geist)',
+          logoUrl: '/img/logo_umadeus_branco.png',
+          confirmaInscricoes: false,
+        }}
+      >
+        <Demo {...args} />
+      </TenantProvider>
+      <TenantProvider
+        initialConfig={{
+          primaryColor: '#dc2626',
+          font: 'var(--font-geist)',
+          logoUrl: '/img/logo_umadeus_branco.png',
+          confirmaInscricoes: false,
+        }}
+      >
+        <Demo {...args} />
+      </TenantProvider>
+    </div>
+  ),
 }

--- a/stories/PostSuggestions.stories.tsx
+++ b/stories/PostSuggestions.stories.tsx
@@ -1,3 +1,4 @@
+import { TenantProvider } from '../lib/context/TenantContext'
 import type { Meta, StoryObj } from '@storybook/nextjs'
 import PostSuggestions from '@/components/organisms/PostSuggestions'
 
@@ -46,3 +47,30 @@ export default meta
 type Story = StoryObj<typeof meta>
 
 export const Default: Story = {}
+
+export const TemaDinamico: Story = {
+  render: (args) => (
+    <div className=\"space-y-4\">
+      <TenantProvider
+        initialConfig={{
+          primaryColor: '#2563eb',
+          font: 'var(--font-geist)',
+          logoUrl: '/img/logo_umadeus_branco.png',
+          confirmaInscricoes: false,
+        }}
+      >
+        <PostSuggestions {...args} />
+      </TenantProvider>
+      <TenantProvider
+        initialConfig={{
+          primaryColor: '#dc2626',
+          font: 'var(--font-geist)',
+          logoUrl: '/img/logo_umadeus_branco.png',
+          confirmaInscricoes: false,
+        }}
+      >
+        <PostSuggestions {...args} />
+      </TenantProvider>
+    </div>
+  ),
+}

--- a/stories/ProdutosFiltrados.stories.tsx
+++ b/stories/ProdutosFiltrados.stories.tsx
@@ -1,3 +1,4 @@
+import { TenantProvider } from '../lib/context/TenantContext'
 import type { Meta, StoryObj } from '@storybook/nextjs'
 import ProdutosFiltrados from '../app/loja/produtos/ProdutosFiltrados'
 
@@ -30,3 +31,30 @@ export default meta
 export type Story = StoryObj<typeof meta>
 
 export const Default: Story = {}
+
+export const TemaDinamico: Story = {
+  render: (args) => (
+    <div className=\"space-y-4\">
+      <TenantProvider
+        initialConfig={{
+          primaryColor: '#2563eb',
+          font: 'var(--font-geist)',
+          logoUrl: '/img/logo_umadeus_branco.png',
+          confirmaInscricoes: false,
+        }}
+      >
+        <ProdutosFiltrados {...args} />
+      </TenantProvider>
+      <TenantProvider
+        initialConfig={{
+          primaryColor: '#dc2626',
+          font: 'var(--font-geist)',
+          logoUrl: '/img/logo_umadeus_branco.png',
+          confirmaInscricoes: false,
+        }}
+      >
+        <ProdutosFiltrados {...args} />
+      </TenantProvider>
+    </div>
+  ),
+}

--- a/stories/RedefinirSenhaModal.stories.tsx
+++ b/stories/RedefinirSenhaModal.stories.tsx
@@ -1,3 +1,4 @@
+import { TenantProvider } from '../lib/context/TenantContext'
 import type { Meta, StoryObj } from '@storybook/nextjs'
 import { within, expect, fn } from 'storybook/test'
 import RedefinirSenhaModal from '../app/admin/components/RedefinirSenhaModal'
@@ -30,4 +31,31 @@ export const Default: Story = {
     const canvas = within(canvasElement)
     await expect(canvas.getByText(/Redefinir senha/i)).toBeInTheDocument()
   },
+}
+
+export const TemaDinamico: Story = {
+  render: (args) => (
+    <div className=\"space-y-4\">
+      <TenantProvider
+        initialConfig={{
+          primaryColor: '#2563eb',
+          font: 'var(--font-geist)',
+          logoUrl: '/img/logo_umadeus_branco.png',
+          confirmaInscricoes: false,
+        }}
+      >
+        <RedefinirSenhaModal {...args} />
+      </TenantProvider>
+      <TenantProvider
+        initialConfig={{
+          primaryColor: '#dc2626',
+          font: 'var(--font-geist)',
+          logoUrl: '/img/logo_umadeus_branco.png',
+          confirmaInscricoes: false,
+        }}
+      >
+        <RedefinirSenhaModal {...args} />
+      </TenantProvider>
+    </div>
+  ),
 }

--- a/stories/SaldoCard.stories.tsx
+++ b/stories/SaldoCard.stories.tsx
@@ -1,3 +1,4 @@
+import { TenantProvider } from '../lib/context/TenantContext'
 import type { Meta, StoryObj } from '@storybook/nextjs'
 import SaldoCard from '../components/molecules/SaldoCard'
 
@@ -15,4 +16,31 @@ export const ComSaldo: Story = {}
 
 export const SemSaldo: Story = {
   args: { saldo: 0 },
+}
+
+export const TemaDinamico: Story = {
+  render: (args) => (
+    <div className=\"space-y-4\">
+      <TenantProvider
+        initialConfig={{
+          primaryColor: '#2563eb',
+          font: 'var(--font-geist)',
+          logoUrl: '/img/logo_umadeus_branco.png',
+          confirmaInscricoes: false,
+        }}
+      >
+        <SaldoCard {...args} />
+      </TenantProvider>
+      <TenantProvider
+        initialConfig={{
+          primaryColor: '#dc2626',
+          font: 'var(--font-geist)',
+          logoUrl: '/img/logo_umadeus_branco.png',
+          confirmaInscricoes: false,
+        }}
+      >
+        <SaldoCard {...args} />
+      </TenantProvider>
+    </div>
+  ),
 }

--- a/stories/SignUpForm.stories.tsx
+++ b/stories/SignUpForm.stories.tsx
@@ -1,3 +1,4 @@
+import { TenantProvider } from '../lib/context/TenantContext'
 import type { Meta, StoryObj } from '@storybook/nextjs'
 import { within, expect } from 'storybook/test'
 import SignUpForm from '../app/components/SignUpForm'
@@ -31,4 +32,31 @@ export const Default: Story = {
     ).toBeInTheDocument()
     await expect(canvas.getByLabelText(/nome completo/i)).toBeInTheDocument()
   },
+}
+
+export const TemaDinamico: Story = {
+  render: (args) => (
+    <div className=\"space-y-4\">
+      <TenantProvider
+        initialConfig={{
+          primaryColor: '#2563eb',
+          font: 'var(--font-geist)',
+          logoUrl: '/img/logo_umadeus_branco.png',
+          confirmaInscricoes: false,
+        }}
+      >
+        <SignUpForm {...args} />
+      </TenantProvider>
+      <TenantProvider
+        initialConfig={{
+          primaryColor: '#dc2626',
+          font: 'var(--font-geist)',
+          logoUrl: '/img/logo_umadeus_branco.png',
+          confirmaInscricoes: false,
+        }}
+      >
+        <SignUpForm {...args} />
+      </TenantProvider>
+    </div>
+  ),
 }

--- a/stories/SmoothTabs.stories.tsx
+++ b/stories/SmoothTabs.stories.tsx
@@ -1,3 +1,4 @@
+import { TenantProvider } from '../lib/context/TenantContext'
 import type { Meta, StoryObj } from '@storybook/nextjs'
 import SmoothTabs from '../components/molecules/SmoothTabs'
 import { within, userEvent, expect } from 'storybook/test'
@@ -29,4 +30,31 @@ export const Default: Story = {
     await userEvent.click(tab3)
     await expect(canvas.getByText('Conteúdo 3')).toBeInTheDocument()
   },
+}
+
+export const TemaDinamico: Story = {
+  render: (args) => (
+    <div className=\"space-y-4\">
+      <TenantProvider
+        initialConfig={{
+          primaryColor: '#2563eb',
+          font: 'var(--font-geist)',
+          logoUrl: '/img/logo_umadeus_branco.png',
+          confirmaInscricoes: false,
+        }}
+      >
+        <SmoothTabs {...args} />
+      </TenantProvider>
+      <TenantProvider
+        initialConfig={{
+          primaryColor: '#dc2626',
+          font: 'var(--font-geist)',
+          logoUrl: '/img/logo_umadeus_branco.png',
+          confirmaInscricoes: false,
+        }}
+      >
+        <SmoothTabs {...args} />
+      </TenantProvider>
+    </div>
+  ),
 }

--- a/stories/Spinner.stories.tsx
+++ b/stories/Spinner.stories.tsx
@@ -1,5 +1,6 @@
 import type { Meta, StoryObj } from '@storybook/nextjs'
 import Spinner from '../components/atoms/Spinner'
+import { TenantProvider } from '../lib/context/TenantContext'
 
 const meta = {
   title: 'Design System/Spinner',
@@ -19,4 +20,31 @@ export const CustomSize: Story = {
   args: {
     className: 'w-12 h-12 text-primary-500',
   },
+}
+
+export const TemaDinamico: Story = {
+  render: (args) => (
+    <div className=\"space-y-4\">
+      <TenantProvider
+        initialConfig={{
+          primaryColor: '#2563eb',
+          font: 'var(--font-geist)',
+          logoUrl: '/img/logo_umadeus_branco.png',
+          confirmaInscricoes: false,
+        }}
+      >
+        <Spinner {...args} />
+      </TenantProvider>
+      <TenantProvider
+        initialConfig={{
+          primaryColor: '#dc2626',
+          font: 'var(--font-geist)',
+          logoUrl: '/img/logo_umadeus_branco.png',
+          confirmaInscricoes: false,
+        }}
+      >
+        <Spinner {...args} />
+      </TenantProvider>
+    </div>
+  ),
 }

--- a/stories/TooltipIcon.stories.tsx
+++ b/stories/TooltipIcon.stories.tsx
@@ -1,3 +1,4 @@
+import { TenantProvider } from '../lib/context/TenantContext'
 import type { Meta, StoryObj } from '@storybook/nextjs'
 import { within, expect, userEvent } from 'storybook/test'
 import TooltipIcon from '../app/admin/components/TooltipIcon'
@@ -27,4 +28,31 @@ export const Default: Story = {
     await userEvent.hover(button)
     await expect(canvas.getByText(args.label)).toBeInTheDocument()
   },
+}
+
+export const TemaDinamico: Story = {
+  render: (args) => (
+    <div className=\"space-y-4\">
+      <TenantProvider
+        initialConfig={{
+          primaryColor: '#2563eb',
+          font: 'var(--font-geist)',
+          logoUrl: '/img/logo_umadeus_branco.png',
+          confirmaInscricoes: false,
+        }}
+      >
+        <TooltipIcon {...args} />
+      </TenantProvider>
+      <TenantProvider
+        initialConfig={{
+          primaryColor: '#dc2626',
+          font: 'var(--font-geist)',
+          logoUrl: '/img/logo_umadeus_branco.png',
+          confirmaInscricoes: false,
+        }}
+      >
+        <TooltipIcon {...args} />
+      </TenantProvider>
+    </div>
+  ),
 }

--- a/stories/TransferenciaForm.stories.tsx
+++ b/stories/TransferenciaForm.stories.tsx
@@ -1,3 +1,4 @@
+import { TenantProvider } from '../lib/context/TenantContext'
 import type { Meta, StoryObj } from '@storybook/nextjs'
 import { within, userEvent, expect } from 'storybook/test'
 import TransferenciaForm from '../app/admin/financeiro/transferencias/components/TransferenciaForm'
@@ -49,4 +50,31 @@ export const ErroTransferencia: Story = {
     await userEvent.click(canvas.getByRole('button', { name: /transferir/i }))
     await expect(canvas.getByText(/erro ao transferir/i)).toBeInTheDocument()
   },
+}
+
+export const TemaDinamico: Story = {
+  render: (args) => (
+    <div className=\"space-y-4\">
+      <TenantProvider
+        initialConfig={{
+          primaryColor: '#2563eb',
+          font: 'var(--font-geist)',
+          logoUrl: '/img/logo_umadeus_branco.png',
+          confirmaInscricoes: false,
+        }}
+      >
+        <TransferenciaForm {...args} />
+      </TenantProvider>
+      <TenantProvider
+        initialConfig={{
+          primaryColor: '#dc2626',
+          font: 'var(--font-geist)',
+          logoUrl: '/img/logo_umadeus_branco.png',
+          confirmaInscricoes: false,
+        }}
+      >
+        <TransferenciaForm {...args} />
+      </TenantProvider>
+    </div>
+  ),
 }


### PR DESCRIPTION
## Summary
- show multi-tenant tokens in every story
- note update in DOC_LOG

## Testing
- `npm run lint` *(fails: next not found)*
- `npm run build` *(fails: next not found)*
- `npm run build-storybook` *(fails: storybook not found)*

------
https://chatgpt.com/codex/tasks/task_e_6855eb750bc8832c9bf501770cba701d