### PR TITLE
docs: highlight npm install before linting/building

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -5,6 +5,8 @@ Após clonar o repositório, execute `npm install` para instalar o **Next**, o *
 
 ## Validação de código
 
+Certifique-se de rodar `npm install` **antes** de executar `npm run lint` ou `npm run build`.
+
 Execute `npm run lint` antes de cada commit para garantir que não há problemas de lint.
 
 ## Atualização da documentação

--- a/README.md
+++ b/README.md
@@ -49,8 +49,9 @@ Consulte a [documentação de deploy do Next.js](https://nextjs.org/docs/app/bui
 
 ## Lint e boas práticas
 
+**Importante:** execute `npm install` **antes** de rodar `npm run lint` ou `npm run build` para que todas as dependências (como **Next** e **Vitest**) estejam instaladas.
+
 Execute `npm run lint` para verificar problemas de código. Evite o uso de `any` especificando tipos adequados e sempre inclua todas as dependências utilizadas dentro dos hooks `useEffect`.
-Antes de rodar `npm run lint`, `npm run build` ou `npm run test`, execute `npm install` para garantir que todos os pacotes (como **Next** e **Vitest**) estejam disponíveis.
 
 ## Funcionalidades Adicionais
 

--- a/logs/DOC_LOG.md
+++ b/logs/DOC_LOG.md
@@ -325,3 +325,5 @@
 ## [2025-06-20] Adicionada seção sobre SSR e preload no design system, explicando `window.__TENANT_CONFIG__` e o cabeçalho `x-tenant-id`. Impacto: documentação mais completa.
 
 ## [2025-06-20] Atualizado inventário de componentes com caminhos corretos e novo item InscricaoFormNoSSR. Lint e build executados mas falharam por 'next' ausente.
+
+## [2025-07-17] README e CONTRIBUTING destacam que `npm install` deve ser executado antes de `npm run lint` ou `npm run build`. Lint e build executados.


### PR DESCRIPTION
## Summary
- emphasize running `npm install` before `npm run lint` or `npm run build`
- highlight the same requirement in CONTRIBUTING guidelines
- log documentation updates

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6855ed522888832ca37aede405a4705b