### PR TITLE
Atualiza hooks para usar rotas internas

### DIFF
--- a/app/admin/financeiro/transferencias/modals/BankAccountModal.tsx
+++ b/app/admin/financeiro/transferencias/modals/BankAccountModal.tsx
@@ -4,7 +4,6 @@ import { useEffect, useState } from 'react'
 import * as Dialog from '@radix-ui/react-dialog'
 import ModalAnimated from '@/components/organisms/ModalAnimated'
 import SmoothTabs from '@/components/molecules/SmoothTabs'
-import type { UserModel } from '@/types/UserModel'
 import {
   searchBanks,
   createBankAccountApi,

--- a/lib/hooks/useAuth.ts
+++ b/lib/hooks/useAuth.ts
@@ -2,12 +2,12 @@
 
 'use client'
 
-import { useState, useEffect } from 'react'
-import usePocketBase from './usePocketBase'
+import { useState, useEffect, useMemo } from 'react'
+import createPocketBase from '@/lib/pocketbase'
 import type { UserModel } from '@/types/UserModel'
 
 export function useAuth() {
-  const pb = usePocketBase()
+  const pb = useMemo(() => createPocketBase(), [])
   const [user, setUser] = useState<UserModel | null>(null)
   const [token, setToken] = useState<string | null>(null)
   const [isLoggedIn, setIsLoggedIn] = useState(false)

--- a/lib/hooks/useInscricoes.ts
+++ b/lib/hooks/useInscricoes.ts
@@ -1,6 +1,6 @@
 'use client'
 import { useEffect, useState } from 'react'
-import { fetchInscricoes } from '@/lib/services/pocketbase'
+
 import { useAuthContext } from '@/lib/context/AuthContext'
 import type { Inscricao } from '@/types'
 
@@ -12,9 +12,10 @@ export default function useInscricoes() {
   useEffect(() => {
     if (!tenantId) return
     let active = true
-    fetchInscricoes(tenantId)
-      .then((res) => {
-        if (active) setInscricoes(res as unknown as Inscricao[])
+    fetch('/api/inscricoes', { credentials: 'include' })
+      .then((res) => (res.ok ? res.json() : Promise.reject()))
+      .then((data) => {
+        if (active) setInscricoes(data as Inscricao[])
       })
       .catch(() => {
         if (active) setInscricoes([])

--- a/lib/hooks/usePocketBase.ts
+++ b/lib/hooks/usePocketBase.ts
@@ -1,6 +1,0 @@
-import { useMemo } from 'react'
-import createPocketBase from '@/lib/pocketbase'
-
-export default function usePocketBase() {
-  return useMemo(() => createPocketBase(), [])
-}

--- a/lib/hooks/useProdutos.ts
+++ b/lib/hooks/useProdutos.ts
@@ -1,6 +1,6 @@
 'use client'
 import { useEffect, useState } from 'react'
-import { fetchProdutos } from '@/lib/services/pocketbase'
+
 import { useAuthContext } from '@/lib/context/AuthContext'
 import type { Produto } from '@/types'
 
@@ -12,9 +12,10 @@ export default function useProdutos() {
   useEffect(() => {
     if (!tenantId) return
     let active = true
-    fetchProdutos(tenantId)
-      .then((res) => {
-        if (active) setProdutos(res as unknown as Produto[])
+    fetch('/api/produtos', { credentials: 'include' })
+      .then((res) => (res.ok ? res.json() : Promise.reject()))
+      .then((data) => {
+        if (active) setProdutos(data as Produto[])
       })
       .catch(() => {
         if (active) setProdutos([])


### PR DESCRIPTION
## Summary
- fetch inscricoes e produtos via API com credenciais
- remove o hook `usePocketBase`
- ajusta `useAuth` para criar PocketBase direto
- remove import não utilizado em `BankAccountModal`

## Testing
- `npm run lint`
- `npm run build`
- `npm run test` *(falha: TypeError em vitest.setup.ts)*

------
https://chatgpt.com/codex/tasks/task_e_6856ae6855bc832c8e7842b83a6eaccf