### PR TITLE
Atualizar TenantContext para pb_user e cookies

### DIFF
--- a/components/templates/HeaderAdmin.tsx
+++ b/components/templates/HeaderAdmin.tsx
@@ -74,7 +74,6 @@ export default function Header() {
 
   const handleLogout = () => {
     pb.authStore.clear()
-    localStorage.removeItem('pb_token')
     localStorage.removeItem('pb_user')
     window.location.href = '/login'
   }

--- a/lib/context/TenantContext.tsx
+++ b/lib/context/TenantContext.tsx
@@ -128,14 +128,13 @@ export function TenantProvider({
         }
 
         // Fallback: tenta pelo /admin/api/configuracoes
-        const token = localStorage.getItem('pb_token')
         const user = localStorage.getItem('pb_user')
 
-        if (token && user) {
+        if (user) {
           try {
             const res = await fetch('/admin/api/configuracoes', {
+              credentials: 'include',
               headers: {
-                Authorization: `Bearer ${token}`,
                 'X-PB-User': user,
               },
             })
@@ -200,14 +199,13 @@ export function TenantProvider({
     setConfig(newCfg)
 
     if (typeof window !== 'undefined') {
-      const token = localStorage.getItem('pb_token')
       const user = localStorage.getItem('pb_user')
-      if (token && user && configId) {
+      if (user && configId) {
         fetch('/admin/api/configuracoes', {
           method: 'PUT',
+          credentials: 'include',
           headers: {
             'Content-Type': 'application/json',
-            Authorization: `Bearer ${token}`,
             'X-PB-User': user,
           },
           body: JSON.stringify({


### PR DESCRIPTION
## Summary
- remove pb_token usage
- send stored `pb_user` and cookies when acessing `/admin/api/configuracoes`
- clean up logout handler

## Testing
- `npm run lint` *(fails: next not found)*
- `npm run build` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_6855fc0d4cc8832cb1bc7d53165910bc