### PR TITLE
Implement client area pages

### DIFF
--- a/app/api/inscricoes/[id]/route.ts
+++ b/app/api/inscricoes/[id]/route.ts
@@ -1,0 +1,25 @@
+import { NextRequest, NextResponse } from 'next/server'
+import { requireRole } from '@/lib/apiAuth'
+
+export async function DELETE(req: NextRequest) {
+  const id = req.nextUrl.pathname.split('/').pop() || ''
+  if (!id) {
+    return NextResponse.json({ error: 'ID inválido' }, { status: 400 })
+  }
+  const auth = requireRole(req, 'usuario')
+  if ('error' in auth) {
+    return NextResponse.json({ error: auth.error }, { status: auth.status })
+  }
+  const { pb, user } = auth
+  try {
+    const inscricao = await pb.collection('inscricoes').getOne(id)
+    if (inscricao.criado_por !== user.id) {
+      return NextResponse.json({ error: 'Acesso negado' }, { status: 403 })
+    }
+    await pb.collection('inscricoes').update(id, { status: 'cancelado' })
+    return NextResponse.json({ ok: true })
+  } catch (err) {
+    console.error('Erro ao cancelar inscricao:', err)
+    return NextResponse.json({ error: 'Erro ao cancelar' }, { status: 500 })
+  }
+}

--- a/app/api/inscricoes/route.ts
+++ b/app/api/inscricoes/route.ts
@@ -1,0 +1,21 @@
+import { NextRequest, NextResponse } from 'next/server'
+import { requireRole } from '@/lib/apiAuth'
+
+export async function GET(req: NextRequest) {
+  const auth = requireRole(req, 'usuario')
+  if ('error' in auth) {
+    return NextResponse.json({ error: auth.error }, { status: auth.status })
+  }
+  const { pb, user } = auth
+  try {
+    const inscricoes = await pb.collection('inscricoes').getFullList({
+      filter: `criado_por = "${user.id}"`,
+      expand: 'evento',
+      sort: '-created',
+    })
+    return NextResponse.json(inscricoes, { status: 200 })
+  } catch (err) {
+    console.error('Erro ao listar inscricoes:', err)
+    return NextResponse.json({ error: 'Erro ao listar' }, { status: 500 })
+  }
+}

--- a/app/api/pedidos/route.ts
+++ b/app/api/pedidos/route.ts
@@ -1,0 +1,20 @@
+import { NextRequest, NextResponse } from 'next/server'
+import { requireRole } from '@/lib/apiAuth'
+
+export async function GET(req: NextRequest) {
+  const auth = requireRole(req, 'usuario')
+  if ('error' in auth) {
+    return NextResponse.json({ error: auth.error }, { status: auth.status })
+  }
+  const { pb, user } = auth
+  try {
+    const pedidos = await pb.collection('pedidos').getFullList({
+      filter: `responsavel = "${user.id}"`,
+      sort: '-created',
+    })
+    return NextResponse.json(pedidos, { status: 200 })
+  } catch (err) {
+    console.error('Erro ao listar pedidos:', err)
+    return NextResponse.json({ error: 'Erro ao listar' }, { status: 500 })
+  }
+}

--- a/app/api/usuarios/[id]/route.ts
+++ b/app/api/usuarios/[id]/route.ts
@@ -1,0 +1,31 @@
+import { NextRequest, NextResponse } from 'next/server'
+import { requireRole } from '@/lib/apiAuth'
+
+export async function PATCH(req: NextRequest) {
+  const id = req.nextUrl.pathname.split('/').pop() || ''
+  if (!id) {
+    return NextResponse.json({ error: 'ID inválido' }, { status: 400 })
+  }
+  const auth = requireRole(req, 'usuario')
+  if ('error' in auth) {
+    return NextResponse.json({ error: auth.error }, { status: auth.status })
+  }
+  const { pb, user } = auth
+  if (user.id !== id) {
+    return NextResponse.json({ error: 'Acesso negado' }, { status: 403 })
+  }
+  try {
+    const data = await req.json()
+    await pb.collection('usuarios').update(id, {
+      nome: String(data.nome || '').trim(),
+      telefone: String(data.telefone || '').trim(),
+      cpf: String(data.cpf || '').trim(),
+      data_nascimento: String(data.data_nascimento || ''),
+      role: user.role,
+    })
+    return NextResponse.json({ ok: true })
+  } catch (err) {
+    console.error('Erro ao atualizar perfil:', err)
+    return NextResponse.json({ error: 'Erro ao atualizar' }, { status: 500 })
+  }
+}

--- a/app/cliente/components/DashboardHeader.tsx
+++ b/app/cliente/components/DashboardHeader.tsx
@@ -1,0 +1,48 @@
+'use client'
+import { useAuthGuard } from '@/lib/hooks/useAuthGuard'
+import { useEffect, useState } from 'react'
+import type { Pedido, Inscricao } from '@/types'
+
+export default function DashboardHeader() {
+  const { user, pb, authChecked } = useAuthGuard(['usuario'])
+  const [inscricoes, setInscricoes] = useState<Inscricao[]>([])
+  const [pedidos, setPedidos] = useState<Pedido[]>([])
+
+  useEffect(() => {
+    if (!authChecked || !user) return
+    const token = pb.authStore.token
+    const headers = {
+      Authorization: `Bearer ${token}`,
+      'X-PB-User': JSON.stringify(user),
+    }
+    fetch('/api/inscricoes', { headers })
+      .then((res) => res.json())
+      .then((data) => setInscricoes(Array.isArray(data) ? data : []))
+      .catch(() => setInscricoes([]))
+
+    fetch('/api/pedidos', { headers })
+      .then((res) => res.json())
+      .then((data) => setPedidos(Array.isArray(data) ? data : []))
+      .catch(() => setPedidos([]))
+  }, [authChecked, user, pb])
+
+  if (!authChecked) return null
+
+  return (
+    <div className="space-y-4">
+      <h1 className="text-xl font-bold">
+        Olá, {user?.nome?.split(' ')[0] || 'cliente'}!
+      </h1>
+      <div className="grid grid-cols-2 gap-4">
+        <div className="card text-center">
+          <p className="text-sm">Total de Inscrições</p>
+          <p className="text-2xl font-bold">{inscricoes.length}</p>
+        </div>
+        <div className="card text-center">
+          <p className="text-sm">Total de Pedidos</p>
+          <p className="text-2xl font-bold">{pedidos.length}</p>
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/app/cliente/components/InscricoesTable.tsx
+++ b/app/cliente/components/InscricoesTable.tsx
@@ -1,0 +1,56 @@
+'use client'
+import { useAuthGuard } from '@/lib/hooks/useAuthGuard'
+import { useEffect, useState } from 'react'
+import type { Inscricao } from '@/types'
+
+export default function InscricoesTable({ limit }: { limit?: number }) {
+  const { user, pb, authChecked } = useAuthGuard(['usuario'])
+  const [inscricoes, setInscricoes] = useState<Inscricao[]>([])
+
+  useEffect(() => {
+    if (!authChecked || !user) return
+    const token = pb.authStore.token
+    const headers = {
+      Authorization: `Bearer ${token}`,
+      'X-PB-User': JSON.stringify(user),
+    }
+    fetch('/api/inscricoes', { headers })
+      .then((res) => res.json())
+      .then((data) =>
+        setInscricoes(
+          Array.isArray(data) ? data.slice(0, limit ?? data.length) : [],
+        ),
+      )
+      .catch(() => setInscricoes([]))
+  }, [authChecked, user, pb, limit])
+
+  if (!authChecked) return null
+
+  return (
+    <div className="card">
+      <h3 className="text-lg font-semibold mb-2">Inscrições</h3>
+      <table className="table-base">
+        <thead>
+          <tr>
+            <th>Status</th>
+            <th>Evento</th>
+            <th>Data</th>
+          </tr>
+        </thead>
+        <tbody>
+          {inscricoes.map((i) => (
+            <tr key={i.id}>
+              <td className="capitalize">{i.status}</td>
+              <td>{i.expand?.evento?.titulo || '-'}</td>
+              <td>
+                {i.created
+                  ? new Date(i.created).toLocaleDateString('pt-BR')
+                  : '-'}
+              </td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    </div>
+  )
+}

--- a/app/cliente/components/PedidosTable.tsx
+++ b/app/cliente/components/PedidosTable.tsx
@@ -1,0 +1,52 @@
+'use client'
+import { useAuthGuard } from '@/lib/hooks/useAuthGuard'
+import { useEffect, useState } from 'react'
+import type { Pedido } from '@/types'
+
+export default function PedidosTable({ limit }: { limit?: number }) {
+  const { user, pb, authChecked } = useAuthGuard(['usuario'])
+  const [pedidos, setPedidos] = useState<Pedido[]>([])
+
+  useEffect(() => {
+    if (!authChecked || !user) return
+    const token = pb.authStore.token
+    const headers = {
+      Authorization: `Bearer ${token}`,
+      'X-PB-User': JSON.stringify(user),
+    }
+    fetch('/api/pedidos', { headers })
+      .then((res) => res.json())
+      .then((data) =>
+        setPedidos(
+          Array.isArray(data) ? data.slice(0, limit ?? data.length) : [],
+        ),
+      )
+      .catch(() => setPedidos([]))
+  }, [authChecked, user, pb, limit])
+
+  if (!authChecked) return null
+
+  return (
+    <div className="card">
+      <h3 className="text-lg font-semibold mb-2">Pedidos</h3>
+      <table className="table-base">
+        <thead>
+          <tr>
+            <th>ID</th>
+            <th>Valor</th>
+            <th>Status</th>
+          </tr>
+        </thead>
+        <tbody>
+          {pedidos.map((p) => (
+            <tr key={p.id}>
+              <td>{p.id_pagamento || p.id}</td>
+              <td>R$ {Number(p.valor).toFixed(2)}</td>
+              <td className="capitalize">{p.status}</td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    </div>
+  )
+}

--- a/app/cliente/components/ProfileForm.tsx
+++ b/app/cliente/components/ProfileForm.tsx
@@ -1,0 +1,108 @@
+'use client'
+import { useAuthGuard } from '@/lib/hooks/useAuthGuard'
+import { useEffect, useState } from 'react'
+import { useToast } from '@/lib/context/ToastContext'
+import { FormField, TextField, InputWithMask } from '@/components'
+
+export default function ProfileForm() {
+  const { user, pb, authChecked } = useAuthGuard(['usuario'])
+  const { showSuccess, showError } = useToast()
+
+  const [nome, setNome] = useState('')
+  const [telefone, setTelefone] = useState('')
+  const [cpf, setCpf] = useState('')
+  const [dataNascimento, setDataNascimento] = useState('')
+
+  useEffect(() => {
+    if (user) {
+      setNome(String(user.nome ?? ''))
+      setTelefone(String(user.telefone ?? ''))
+      setCpf(String(user.cpf ?? ''))
+      setDataNascimento(String(user.data_nascimento ?? ''))
+    }
+  }, [user])
+
+  async function handleSave(e: React.FormEvent) {
+    e.preventDefault()
+    if (!user?.id) return
+    try {
+      const token = pb.authStore.token
+      const headers = {
+        Authorization: `Bearer ${token}`,
+        'X-PB-User': JSON.stringify(user),
+        'Content-Type': 'application/json',
+      }
+      const res = await fetch(`/api/usuarios/${user.id}`, {
+        method: 'PATCH',
+        headers,
+        body: JSON.stringify({
+          nome: nome.trim(),
+          telefone: telefone.trim(),
+          cpf: cpf.trim(),
+          data_nascimento: dataNascimento,
+        }),
+      })
+      if (res.ok) {
+        showSuccess('Dados atualizados!')
+      } else {
+        showError('Erro ao salvar.')
+      }
+    } catch {
+      showError('Erro ao salvar.')
+    }
+  }
+
+  if (!authChecked) return null
+
+  const inputStyle =
+    'w-full border border-gray-300 dark:border-zinc-700 bg-white dark:bg-zinc-800 p-2 rounded'
+
+  return (
+    <form onSubmit={handleSave} className="card space-y-4">
+      <h3 className="text-lg font-semibold">Perfil</h3>
+      <FormField label="Nome completo" htmlFor="perfil-nome">
+        <TextField
+          id="perfil-nome"
+          type="text"
+          className={inputStyle}
+          value={nome}
+          onChange={(e) => setNome(e.target.value)}
+        />
+      </FormField>
+      <FormField label="Telefone" htmlFor="perfil-telefone">
+        <InputWithMask
+          id="perfil-telefone"
+          type="text"
+          mask="telefone"
+          className={inputStyle}
+          value={telefone}
+          onChange={(e) => setTelefone(e.target.value)}
+        />
+      </FormField>
+      <FormField label="CPF" htmlFor="perfil-cpf">
+        <InputWithMask
+          id="perfil-cpf"
+          type="text"
+          mask="cpf"
+          className={inputStyle}
+          value={cpf}
+          onChange={(e) => setCpf(e.target.value)}
+        />
+      </FormField>
+      <FormField label="Data de nascimento" htmlFor="perfil-data">
+        <TextField
+          id="perfil-data"
+          type="date"
+          className={inputStyle}
+          value={dataNascimento}
+          onChange={(e) => setDataNascimento(e.target.value)}
+        />
+      </FormField>
+      <div className="text-right">
+        <button className="bg-black dark:bg-white text-white dark:text-black px-4 py-2 rounded">
+          Salvar
+        </button>
+      </div>
+    </form>
+  )
+}

--- a/app/cliente/components/Sidebar.tsx
+++ b/app/cliente/components/Sidebar.tsx
@@ -1,0 +1,33 @@
+'use client'
+import Link from 'next/link'
+import { usePathname } from 'next/navigation'
+
+export default function Sidebar() {
+  const pathname = usePathname()
+  const links = [
+    { href: '/cliente/dashboard', label: 'Dashboard' },
+    { href: '/cliente/pedidos', label: 'Pedidos' },
+    { href: '/cliente/inscricoes', label: 'Inscrições' },
+    { href: '/cliente/perfil', label: 'Perfil' },
+  ]
+  return (
+    <nav className="card w-full md:w-60">
+      <ul className="space-y-2">
+        {links.map((link) => (
+          <li key={link.href}>
+            <Link
+              href={link.href}
+              className={`block p-2 rounded ${
+                pathname === link.href
+                  ? 'bg-purple-600 text-white'
+                  : 'hover:bg-neutral-100 dark:hover:bg-neutral-800'
+              }`}
+            >
+              {link.label}
+            </Link>
+          </li>
+        ))}
+      </ul>
+    </nav>
+  )
+}

--- a/app/cliente/dashboard/page.tsx
+++ b/app/cliente/dashboard/page.tsx
@@ -1,0 +1,13 @@
+import DashboardHeader from '../components/DashboardHeader'
+import PedidosTable from '../components/PedidosTable'
+import InscricoesTable from '../components/InscricoesTable'
+
+export default function DashboardPage() {
+  return (
+    <div className="space-y-6">
+      <DashboardHeader />
+      <PedidosTable limit={5} />
+      <InscricoesTable limit={5} />
+    </div>
+  )
+}

--- a/app/cliente/inscricoes/page.tsx
+++ b/app/cliente/inscricoes/page.tsx
@@ -1,0 +1,9 @@
+import InscricoesTable from '../components/InscricoesTable'
+
+export default function InscricoesPage() {
+  return (
+    <div className="space-y-4">
+      <InscricoesTable />
+    </div>
+  )
+}

--- a/app/cliente/layout.tsx
+++ b/app/cliente/layout.tsx
@@ -1,0 +1,20 @@
+import '../globals.css'
+import LayoutWrapper from '@/components/templates/LayoutWrapper'
+import Sidebar from './components/Sidebar'
+
+export default function ClientLayout({
+  children,
+}: {
+  children: React.ReactNode
+}) {
+  return (
+    <div className="text-platinum font-sans">
+      <LayoutWrapper>
+        <div className="flex flex-col md:flex-row gap-6 p-4 md:p-8">
+          <Sidebar />
+          <div className="flex-1">{children}</div>
+        </div>
+      </LayoutWrapper>
+    </div>
+  )
+}

--- a/app/cliente/pedidos/page.tsx
+++ b/app/cliente/pedidos/page.tsx
@@ -1,0 +1,9 @@
+import PedidosTable from '../components/PedidosTable'
+
+export default function PedidosPage() {
+  return (
+    <div className="space-y-4">
+      <PedidosTable />
+    </div>
+  )
+}

--- a/app/cliente/perfil/page.tsx
+++ b/app/cliente/perfil/page.tsx
@@ -1,0 +1,9 @@
+import ProfileForm from '../components/ProfileForm'
+
+export default function PerfilPage() {
+  return (
+    <div className="space-y-4">
+      <ProfileForm />
+    </div>
+  )
+}

--- a/components/templates/Header.tsx
+++ b/components/templates/Header.tsx
@@ -193,7 +193,7 @@ export default function Header() {
                   >
                     <li>
                       <Link
-                        href="/loja/cliente"
+                        href="/cliente/dashboard"
                         className="block px-4 py-2 hover:bg-zinc-100 dark:hover:bg-zinc-800"
                         onClick={() => setClientOpen(false)}
                       >
@@ -285,7 +285,7 @@ export default function Header() {
               {role === 'usuario' && (
                 <>
                   <Link
-                    href="/loja/cliente"
+                    href="/cliente/dashboard"
                     className="text-platinum hover:text-primary-400 transition py-2 text-base font-medium"
                     onClick={() => setOpen(false)}
                   >


### PR DESCRIPTION
## Summary
- link header to `/cliente/dashboard`
- add API routes for pedidos, inscricoes and usuario updates
- scaffold client dashboard, pedidos, inscricoes and perfil pages
- create client area components (dashboard header, tables, profile form, sidebar)

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6855f7d764dc832c960824997e838d4a