### PR TITLE
Implement dynamic imports for blog and store

### DIFF
--- a/app/blog/BlogClient.tsx
+++ b/app/blog/BlogClient.tsx
@@ -2,8 +2,12 @@
 
 import { useEffect, useState } from 'react'
 import { useSearchParams } from 'next/navigation'
-import BlogSidebar from '@/components/organisms/BlogSidebar'
-import BlogHeroCarousel from '@/components/organisms/BlogHeroCarousel'
+import dynamic from 'next/dynamic'
+
+const BlogSidebar = dynamic(() => import('@/components/organisms/BlogSidebar'))
+const BlogHeroCarousel = dynamic(
+  () => import('@/components/organisms/BlogHeroCarousel'),
+)
 import Link from 'next/link'
 import Image from 'next/image'
 import createPocketBase from '@/lib/pocketbase'

--- a/app/blog/post/[slug]/page.tsx
+++ b/app/blog/post/[slug]/page.tsx
@@ -6,8 +6,14 @@ import { isExternalUrl } from '@/utils/isExternalUrl'
 import type { Metadata } from 'next'
 import { getRelatedPostsFromPB } from '@/lib/posts/getRelatedPostsFromPB'
 import { getPostBySlug } from '@/lib/posts/getPostBySlug'
-import NextPostButton from '@/components/molecules/NextPostButton'
-import PostSuggestions from '@/components/organisms/PostSuggestions'
+import dynamic from 'next/dynamic'
+
+const NextPostButton = dynamic(
+  () => import('@/components/molecules/NextPostButton'),
+)
+const PostSuggestions = dynamic(
+  () => import('@/components/organisms/PostSuggestions'),
+)
 import Script from 'next/script'
 
 export const dynamic = 'force-dynamic'

--- a/app/loja/categorias/[slug]/page.tsx
+++ b/app/loja/categorias/[slug]/page.tsx
@@ -1,6 +1,8 @@
 // app/loja/categorias/[slug]/page.tsx
 import createPocketBase from '@/lib/pocketbase'
-import ProdutosFiltrados from './ProdutosFiltrados'
+import dynamic from 'next/dynamic'
+
+const ProdutosFiltrados = dynamic(() => import('./ProdutosFiltrados'))
 import { getTenantFromHost } from '@/lib/getTenantFromHost'
 
 interface Produto {

--- a/app/loja/produtos/page.tsx
+++ b/app/loja/produtos/page.tsx
@@ -1,5 +1,7 @@
 import createPocketBase from '@/lib/pocketbase'
-import ProdutosFiltrados from './ProdutosFiltrados'
+import dynamic from 'next/dynamic'
+
+const ProdutosFiltrados = dynamic(() => import('./ProdutosFiltrados'))
 import { getTenantFromHost } from '@/lib/getTenantFromHost'
 
 export const dynamic = 'force-dynamic'


### PR DESCRIPTION
## Summary
- lazy-load BlogHeroCarousel and BlogSidebar
- lazy-load PostSuggestions and NextPostButton
- lazy-load ProdutosFiltrados components used in store

## Testing
- `npm run lint` *(fails: next not found)*
- `npm run build` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_6855f859e0c8832c951a72b69dedf190