### PR TITLE
Fix beforeSend return for PocketBase 0.28+

### DIFF
--- a/lib/pocketbase.ts
+++ b/lib/pocketbase.ts
@@ -11,9 +11,9 @@ export function createPocketBase() {
       : new PocketBase(PB_URL)
 
   pb.authStore.save(basePb.authStore.token, basePb.authStore.model)
-  pb.beforeSend = (_, opt) => {
+  pb.beforeSend = (url, opt) => {
     opt.credentials = 'include'
-    return opt
+    return { url, options: opt }
   }
   pb.autoCancellation(false)
   return pb


### PR DESCRIPTION
## Summary
- adjust the PocketBase client to return `{ url, options }` in `beforeSend`

## Testing
- `npm run lint` *(fails: `next` not found)*
- `npm run build` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6856a514ab64832cb7c01f00bcd71545