### PR TITLE
Documentação de rotas internas para o PocketBase

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,5 +1,6 @@
 
 NEXT_PUBLIC_PB_URL=
+# Todas as chamadas ao PocketBase ocorrem via rotas internas; mantenha esta URL acessível apenas no servidor.
 PB_ADMIN_EMAIL=
 PB_ADMIN_PASSWORD=
 # Opcional. O backend procura primeiro `asaas_api_key` em `m24_clientes`,

--- a/README.md
+++ b/README.md
@@ -99,6 +99,9 @@ Esta integração realiza chamadas HTTP diretamente na API do Asaas, sem utiliza
 1. Defina `NEXT_PUBLIC_PB_URL` apontando para a URL onde o PocketBase está rodando, por exemplo:
 
 2. Utilize as variáveis `PB_ADMIN_EMAIL` e `PB_ADMIN_PASSWORD` para autenticar a aplicação.
+3. **Sempre chame o PocketBase através das rotas internas (`/api/*` ou `/admin/api/*`).**
+   Dessa forma todas as requisições ocorrem no mesmo domínio e os cookies de autenticação
+   são enviados corretamente, eliminando erros de CORS.
 
 ## Fluxo de Cadastro e Checkout
 

--- a/logs/DOC_LOG.md
+++ b/logs/DOC_LOG.md
@@ -331,3 +331,5 @@
 ## [2025-06-21] Componentes de loja e blog movidos para `components/` e inventário atualizado. Lint e build executados.
 
 ## [2025-06-21] Documentadas páginas públicas do admin e adicionados comentários explicativos nos arquivos.
+## [2025-07-21] Orientações de PocketBase atualizadas. README instrui a usar rotas internas
+e .env.example observa que a URL do PB deve ser acessada apenas pelo servidor. Impacto: chamadas sem CORS e variáveis de ambiente simplificadas.

--- a/logs/ERR_LOG.md
+++ b/logs/ERR_LOG.md
@@ -165,3 +165,4 @@
 ## [2025-06-20] Caminho incorreto dos testes de acessibilidade corrigido em package.json - dev - 01d4b28
 
 ## [2025-06-20] Corrigido erro de hidratação e ordem de hooks em UsuariosPage e Layout - dev - 30c0f0f
+## [2025-07-21] Erro de CORS ao chamar o PocketBase diretamente pelo cliente. Agora todas as requisições passam por rotas internas do Next.js. - dev - a521f30


### PR DESCRIPTION
## Summary
- instruções de uso das rotas internas para PocketBase
- comentário no `.env.example` reforçando o acesso via rotas internas
- log de mudança documental
- log de correção de CORS

## Testing
- `npm run lint` *(fails: next not found)*
- `npm run build` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_6856ad1bf294832ca9c32f914d5e0088