### PR TITLE
Create shared PocketBase mock for tests

### DIFF
--- a/__tests__/api/camposRoute.test.ts
+++ b/__tests__/api/camposRoute.test.ts
@@ -1,12 +1,13 @@
 import { describe, it, expect, vi } from 'vitest'
 import { GET } from '../../app/api/campos/route'
 import { NextRequest } from 'next/server'
+import createPocketBaseMock from '../mocks/pocketbase'
 
 const getFullListMock = vi.fn().mockResolvedValue([{ id: '1', nome: 'Campo' }])
+const pb = createPocketBaseMock()
+pb.collection.mockReturnValue({ getFullList: getFullListMock })
 vi.mock('../../lib/pocketbase', () => ({
-  default: vi.fn(() => ({
-    collection: () => ({ getFullList: getFullListMock }),
-  })),
+  default: vi.fn(() => pb),
 }))
 
 vi.mock('../../lib/getTenantFromHost', () => ({

--- a/__tests__/api/produtoSlugRoute.test.ts
+++ b/__tests__/api/produtoSlugRoute.test.ts
@@ -1,12 +1,12 @@
 import { describe, it, expect, vi } from 'vitest'
 import { GET } from '../../app/api/produtos/[slug]/route'
 import { NextRequest } from 'next/server'
+import createPocketBaseMock from '../mocks/pocketbase'
 
+const pb = createPocketBaseMock()
+pb.collection.mockReturnValue({ getFirstListItem: vi.fn() })
 vi.mock('../../lib/pocketbase', () => ({
-  default: vi.fn(() => ({
-    collection: () => ({ getFirstListItem: vi.fn() }),
-    files: { getURL: vi.fn() },
-  })),
+  default: vi.fn(() => pb),
 }))
 
 vi.mock('../../lib/getTenantFromHost', () => ({

--- a/__tests__/api/produtosRoute.test.ts
+++ b/__tests__/api/produtosRoute.test.ts
@@ -1,13 +1,14 @@
 import { describe, it, expect, vi } from 'vitest'
 import { GET } from '../../app/api/produtos/route'
 import { NextRequest } from 'next/server'
+import createPocketBaseMock from '../mocks/pocketbase'
 
+const pb = createPocketBaseMock()
+pb.collection.mockReturnValue({
+  getFullList: vi.fn().mockRejectedValue(new Error('fail')),
+})
 vi.mock('../../lib/pocketbase', () => ({
-  default: vi.fn(() => ({
-    collection: () => ({
-      getFullList: vi.fn().mockRejectedValue(new Error('fail')),
-    }),
-  })),
+  default: vi.fn(() => pb),
 }))
 
 vi.mock('../../lib/products', () => ({

--- a/__tests__/api/registerRoute.test.ts
+++ b/__tests__/api/registerRoute.test.ts
@@ -1,14 +1,14 @@
 import { describe, it, expect, vi } from 'vitest'
 import { POST } from '../../app/api/register/route'
 import { NextRequest } from 'next/server'
+import createPocketBaseMock from '../mocks/pocketbase'
 
 const getOneMock = vi.fn().mockRejectedValue(new Error('not found'))
 const createMock = vi.fn().mockResolvedValue({ id: 'u1' })
-
+const pb = createPocketBaseMock()
+pb.collection.mockReturnValue({ getOne: getOneMock, create: createMock })
 vi.mock('../../lib/pocketbase', () => ({
-  default: vi.fn(() => ({
-    collection: () => ({ getOne: getOneMock, create: createMock }),
-  })),
+  default: vi.fn(() => pb),
 }))
 
 describe('POST /api/register', () => {

--- a/__tests__/bankAccounts.test.ts
+++ b/__tests__/bankAccounts.test.ts
@@ -15,6 +15,7 @@ import {
   type ClienteContaBancariaRecord,
 } from '../lib/bankAccounts'
 import type PocketBase from 'pocketbase'
+import createPocketBaseMock from './mocks/pocketbase'
 
 describe('searchBanks', () => {
   const env = process.env
@@ -61,9 +62,8 @@ describe('searchBanks', () => {
 describe('createBankAccount', () => {
   it('envia dados para pocketbase', async () => {
     const createMock = vi.fn().mockResolvedValue({ id: '1' })
-    const pb = {
-      collection: vi.fn(() => ({ create: createMock })),
-    } as unknown as PocketBase
+    const pb = createPocketBaseMock() as unknown as PocketBase
+    pb.collection.mockReturnValue({ create: createMock })
     await createBankAccount(
       pb,
       {
@@ -95,9 +95,8 @@ describe('createBankAccount', () => {
 
   it('inclui accountName no payload', async () => {
     const createMock = vi.fn().mockResolvedValue({ id: '1' })
-    const pb = {
-      collection: vi.fn(() => ({ create: createMock })),
-    } as unknown as PocketBase
+    const pb = createPocketBaseMock() as unknown as PocketBase
+    pb.collection.mockReturnValue({ create: createMock })
     await createBankAccount(
       pb,
       {
@@ -129,9 +128,8 @@ describe('createBankAccount', () => {
 describe('createPixKey', () => {
   it('chama a coleção clientes_pix', async () => {
     const createMock = vi.fn().mockResolvedValue({ id: '1' })
-    const pb = {
-      collection: vi.fn(() => ({ create: createMock })),
-    } as unknown as PocketBase
+    const pb = createPocketBaseMock() as unknown as PocketBase
+    pb.collection.mockReturnValue({ create: createMock })
     await createPixKey(
       pb,
       {
@@ -148,9 +146,8 @@ describe('createPixKey', () => {
 
   it('inclui usuario e cliente no payload', async () => {
     const createMock = vi.fn().mockResolvedValue({ id: '1' })
-    const pb = {
-      collection: vi.fn(() => ({ create: createMock })),
-    } as unknown as PocketBase
+    const pb = createPocketBaseMock() as unknown as PocketBase
+    pb.collection.mockReturnValue({ create: createMock })
     await createPixKey(
       pb,
       {
@@ -171,9 +168,8 @@ describe('createPixKey', () => {
 describe('getBankAccountsByTenant', () => {
   it('filtra por cliente', async () => {
     const listMock = vi.fn().mockResolvedValue([{ id: '1', cliente: 'cli1' }])
-    const pb = {
-      collection: vi.fn(() => ({ getFullList: listMock })),
-    } as unknown as PocketBase
+    const pb = createPocketBaseMock() as unknown as PocketBase
+    pb.collection.mockReturnValue({ getFullList: listMock })
     const contas = await getBankAccountsByTenant(pb, 'cli1')
     expect(pb.collection).toHaveBeenCalledWith('clientes_contas_bancarias')
     expect(listMock).toHaveBeenCalledWith({ filter: "cliente='cli1'" })
@@ -186,9 +182,8 @@ describe('getBankAccountsByTenant', () => {
       .mockResolvedValue([
         { id: '1', accountName: 'Conta', ownerName: 'Fulano' },
       ])
-    const pb = {
-      collection: vi.fn(() => ({ getFullList: listMock })),
-    } as unknown as PocketBase
+    const pb = createPocketBaseMock() as unknown as PocketBase
+    pb.collection.mockReturnValue({ getFullList: listMock })
     const contas = await getBankAccountsByTenant(pb, 'cli1')
     expectTypeOf(contas).toEqualTypeOf<ClienteContaBancariaRecord[]>()
     expect(contas[0].accountName).toBe('Conta')

--- a/__tests__/mocks/pocketbase.ts
+++ b/__tests__/mocks/pocketbase.ts
@@ -1,0 +1,17 @@
+import { vi } from 'vitest'
+
+export default function createPocketBaseMock() {
+  return {
+    collection: vi.fn(() => ({
+      create: vi.fn(),
+      update: vi.fn(),
+      getFullList: vi.fn(),
+      getList: vi.fn(),
+      getOne: vi.fn(),
+      getFirstListItem: vi.fn(),
+    })),
+    files: { getURL: vi.fn() },
+    admins: { authWithPassword: vi.fn() },
+    authStore: { save: vi.fn(), clear: vi.fn(), isValid: true },
+  }
+}


### PR DESCRIPTION
## Summary
- add shared PocketBase mock helper
- refactor bankAccounts and API route tests to use the helper

## Testing
- `npm run lint` *(fails: next not found)*
- `npm run build` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_6855ed4daaa0832c984a9e1ba4a04a5a