### PR TITLE
Fix pocketbase auth load

### DIFF
--- a/lib/pbWithAuth.ts
+++ b/lib/pbWithAuth.ts
@@ -3,8 +3,8 @@ import PocketBase from 'pocketbase'
 
 export function getPocketBaseFromRequest(req: NextRequest) {
   const pb = new PocketBase(process.env.NEXT_PUBLIC_PB_URL!)
-  const cookie = req.cookies.get('pb_auth')?.value
-  if (cookie) pb.authStore.loadFromCookie(`pb_auth=${cookie}`)
+  const cookieHeader = req.headers.get('cookie') || ''
+  pb.authStore.loadFromCookie(cookieHeader)
   pb.autoCancellation(false)
   return pb
 }


### PR DESCRIPTION
## Summary
- load pocketbase authentication from request headers

## Testing
- `npm run lint`
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_6855f91efd8c832c997451f8b857c8d1