### PR TITLE
Update AuthContext login behaviour

### DIFF
--- a/lib/context/AuthContext.tsx
+++ b/lib/context/AuthContext.tsx
@@ -47,7 +47,7 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
     let unsubscribe = () => {}
     async function loadAuth() {
       try {
-        const meRes = await fetch('/api/auth/me')
+        const meRes = await fetch('/api/auth/me', { credentials: 'include' })
         if (meRes.ok) {
           const data = await meRes.json()
           pb.authStore.clear()
@@ -91,6 +91,9 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
     const data = await res.json()
     setUser(data.user as UserModel)
     setIsLoggedIn(true)
+    if (typeof window !== 'undefined') {
+      localStorage.setItem('pb_user', JSON.stringify(data.user))
+    }
     const tenantRes = await fetch('/api/tenant')
     if (tenantRes.ok) {
       const { tenantId } = await tenantRes.json()


### PR DESCRIPTION
## Summary
- fetch credentials when loading auth context
- persist user data in localStorage after login

## Testing
- `npm run lint`
- `npm run build` *(fails: Type error in `app/blog/post/[slug]/page.tsx`)*

------
https://chatgpt.com/codex/tasks/task_e_6855fa2513cc832cab3ae704217a7e9c