### PR TITLE
Implement API wrappers for loja

### DIFF
--- a/app/api/tenant-config/route.ts
+++ b/app/api/tenant-config/route.ts
@@ -1,0 +1,56 @@
+import { NextRequest, NextResponse } from 'next/server'
+import createPocketBase from '@/lib/pocketbase'
+import { getTenantFromHost } from '@/lib/getTenantFromHost'
+import { requireRole } from '@/lib/apiAuth'
+import { logConciliacaoErro } from '@/lib/server/logger'
+
+export async function GET() {
+  const pb = createPocketBase()
+  const tenantId = await getTenantFromHost()
+
+  if (!tenantId) {
+    return NextResponse.json({ error: 'Tenant n\u00e3o informado' }, { status: 400 })
+  }
+
+  try {
+    const cfg = await pb
+      .collection('clientes_config')
+      .getFirstListItem(`cliente='${tenantId}'`)
+
+    return NextResponse.json({
+      id: cfg.id,
+      nome: cfg.nome ?? '',
+      cor_primary: cfg.cor_primary ?? '',
+      logo_url: cfg.logo_url ?? '',
+      font: cfg.font ?? '',
+      confirma_inscricoes: cfg.confirmaInscricoes ?? cfg.confirma_inscricoes ?? false,
+    })
+  } catch (err) {
+    await logConciliacaoErro(`Erro ao obter tenant-config: ${String(err)}`)
+    return NextResponse.json({ error: 'Erro ao obter' }, { status: 500 })
+  }
+}
+
+export async function PUT(req: NextRequest) {
+  const auth = requireRole(req, 'coordenador')
+  if ('error' in auth) {
+    return NextResponse.json({ error: auth.error }, { status: auth.status })
+  }
+  const { pb, user } = auth
+  try {
+    const data = await req.json()
+    const cfg = await pb
+      .collection('clientes_config')
+      .getFirstListItem(`cliente='${user.cliente}'`)
+    const updated = await pb.collection('clientes_config').update(cfg.id, {
+      cor_primary: data.cor_primary,
+      logo_url: data.logo_url,
+      font: data.font,
+      confirma_inscricoes: data.confirma_inscricoes,
+    })
+    return NextResponse.json(updated)
+  } catch (err) {
+    await logConciliacaoErro(`Erro ao atualizar tenant-config: ${String(err)}`)
+    return NextResponse.json({ error: 'Erro ao atualizar' }, { status: 500 })
+  }
+}

--- a/app/api/usuarios/[id]/route.ts
+++ b/app/api/usuarios/[id]/route.ts
@@ -1,6 +1,28 @@
 import { NextRequest, NextResponse } from 'next/server'
 import { requireRole } from '@/lib/apiAuth'
 
+export async function GET(req: NextRequest) {
+  const id = req.nextUrl.pathname.split('/').pop() || ''
+  if (!id) {
+    return NextResponse.json({ error: 'ID inv\u00e1lido' }, { status: 400 })
+  }
+  const auth = requireRole(req, 'usuario')
+  if ('error' in auth) {
+    return NextResponse.json({ error: auth.error }, { status: auth.status })
+  }
+  const { pb, user } = auth
+  if (user.id !== id) {
+    return NextResponse.json({ error: 'Acesso negado' }, { status: 403 })
+  }
+  try {
+    const record = await pb.collection('usuarios').getOne(id, { expand: 'campo' })
+    return NextResponse.json(record, { status: 200 })
+  } catch (err) {
+    console.error('Erro ao obter usuario:', err)
+    return NextResponse.json({ error: 'Erro ao obter' }, { status: 500 })
+  }
+}
+
 export async function PATCH(req: NextRequest) {
   const id = req.nextUrl.pathname.split('/').pop() || ''
   if (!id) {

--- a/components/organisms/BlogClient.tsx
+++ b/components/organisms/BlogClient.tsx
@@ -17,7 +17,6 @@ const BlogHeroCarousel = dynamic(
 const BlogPostsList = dynamic(
   () => import('@/components/organisms/BlogPostsList'),
 )
-import createPocketBase from '@/lib/pocketbase'
 import type { Cliente } from '@/types'
 import {
   getPostsClientPB,
@@ -32,17 +31,12 @@ export default function BlogClient() {
   const [nomeCliente, setNomeCliente] = useState('')
 
   useEffect(() => {
-    const pb = createPocketBase()
     async function fetchCliente() {
       try {
-        const res = await fetch('/api/tenant')
-        const data = (await res.json()) as { tenantId: string | null }
-        const id = data.tenantId
-        if (id) {
-          const c = await pb
-            .collection('clientes_config')
-            .getFirstListItem<Cliente>(`cliente='${id}'`)
-          setNomeCliente(c?.nome ?? '')
+        const res = await fetch('/api/tenant-config', { credentials: 'include' })
+        if (res.ok) {
+          const data = (await res.json()) as Cliente
+          setNomeCliente(data?.nome ?? '')
         } else {
           setNomeCliente('')
         }

--- a/logs/DOC_LOG.md
+++ b/logs/DOC_LOG.md
@@ -337,3 +337,5 @@
 ## [2025-06-21] Rotas de login e recuperar-link agora usam createPocketBase e .env atualizado para PB_URL. Lint e build executados.
 
 ## [2025-07-19] Rotas lider, inscricoes, pedidos, n8n e asaas movidas de /admin/api para /api. Documentação e testes atualizados. Lint e build executados.
+
+## [2025-06-21] Rotas publicas para tenant-config, produtos e pedidos criadas. Frontend da loja agora usa fetch nas novas rotas e não expõe PocketBase. Lint e build executados.

--- a/logs/ERR_LOG.md
+++ b/logs/ERR_LOG.md
@@ -167,3 +167,7 @@
 ## [2025-06-20] Corrigido erro de hidratação e ordem de hooks em UsuariosPage e Layout - dev - 30c0f0f
 
 ## [2025-07-21] Erro de CORS ao chamar o PocketBase diretamente pelo cliente. Agora todas as requisições passam por rotas internas do Next.js. - dev - a521f30
+
+## [2025-06-21] Lint falhou: next not found - dev
+
+## [2025-06-21] Build falhou: next not found - dev


### PR DESCRIPTION
## Summary
- add `/api/tenant-config` endpoint
- extend `/api/pedidos` to handle loja orders
- expose GET `/api/usuarios/[id]`
- refactor tenant context, blog client and loja pages to use the new routes
- log docs and failures

## Testing
- `npm run lint` *(fails: next not found)*
- `npm run build` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_6856bc581d8c832cb4dc621c6e2695ad