### PR TITLE
Implement cookie-based PocketBase auth

### DIFF
--- a/app/admin/configuracoes/page.tsx
+++ b/app/admin/configuracoes/page.tsx
@@ -1,7 +1,6 @@
 'use client'
-import { useState, useRef, ChangeEvent, useCallback } from 'react'
+import { useState, useRef, ChangeEvent } from 'react'
 import { useTenant } from '@/lib/context/TenantContext'
-import { useAuthContext } from '@/lib/context/AuthContext'
 import { useToast } from '@/lib/context/ToastContext'
 import Image from 'next/image'
 import { Check } from 'lucide-react'
@@ -76,17 +75,8 @@ const fontes = [
 
 export default function ConfiguracoesPage() {
   const { config, updateConfig } = useTenant()
-  const { user: ctxUser } = useAuthContext()
   const { showSuccess, showError } = useToast()
   const { authChecked } = useAuthGuard(['coordenador'])
-  const getAuth = useCallback(() => {
-    const token =
-      typeof window !== 'undefined' ? localStorage.getItem('pb_token') : null
-    const raw =
-      typeof window !== 'undefined' ? localStorage.getItem('pb_user') : null
-    const user = raw ? JSON.parse(raw) : ctxUser
-    return { token, user } as const
-  }, [ctxUser])
   const [font, setFont] = useState(config.font)
   const [primaryColor, setPrimaryColor] = useState(config.primaryColor)
   const [logoUrl, setLogoUrl] = useState(config.logoUrl || '')
@@ -142,19 +132,11 @@ export default function ConfiguracoesPage() {
       return
     }
 
-    const { token, user } = getAuth()
-    if (!token || !user) {
-      showError('Erro ao salvar configurações')
-      return
-    }
-
     try {
       const res = await fetch('/admin/api/configuracoes', {
         method: 'PUT',
         headers: {
           'Content-Type': 'application/json',
-          Authorization: `Bearer ${token}`,
-          'X-PB-User': JSON.stringify(user),
         },
         body: JSON.stringify({
           cor_primary: primaryColor,

--- a/app/admin/usuarios/novo/page.tsx
+++ b/app/admin/usuarios/novo/page.tsx
@@ -40,15 +40,7 @@ export default function NovoUsuarioPage() {
 
   useEffect(() => {
     if (!authChecked) return
-    const token = localStorage.getItem('pb_token')
-    const user = localStorage.getItem('pb_user')
-
-    fetch('/admin/api/campos', {
-      headers: {
-        Authorization: `Bearer ${token}`,
-        'X-PB-User': user ?? '',
-      },
-    })
+    fetch('/admin/api/campos')
       .then((res) => res.json())
       .then((data) => setCampos(data))
       .catch(() => showError('Erro ao carregar os campos.'))
@@ -57,15 +49,10 @@ export default function NovoUsuarioPage() {
   async function handleSubmit(e: React.FormEvent) {
     e.preventDefault()
 
-    const token = localStorage.getItem('pb_token')
-    const user = localStorage.getItem('pb_user')
-
     const res = await fetch('/admin/api/usuarios', {
       method: 'POST',
       headers: {
         'Content-Type': 'application/json',
-        Authorization: `Bearer ${token}`,
-        'X-PB-User': user ?? '',
       },
       body: JSON.stringify({
         nome,

--- a/app/admin/usuarios/page.tsx
+++ b/app/admin/usuarios/page.tsx
@@ -31,15 +31,7 @@ export default function UsuariosPage() {
     if (!authChecked) return
     async function fetchUsuarios() {
       try {
-        const token = localStorage.getItem('pb_token')
-        const user = localStorage.getItem('pb_user')
-
-        const res = await fetch('/admin/api/usuarios', {
-          headers: {
-            Authorization: `Bearer ${token}`,
-            'X-PB-User': user ?? '',
-          },
-        })
+        const res = await fetch('/admin/api/usuarios')
 
         if (!res.ok) {
           const erro = await res.json()
@@ -64,14 +56,7 @@ export default function UsuariosPage() {
     if (!authChecked) return
     async function fetchEventos() {
       try {
-        const token = localStorage.getItem('pb_token')
-        const user = localStorage.getItem('pb_user')
-        const res = await fetch('/admin/api/eventos', {
-          headers: {
-            Authorization: `Bearer ${token}`,
-            'X-PB-User': user ?? '',
-          },
-        })
+        const res = await fetch('/admin/api/eventos')
         if (!res.ok) return
         const data = await res.json()
         const ativos = Array.isArray(data)

--- a/app/api/auth/login/route.ts
+++ b/app/api/auth/login/route.ts
@@ -1,0 +1,26 @@
+import { NextRequest, NextResponse } from 'next/server'
+import PocketBase from 'pocketbase'
+
+export async function POST(req: NextRequest) {
+  try {
+    const { email, password } = await req.json()
+    const pb = new PocketBase(process.env.NEXT_PUBLIC_PB_URL!)
+    await pb.collection('usuarios').authWithPassword(email, password)
+    const token = pb.authStore.token
+    const user = pb.authStore.model
+    const res = NextResponse.json({ user })
+    const secure = process.env.NODE_ENV === 'production'
+    res.cookies.set('pb_token', token, {
+      httpOnly: true,
+      secure,
+      sameSite: 'strict',
+      path: '/',
+    })
+    return res
+  } catch {
+    return NextResponse.json(
+      { error: 'Credenciais inválidas' },
+      { status: 401 },
+    )
+  }
+}

--- a/app/api/auth/logout/route.ts
+++ b/app/api/auth/logout/route.ts
@@ -1,0 +1,7 @@
+import { NextResponse } from 'next/server'
+
+export async function POST() {
+  const res = NextResponse.json({ success: true })
+  res.cookies.set('pb_token', '', { path: '/', expires: new Date(0) })
+  return res
+}

--- a/app/api/auth/me/route.ts
+++ b/app/api/auth/me/route.ts
@@ -1,0 +1,10 @@
+import { NextRequest, NextResponse } from 'next/server'
+import { getPocketBaseFromRequest } from '@/lib/pbWithAuth'
+
+export async function GET(req: NextRequest) {
+  const pb = getPocketBaseFromRequest(req)
+  if (!pb.authStore.isValid || !pb.authStore.model) {
+    return NextResponse.json({ user: null }, { status: 401 })
+  }
+  return NextResponse.json({ user: pb.authStore.model })
+}

--- a/app/campos/page.tsx
+++ b/app/campos/page.tsx
@@ -4,6 +4,7 @@ import { useEffect, useState } from 'react'
 import { logInfo } from '@/lib/logger'
 import { useToast } from '@/lib/context/ToastContext'
 import Spinner from '@/components/atoms/Spinner'
+import { useAuthContext } from '@/lib/context/AuthContext'
 
 interface Campo {
   id: string
@@ -17,29 +18,19 @@ export default function GerenciarCamposPage() {
   const [editandoId, setEditandoId] = useState<string | null>(null)
   const [loading, setLoading] = useState(false)
 
-  const token =
-    typeof window !== 'undefined' ? localStorage.getItem('pb_token') : null
-  const userRaw =
-    typeof window !== 'undefined' ? localStorage.getItem('pb_user') : null
-  const user = userRaw ? JSON.parse(userRaw) : null
+  const { isLoggedIn } = useAuthContext()
 
   useEffect(() => {
     async function carregarCampos() {
       logInfo('🔐 Iniciando carregamento de campos...')
-      if (!token || !user) {
-        logInfo('⚠️ Usuário ou token ausente.')
+      if (!isLoggedIn) {
+        logInfo('⚠️ Usuário não autenticado.')
         showError('Usuário não autenticado.')
         return
       }
 
       try {
-        const res = await fetch('/api/campos', {
-          method: 'GET',
-          headers: {
-            Authorization: `Bearer ${token}`,
-            'X-PB-User': JSON.stringify(user),
-          },
-        })
+        const res = await fetch('/api/campos')
 
         const data = await res.json()
 
@@ -66,13 +57,13 @@ export default function GerenciarCamposPage() {
     }
 
     carregarCampos()
-  }, [token, user, showError, showSuccess])
+  }, [isLoggedIn, showError, showSuccess])
 
   async function handleCriarOuAtualizar(e: React.FormEvent) {
     e.preventDefault()
     setLoading(true)
 
-    if (!token || !user) {
+    if (!isLoggedIn) {
       showError('Usuário não autenticado.')
       return
     }
@@ -85,8 +76,6 @@ export default function GerenciarCamposPage() {
         method: metodo,
         headers: {
           'Content-Type': 'application/json',
-          Authorization: `Bearer ${token}`,
-          'X-PB-User': JSON.stringify(user),
         },
         body: JSON.stringify({ nome }),
       })
@@ -113,15 +102,10 @@ export default function GerenciarCamposPage() {
   }
 
   const fetchCampos = async () => {
-    if (!token || !user) return
+    if (!isLoggedIn) return
 
     try {
-      const res = await fetch('/api/campos', {
-        headers: {
-          Authorization: `Bearer ${token}`,
-          'X-PB-User': JSON.stringify(user),
-        },
-      })
+      const res = await fetch('/api/campos')
       const data = await res.json()
       if (res.ok) setCampos(data)
     } catch (err: unknown) {
@@ -132,7 +116,7 @@ export default function GerenciarCamposPage() {
   async function handleExcluir(id: string) {
     if (!confirm('Tem certeza que deseja excluir este campo?')) return
 
-    if (!token || !user) {
+    if (!isLoggedIn) {
       showError('Usuário não autenticado.')
       return
     }
@@ -140,10 +124,6 @@ export default function GerenciarCamposPage() {
     try {
       const res = await fetch(`/api/campos/${id}`, {
         method: 'DELETE',
-        headers: {
-          Authorization: `Bearer ${token}`,
-          'X-PB-User': JSON.stringify(user),
-        },
       })
 
       const data = await res.json()

--- a/lib/getUserFromHeaders.ts
+++ b/lib/getUserFromHeaders.ts
@@ -1,10 +1,10 @@
 import type { NextRequest } from 'next/server'
-import createPocketBase from '@/lib/pocketbase'
-import type { RecordModel } from 'pocketbase'
+import { getPocketBaseFromRequest } from '@/lib/pbWithAuth'
+import PocketBase, { RecordModel } from 'pocketbase'
 
 type AuthOk = {
   user: RecordModel
-  pbSafe: ReturnType<typeof createPocketBase>
+  pbSafe: PocketBase
 }
 
 type AuthError = {
@@ -12,22 +12,10 @@ type AuthError = {
 }
 
 export function getUserFromHeaders(req: NextRequest): AuthOk | AuthError {
-  const token = req.headers.get('Authorization')?.replace('Bearer ', '')
-  const rawUser = req.headers.get('X-PB-User')
-
-  if (!token || !rawUser) {
+  const pb = getPocketBaseFromRequest(req)
+  const user = pb.authStore.model as RecordModel | null
+  if (!pb.authStore.isValid || !user) {
     return { error: 'Token ou usuário ausente.' }
   }
-
-  try {
-    const parsedUser = JSON.parse(rawUser) as RecordModel
-
-    const pb = createPocketBase()
-    pb.authStore.save(token, parsedUser)
-    pb.autoCancellation(false)
-
-    return { user: parsedUser, pbSafe: pb }
-  } catch {
-    return { error: 'Usuário inválido.' }
-  }
+  return { user, pbSafe: pb }
 }

--- a/lib/pbWithAuth.ts
+++ b/lib/pbWithAuth.ts
@@ -1,0 +1,10 @@
+import type { NextRequest } from 'next/server'
+import PocketBase from 'pocketbase'
+
+export function getPocketBaseFromRequest(req: NextRequest) {
+  const pb = new PocketBase(process.env.NEXT_PUBLIC_PB_URL!)
+  const token = req.cookies.get('pb_token')?.value
+  if (token) pb.authStore.loadFromCookie(`pb_auth=${token}`)
+  pb.autoCancellation(false)
+  return pb
+}


### PR DESCRIPTION
## Summary
- add PocketBase cookie helper
- add API routes for login, logout and me
- update auth context to use the new endpoints
- refactor admin pages to fetch without token headers

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6855ea9dbb0c832ca422d30936488c22