### PR TITLE
Update auth to sync pocketbase token from cookie

### DIFF
--- a/app/blog/BlogClient.dynamic.tsx
+++ b/app/blog/BlogClient.dynamic.tsx
@@ -1,5 +1,8 @@
 'use client'
 import dynamic from 'next/dynamic'
 
-const BlogClient = dynamic(() => import('./BlogClient'), { ssr: false })
+const BlogClient = dynamic(() => import('@/components/organisms/BlogClient'), {
+  ssr: false,
+})
+
 export default BlogClient

--- a/app/loja/categorias/[slug]/ProdutosFiltrados.dynamic.tsx
+++ b/app/loja/categorias/[slug]/ProdutosFiltrados.dynamic.tsx
@@ -1,4 +1,7 @@
 'use client'
 import dynamic from 'next/dynamic'
 
-export default dynamic(() => import('./ProdutosFiltrados'), { ssr: false })
+export default dynamic(
+  () => import('@/components/organisms/ProdutosFiltradosCategoria'),
+  { ssr: false },
+)

--- a/app/loja/produtos/ProdutosFiltrados.dynamic.tsx
+++ b/app/loja/produtos/ProdutosFiltrados.dynamic.tsx
@@ -1,4 +1,7 @@
 'use client'
 import dynamic from 'next/dynamic'
 
-export default dynamic(() => import('./ProdutosFiltrados'), { ssr: false })
+export default dynamic(
+  () => import('@/components/organisms/ProdutosFiltrados'),
+  { ssr: false },
+)

--- a/lib/context/AuthContext.tsx
+++ b/lib/context/AuthContext.tsx
@@ -1,7 +1,10 @@
 'use client'
 
 import { createContext, useContext, useEffect, useMemo, useState } from 'react'
-import createPocketBase, { clearBaseAuth } from '@/lib/pocketbase'
+import createPocketBase, {
+  clearBaseAuth,
+  updateBaseAuth,
+} from '@/lib/pocketbase'
 import type { UserModel } from '@/types/UserModel'
 
 type AuthContextType = {
@@ -50,7 +53,8 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
         const meRes = await fetch('/api/auth/me', { credentials: 'include' })
         if (meRes.ok) {
           const data = await meRes.json()
-          pb.authStore.clear()
+          pb.authStore.loadFromCookie(document.cookie)
+          updateBaseAuth(pb.authStore.token, pb.authStore.model)
           setUser(data.user as UserModel)
           setIsLoggedIn(true)
         }
@@ -64,7 +68,6 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
       } catch (err: unknown) {
         if (err instanceof Error) {
         }
-        pb.authStore.clear()
         clearBaseAuth()
         setUser(null)
         setTenantId(null)
@@ -89,6 +92,8 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
     })
     if (!res.ok) throw new Error('Login failed')
     const data = await res.json()
+    pb.authStore.loadFromCookie(document.cookie)
+    updateBaseAuth(pb.authStore.token, pb.authStore.model)
     setUser(data.user as UserModel)
     setIsLoggedIn(true)
     if (typeof window !== 'undefined') {
@@ -145,6 +150,8 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
       cliente: clienteId,
       tour: false,
     })
+    pb.authStore.loadFromCookie(document.cookie)
+    updateBaseAuth(pb.authStore.token, pb.authStore.model)
     await login(email, password)
   }
 

--- a/lib/pocketbase.ts
+++ b/lib/pocketbase.ts
@@ -11,6 +11,9 @@ export function createPocketBase() {
       : new PocketBase(PB_URL)
 
   pb.authStore.save(basePb.authStore.token, basePb.authStore.model)
+  if (typeof document !== 'undefined') {
+    pb.authStore.loadFromCookie(document.cookie)
+  }
   pb.beforeSend = (_, opt) => {
     opt.credentials = 'include'
     return opt

--- a/stories/ProdutosFiltrados.stories.tsx
+++ b/stories/ProdutosFiltrados.stories.tsx
@@ -1,5 +1,5 @@
 import type { Meta, StoryObj } from '@storybook/nextjs'
-import ProdutosFiltrados from '../app/loja/produtos/ProdutosFiltrados'
+import ProdutosFiltrados from '@/components/organisms/ProdutosFiltrados'
 
 const meta = {
   title: 'Loja/ProdutosFiltrados',


### PR DESCRIPTION
## Summary
- sync pocketbase auth after `/api/auth/me`
- sync session on login and sign up
- load cookie auth when creating pocketbase client
- fix build errors by correcting dynamic import paths

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6856074abdac832c91159d5993ea2bf4