### PR TITLE
Update auth cookies

### DIFF
--- a/app/api/auth/login/route.ts
+++ b/app/api/auth/login/route.ts
@@ -6,16 +6,14 @@ export async function POST(req: NextRequest) {
     const { email, password } = await req.json()
     const pb = new PocketBase(process.env.NEXT_PUBLIC_PB_URL!)
     await pb.collection('usuarios').authWithPassword(email, password)
-    const token = pb.authStore.token
     const user = pb.authStore.model
-    const res = NextResponse.json({ user })
-    const secure = process.env.NODE_ENV === 'production'
-    res.cookies.set('pb_token', token, {
+    const cookie = pb.authStore.exportToCookie({
       httpOnly: true,
-      secure,
-      sameSite: 'strict',
+      secure: process.env.NODE_ENV === 'production',
       path: '/',
     })
+    const res = NextResponse.json({ user })
+    res.headers.append('Set-Cookie', cookie)
     return res
   } catch {
     return NextResponse.json(

--- a/app/api/auth/logout/route.ts
+++ b/app/api/auth/logout/route.ts
@@ -2,6 +2,6 @@ import { NextResponse } from 'next/server'
 
 export async function POST() {
   const res = NextResponse.json({ success: true })
-  res.cookies.set('pb_token', '', { path: '/', expires: new Date(0) })
+  res.cookies.set('pb_auth', '', { path: '/', expires: new Date(0) })
   return res
 }

--- a/lib/pbWithAuth.ts
+++ b/lib/pbWithAuth.ts
@@ -3,8 +3,8 @@ import PocketBase from 'pocketbase'
 
 export function getPocketBaseFromRequest(req: NextRequest) {
   const pb = new PocketBase(process.env.NEXT_PUBLIC_PB_URL!)
-  const token = req.cookies.get('pb_token')?.value
-  if (token) pb.authStore.loadFromCookie(`pb_auth=${token}`)
+  const cookie = req.cookies.get('pb_auth')?.value
+  if (cookie) pb.authStore.loadFromCookie(`pb_auth=${cookie}`)
   pb.autoCancellation(false)
   return pb
 }


### PR DESCRIPTION
## Summary
- use `pb.authStore.exportToCookie` in login
- send pb_auth cookie and clear it on logout
- load pb_auth cookie in utility

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6855f7dbae8c832ca834e0bc43d3f38e