### PR TITLE
Fix PocketBase client with cookies

### DIFF
--- a/app/admin/dashboard/page.tsx
+++ b/app/admin/dashboard/page.tsx
@@ -30,14 +30,18 @@ export default function DashboardPage() {
         })
 
         const perPage = 50
+        const filtroCliente = `cliente='${user.cliente}'`
         const [inscricoesRes, pedidosRes] = await Promise.all([
           pb.collection('inscricoes').getList(page, perPage, {
             expand: 'campo,evento,criado_por,pedido',
+            filter: filtroCliente,
             signal,
           }),
-          pb
-            .collection('pedidos')
-            .getList(page, perPage, { expand: 'campo,criado_por', signal }),
+          pb.collection('pedidos').getList(page, perPage, {
+            expand: 'campo,criado_por',
+            filter: filtroCliente,
+            signal,
+          }),
         ])
         const rawInscricoes = inscricoesRes.items
         const rawPedidos = pedidosRes.items
@@ -111,7 +115,7 @@ export default function DashboardPage() {
       isMounted.current = false
       controller.abort()
     }
-  }, [authChecked, user?.id, user?.role, pb, page])
+  }, [authChecked, user?.id, user?.role, user?.cliente, pb, page])
 
   return (
     <main className="min-h-screen  p-4 md:p-6">

--- a/lib/pocketbase.ts
+++ b/lib/pocketbase.ts
@@ -5,11 +5,17 @@ const basePb = new PocketBase(PB_URL)
 
 export function createPocketBase() {
   const pbWithClone = basePb as PocketBase & { clone?: () => PocketBase }
-  if (typeof pbWithClone.clone === 'function') {
-    return pbWithClone.clone()
-  }
-  const pb = new PocketBase(PB_URL)
+  const pb =
+    typeof pbWithClone.clone === 'function'
+      ? pbWithClone.clone()
+      : new PocketBase(PB_URL)
+
   pb.authStore.save(basePb.authStore.token, basePb.authStore.model)
+  pb.beforeSend = (_, opt) => {
+    opt.credentials = 'include'
+    return opt
+  }
+  pb.autoCancellation(false)
   return pb
 }
 


### PR DESCRIPTION
## Summary
- include cookies when creating a PocketBase client
- filter dashboard data by tenant

## Testing
- `npm run lint`
- `npm run build` *(fails: Module not found: BlogClient, ProdutosFiltrados)*
- `npm test` *(fails: many tests fail due to setup)*

------
https://chatgpt.com/codex/tasks/task_e_6856022ff170832ca971647761af67f4