### PR TITLE
Clarify public admin routes

### DIFF
--- a/app/admin/erro/page.tsx
+++ b/app/admin/erro/page.tsx
@@ -1,3 +1,4 @@
+// Página pública - exibida quando o pagamento falha
 import Link from 'next/link'
 
 export default function ErroPage() {

--- a/app/admin/inscricoes/recuperar/page.tsx
+++ b/app/admin/inscricoes/recuperar/page.tsx
@@ -1,4 +1,5 @@
 'use client'
+// Página pública para recuperar link de pagamento
 
 import { useState } from 'react'
 import { useToast } from '@/lib/context/ToastContext'

--- a/app/admin/obrigado/page.tsx
+++ b/app/admin/obrigado/page.tsx
@@ -1,3 +1,4 @@
+// Página pública - exibida após confirmação do formulário de inscrição
 import Link from 'next/link'
 
 export default function ObrigadoPage() {

--- a/app/admin/page.tsx
+++ b/app/admin/page.tsx
@@ -1,3 +1,4 @@
+// Redirecionamento público para a página de login
 import { redirect } from 'next/navigation'
 
 export default function AdminIndex() {

--- a/app/admin/pendente/page.tsx
+++ b/app/admin/pendente/page.tsx
@@ -1,3 +1,4 @@
+// Página pública - informa que o pagamento está em análise
 import Link from 'next/link'
 
 export default function PagamentoPendentePage() {

--- a/app/admin/redefinir-senha/RedefinirSenhaClient.tsx
+++ b/app/admin/redefinir-senha/RedefinirSenhaClient.tsx
@@ -1,4 +1,5 @@
 'use client'
+// Componente público para redefinição de senha
 
 import { useState, useEffect, useMemo } from 'react'
 import { useSearchParams, useRouter } from 'next/navigation'

--- a/app/admin/redefinir-senha/page.tsx
+++ b/app/admin/redefinir-senha/page.tsx
@@ -1,4 +1,5 @@
 'use client'
+// Página pública para redefinição de senha via token
 
 import dynamic from 'next/dynamic'
 import { Suspense } from 'react'

--- a/arquitetura.md
+++ b/arquitetura.md
@@ -94,9 +94,12 @@ components/                # Componentes reutilizáveis compartilhados
 
 ---
 
-## 🛠️ Admin – Boas Práticas
+-## 🛠️ Admin – Boas Práticas
 
 - Rotas protegidas com `useAuthGuard` e validação de `role`
+- Algumas rotas de confirmação de inscrição são públicas:
+  `/admin/obrigado`, `/admin/pendente`, `/admin/erro`,
+  `/admin/redefinir-senha` e `/admin/inscricoes/recuperar`
 - Layout persistente com navegação clara entre seções (dashboard, pedidos, etc)
 - Paginação, filtros e expand para consultas PocketBase
 - Armazenamento de token com `pb.authStore` e persistência no localStorage

--- a/logs/DOC_LOG.md
+++ b/logs/DOC_LOG.md
@@ -329,3 +329,5 @@
 ## [2025-07-17] README e CONTRIBUTING destacam que `npm install` deve ser executado antes de `npm run lint` ou `npm run build`. Lint e build executados.
 
 ## [2025-06-21] Componentes de loja e blog movidos para `components/` e inventário atualizado. Lint e build executados.
+
+## [2025-06-21] Documentadas páginas públicas do admin e adicionados comentários explicativos nos arquivos.


### PR DESCRIPTION
## Summary
- mark admin pages used in signup flow as public with comments
- document which admin routes are public in `arquitetura.md`
- log doc update

## Testing
- `npm run lint` *(fails: next not found)*
- `npm run build` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_6856029fa394832ca18dd89dd1e8a2d3