### PR TITLE
Add dynamic metadata for public pages

### DIFF
--- a/app/admin/layout.tsx
+++ b/app/admin/layout.tsx
@@ -3,8 +3,6 @@ import '@/app/globals.css'
 import LayoutWrapper from '@/components/templates/LayoutWrapperAdmin'
 
 export const metadata = {
-  title: 'UMADEUS',
-  description: 'Sistema de inscrições e gestão UMADEUS',
   icons: {
     icon: [
       { url: '/favicon.ico' },

--- a/app/iniciar-tour/page.tsx
+++ b/app/iniciar-tour/page.tsx
@@ -1,8 +1,18 @@
 import LayoutWrapper from '@/components/templates/LayoutWrapper'
+import type { Metadata } from 'next'
 
-export const metadata = {
-  title: 'Iniciar Tour',
-  description: 'Guia de primeiro acesso para novos clientes',
+export async function generateMetadata(): Promise<Metadata> {
+  const title = 'Iniciar Tour'
+  const description = 'Guia de primeiro acesso para novos clientes'
+  return {
+    title,
+    description,
+    openGraph: {
+      title,
+      description,
+      images: ['/img/og-default.jpg'],
+    },
+  }
 }
 
 export default function IniciarTourPage() {

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -10,8 +10,6 @@ import { fetchTenantConfig } from '@/lib/fetchTenantConfig'
 import { CartProvider } from '@/lib/context/CartContext'
 
 export const metadata = {
-  title: 'UMADEUS',
-  description: 'Sistema de inscrições e gestão UMADEUS',
   icons: {
     icon: [
       { url: '/favicon.ico' },

--- a/app/loja/carrinho/metadata.ts
+++ b/app/loja/carrinho/metadata.ts
@@ -1,0 +1,15 @@
+import type { Metadata } from 'next'
+
+export async function generateMetadata(): Promise<Metadata> {
+  const title = 'Carrinho'
+  const description = 'Itens selecionados para compra.'
+  return {
+    title,
+    description,
+    openGraph: {
+      title,
+      description,
+      images: ['/img/og-default.jpg'],
+    },
+  }
+}

--- a/app/loja/categorias/[slug]/metadata.ts
+++ b/app/loja/categorias/[slug]/metadata.ts
@@ -1,0 +1,36 @@
+import type { Metadata } from 'next'
+import createPocketBase from '@/lib/pocketbase'
+import { getTenantFromHost } from '@/lib/getTenantFromHost'
+
+interface Params {
+  slug: string
+}
+
+export async function generateMetadata({
+  params,
+}: {
+  params: Params
+}): Promise<Metadata> {
+  const pb = createPocketBase()
+  const tenantId = await getTenantFromHost()
+  let nome = params.slug
+  try {
+    const cat = await pb
+      .collection('categorias')
+      .getFirstListItem(`slug='${params.slug}' && cliente='${tenantId}'`)
+    if (cat?.nome) nome = cat.nome
+  } catch {
+    // ignore errors
+  }
+  const title = `Categoria: ${nome}`
+  const description = `Produtos da categoria ${nome}`
+  return {
+    title,
+    description,
+    openGraph: {
+      title,
+      description,
+      images: ['/img/og-default.jpg'],
+    },
+  }
+}

--- a/app/loja/categorias/metadata.ts
+++ b/app/loja/categorias/metadata.ts
@@ -1,0 +1,15 @@
+import type { Metadata } from 'next'
+
+export async function generateMetadata(): Promise<Metadata> {
+  const title = 'Categorias'
+  const description = 'Navegue pelas categorias de produtos e eventos.'
+  return {
+    title,
+    description,
+    openGraph: {
+      title,
+      description,
+      images: ['/img/og-default.jpg'],
+    },
+  }
+}

--- a/app/loja/checkout/metadata.ts
+++ b/app/loja/checkout/metadata.ts
@@ -1,0 +1,15 @@
+import type { Metadata } from 'next'
+
+export async function generateMetadata(): Promise<Metadata> {
+  const title = 'Checkout'
+  const description = 'Finalize sua compra.'
+  return {
+    title,
+    description,
+    openGraph: {
+      title,
+      description,
+      images: ['/img/og-default.jpg'],
+    },
+  }
+}

--- a/app/loja/cliente/metadata.ts
+++ b/app/loja/cliente/metadata.ts
@@ -1,0 +1,15 @@
+import type { Metadata } from 'next'
+
+export async function generateMetadata(): Promise<Metadata> {
+  const title = 'Área do Cliente'
+  const description = 'Consulte suas inscrições e pedidos.'
+  return {
+    title,
+    description,
+    openGraph: {
+      title,
+      description,
+      images: ['/img/og-default.jpg'],
+    },
+  }
+}

--- a/app/loja/eventos/[id]/metadata.ts
+++ b/app/loja/eventos/[id]/metadata.ts
@@ -1,0 +1,34 @@
+import type { Metadata } from 'next'
+import { headers } from 'next/headers'
+
+async function getEvento(id: string) {
+  try {
+    const protocol = process.env.NODE_ENV === 'development' ? 'http' : 'https'
+    const h = await headers()
+    const host = h.get('host')
+    if (!host) return null
+    const res = await fetch(`${protocol}://${host}/api/eventos/${id}`)
+    if (!res.ok) return null
+    return (await res.json()) as { titulo: string; descricao: string; imagem?: string }
+  } catch {
+    return null
+  }
+}
+
+interface Params { id: string }
+
+export async function generateMetadata({ params }: { params: Params }): Promise<Metadata> {
+  const evento = await getEvento(params.id)
+  const title = evento ? evento.titulo : 'Evento'
+  const description = evento?.descricao || 'Detalhes do evento.'
+  const image = evento?.imagem || '/img/og-default.jpg'
+  return {
+    title,
+    description,
+    openGraph: {
+      title,
+      description,
+      images: [image],
+    },
+  }
+}

--- a/app/loja/eventos/metadata.ts
+++ b/app/loja/eventos/metadata.ts
@@ -1,0 +1,15 @@
+import type { Metadata } from 'next'
+
+export async function generateMetadata(): Promise<Metadata> {
+  const title = 'Eventos'
+  const description = 'Confira nossos próximos eventos.'
+  return {
+    title,
+    description,
+    openGraph: {
+      title,
+      description,
+      images: ['/img/og-default.jpg'],
+    },
+  }
+}

--- a/app/loja/inscricoes/confirmacao/metadata.ts
+++ b/app/loja/inscricoes/confirmacao/metadata.ts
@@ -1,0 +1,15 @@
+import type { Metadata } from 'next'
+
+export async function generateMetadata(): Promise<Metadata> {
+  const title = 'Inscrição enviada'
+  const description = 'Sua inscrição foi registrada com sucesso.'
+  return {
+    title,
+    description,
+    openGraph: {
+      title,
+      description,
+      images: ['/img/og-default.jpg'],
+    },
+  }
+}

--- a/app/loja/login/metadata.ts
+++ b/app/loja/login/metadata.ts
@@ -1,0 +1,15 @@
+import type { Metadata } from 'next'
+
+export async function generateMetadata(): Promise<Metadata> {
+  const title = 'Entrar'
+  const description = 'Acesse sua conta ou cadastre-se.'
+  return {
+    title,
+    description,
+    openGraph: {
+      title,
+      description,
+      images: ['/img/og-default.jpg'],
+    },
+  }
+}

--- a/app/loja/perfil/metadata.ts
+++ b/app/loja/perfil/metadata.ts
@@ -1,0 +1,15 @@
+import type { Metadata } from 'next'
+
+export async function generateMetadata(): Promise<Metadata> {
+  const title = 'Meu Perfil'
+  const description = 'Gerencie suas informações pessoais.'
+  return {
+    title,
+    description,
+    openGraph: {
+      title,
+      description,
+      images: ['/img/og-default.jpg'],
+    },
+  }
+}

--- a/app/loja/produtos/metadata.ts
+++ b/app/loja/produtos/metadata.ts
@@ -1,0 +1,15 @@
+import type { Metadata } from 'next'
+
+export async function generateMetadata(): Promise<Metadata> {
+  const title = 'Produtos'
+  const description = 'Veja todos os produtos disponíveis.'
+  return {
+    title,
+    description,
+    openGraph: {
+      title,
+      description,
+      images: ['/img/og-default.jpg'],
+    },
+  }
+}

--- a/app/loja/sucesso/metadata.ts
+++ b/app/loja/sucesso/metadata.ts
@@ -1,0 +1,15 @@
+import type { Metadata } from 'next'
+
+export async function generateMetadata(): Promise<Metadata> {
+  const title = 'Compra Concluída'
+  const description = 'Seu pedido foi processado com sucesso.'
+  return {
+    title,
+    description,
+    openGraph: {
+      title,
+      description,
+      images: ['/img/og-default.jpg'],
+    },
+  }
+}


### PR DESCRIPTION
## Summary
- export generateMetadata on `iniciar-tour` page
- add metadata files for public store pages
- remove redundant `title` and `description` from root layouts

## Testing
- `npm run lint` *(fails: next not found)*
- `npm run build` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_6855f95e91f8832cb070dffaadc05039