### PR TITLE
Remove PB from auth hooks

### DIFF
--- a/__tests__/inscricoesPage.test.tsx
+++ b/__tests__/inscricoesPage.test.tsx
@@ -4,89 +4,9 @@ import { render, screen, fireEvent } from '@testing-library/react'
 import { vi } from 'vitest'
 import ListaInscricoesPage from '@/app/admin/inscricoes/page'
 
-const pbMock = {
-  autoCancellation: vi.fn(),
-  collection: vi.fn((name: string) => {
-    if (name === 'inscricoes') {
-      return {
-        getFullList: vi.fn().mockResolvedValue([
-          {
-            id: '1',
-            nome: 'Fulano',
-            telefone: '999999',
-            cpf: '123',
-            evento: 'evt1',
-            status: 'pendente',
-            created: '2025-01-01',
-            produto: 'Prod',
-            tamanho: 'P',
-            genero: 'm',
-            email: 'f@e.com',
-            paymentMethod: 'pix',
-            installments: 2,
-            criado_por: 'u1',
-            expand: {
-              campo: { nome: 'Campo 1', id: 'c1', responsavel: 'r1' },
-              evento: { titulo: 'Congresso Teste' },
-              pedido: { id: 'p1', status: 'pago', valor: 10 },
-            },
-          },
-        ]),
-        getOne: vi.fn().mockResolvedValue({
-          id: '1',
-          nome: 'Fulano',
-          telefone: '999999',
-          cpf: '123',
-          evento: 'evt1',
-          status: 'pendente',
-          created: '2025-01-01',
-          produto: 'Prod',
-          tamanho: 'P',
-          genero: 'm',
-          email: 'f@e.com',
-          paymentMethod: 'pix',
-          installments: 2,
-          criado_por: 'u1',
-          expand: {
-            campo: { nome: 'Campo 1', id: 'c1', responsavel: 'r1' },
-          },
-        }),
-        update: vi.fn().mockResolvedValue({}),
-      }
-    }
-    if (name === 'eventos') {
-      return {
-        getFullList: vi
-          .fn()
-          .mockResolvedValue([{ id: 'evt1', titulo: 'Congresso Teste' }]),
-        getOne: vi
-          .fn()
-          .mockResolvedValue({ id: 'evt1', expand: { produtos: [] } }),
-      }
-    }
-    if (name === 'produtos') {
-      return {
-        getFirstListItem: vi.fn().mockResolvedValue({
-          nome: 'Prod',
-          preco: 10,
-          tamanhos: ['P'],
-          generos: ['m'],
-        }),
-      }
-    }
-    if (name === 'pedidos') {
-      return {
-        create: vi.fn().mockResolvedValue({ id: 'ped1', valor: 10 }),
-      }
-    }
-    return {}
-  }),
-}
-
 vi.mock('@/lib/hooks/useAuthGuard', () => ({
   useAuthGuard: () => ({
     user: { id: 'u1', role: 'coordenador', cliente: 't1' },
-    pb: pbMock,
     authChecked: true,
   }),
 }))

--- a/app/admin/dashboard/page.tsx
+++ b/app/admin/dashboard/page.tsx
@@ -1,14 +1,16 @@
 'use client'
 
 import { useAuthGuard } from '@/lib/hooks/useAuthGuard'
-import { useEffect, useRef, useState } from 'react'
+import { useEffect, useMemo, useRef, useState } from 'react'
+import createPocketBase from '@/lib/pocketbase'
 import type { Inscricao, Pedido } from '@/types'
 import DashboardResumo from './components/DashboardResumo'
 import DashboardAnalytics from '../components/DashboardAnalytics'
 import LoadingOverlay from '@/components/organisms/LoadingOverlay'
 
 export default function DashboardPage() {
-  const { user, pb, authChecked } = useAuthGuard(['coordenador', 'lider'])
+  const { user, authChecked } = useAuthGuard(['coordenador', 'lider'])
+  const pb = useMemo(() => createPocketBase(), [])
   const [inscricoes, setInscricoes] = useState<Inscricao[]>([])
   const [pedidos, setPedidos] = useState<Pedido[]>([])
   const [loading, setLoading] = useState(true)

--- a/app/admin/inscricoes/componentes/ModalEdit.tsx
+++ b/app/admin/inscricoes/componentes/ModalEdit.tsx
@@ -1,8 +1,9 @@
 'use client'
 
-import { FormEvent, useEffect, useState } from 'react'
+import { FormEvent, useEffect, useMemo, useState } from 'react'
 import { Inscricao, Evento } from '@/types'
 import { useAuth } from '@/lib/hooks/useAuth'
+import createPocketBase from '@/lib/pocketbase'
 
 type Props = {
   inscricao: Inscricao & { eventoId: string }
@@ -17,7 +18,8 @@ export default function ModalEditarInscricao({
   onClose,
   onSave,
 }: Props) {
-  const { user, pb } = useAuth()
+  const { user } = useAuth()
+  const pb = useMemo(() => createPocketBase(), [])
   const [eventos, setEventos] = useState<Evento[]>([])
 
   useEffect(() => {

--- a/app/admin/inscricoes/page.tsx
+++ b/app/admin/inscricoes/page.tsx
@@ -1,6 +1,6 @@
 'use client'
 
-import { useEffect, useState } from 'react'
+import { useEffect, useMemo, useState } from 'react'
 import { Copy } from 'lucide-react'
 import { saveAs } from 'file-saver'
 import LoadingOverlay from '@/components/organisms/LoadingOverlay'
@@ -10,6 +10,7 @@ import { CheckCircle, XCircle, Pencil, Trash2, Eye } from 'lucide-react'
 import TooltipIcon from '../components/TooltipIcon'
 import { useToast } from '@/lib/context/ToastContext'
 import { useAuthGuard } from '@/lib/hooks/useAuthGuard'
+import createPocketBase from '@/lib/pocketbase'
 import { type PaymentMethod } from '@/lib/asaasFees'
 import type {
   Evento,
@@ -48,7 +49,8 @@ type Inscricao = {
 }
 
 export default function ListaInscricoesPage() {
-  const { user, pb, authChecked } = useAuthGuard(['coordenador', 'lider'])
+  const { user, authChecked } = useAuthGuard(['coordenador', 'lider'])
+  const pb = useMemo(() => createPocketBase(), [])
   const tenantId = user?.cliente || ''
   const [inscricoes, setInscricoes] = useState<Inscricao[]>([])
   const [role, setRole] = useState('')

--- a/app/admin/lider-painel/page.tsx
+++ b/app/admin/lider-painel/page.tsx
@@ -1,13 +1,15 @@
 'use client'
 
-import { useEffect, useRef, useState } from 'react'
+import { useEffect, useMemo, useRef, useState } from 'react'
 import { useAuthGuard } from '@/lib/hooks/useAuthGuard'
+import createPocketBase from '@/lib/pocketbase'
 import DashboardAnalytics from '../components/DashboardAnalytics'
 import type { Inscricao, Pedido } from '@/types'
 import LoadingOverlay from '@/components/organisms/LoadingOverlay'
 
 export default function LiderDashboardPage() {
-  const { user, pb, authChecked } = useAuthGuard(['lider'])
+  const { user, authChecked } = useAuthGuard(['lider'])
+  const pb = useMemo(() => createPocketBase(), [])
 
   const [inscricoes, setInscricoes] = useState<Inscricao[]>([])
   const [pedidos, setPedidos] = useState<Pedido[]>([])

--- a/app/admin/pedidos/page.tsx
+++ b/app/admin/pedidos/page.tsx
@@ -1,6 +1,7 @@
 'use client'
 
-import { useEffect, useState } from 'react'
+import { useEffect, useMemo, useState } from 'react'
+import createPocketBase from '@/lib/pocketbase'
 import { useAuthGuard } from '@/lib/hooks/useAuthGuard'
 import { Pedido } from '@/types'
 import { saveAs } from 'file-saver'
@@ -9,7 +10,8 @@ import ModalEditarPedido from './componentes/ModalEditarPedido'
 import { useToast } from '@/lib/context/ToastContext'
 
 export default function PedidosPage() {
-  const { user, pb, authChecked } = useAuthGuard(['coordenador', 'lider'])
+  const { user, authChecked } = useAuthGuard(['coordenador', 'lider'])
+  const pb = useMemo(() => createPocketBase(), [])
 
   const [pedidos, setPedidos] = useState<Pedido[]>([])
   const [loading, setLoading] = useState(true)

--- a/app/admin/perfil/page.tsx
+++ b/app/admin/perfil/page.tsx
@@ -1,8 +1,9 @@
 'use client'
 
-import { useEffect, useState } from 'react'
+import { useEffect, useMemo, useState } from 'react'
 import { useAuthGuard } from '@/lib/hooks/useAuthGuard'
 import ModalEditarPerfil from './components/ModalEditarPerfil'
+import createPocketBase from '@/lib/pocketbase'
 
 interface UsuarioAuthModel {
   id: string
@@ -26,11 +27,11 @@ interface UsuarioAuthModel {
 }
 
 export default function PerfilPage() {
-  const {
-    user: usuarioGuard,
-    pb,
-    authChecked,
-  } = useAuthGuard(['coordenador', 'lider'])
+  const { user: usuarioGuard, authChecked } = useAuthGuard([
+    'coordenador',
+    'lider',
+  ])
+  const pb = useMemo(() => createPocketBase(), [])
   const [usuario, setUsuario] = useState<UsuarioAuthModel | null>(
     usuarioGuard as UsuarioAuthModel | null,
   )

--- a/app/cliente/components/DashboardHeader.tsx
+++ b/app/cliente/components/DashboardHeader.tsx
@@ -1,10 +1,12 @@
 'use client'
 import { useAuthGuard } from '@/lib/hooks/useAuthGuard'
-import { useEffect, useState } from 'react'
+import { useEffect, useMemo, useState } from 'react'
+import createPocketBase from '@/lib/pocketbase'
 import type { Pedido, Inscricao } from '@/types'
 
 export default function DashboardHeader() {
-  const { user, pb, authChecked } = useAuthGuard(['usuario'])
+  const { user, authChecked } = useAuthGuard(['usuario'])
+  const pb = useMemo(() => createPocketBase(), [])
   const [inscricoes, setInscricoes] = useState<Inscricao[]>([])
   const [pedidos, setPedidos] = useState<Pedido[]>([])
 

--- a/app/cliente/components/InscricoesTable.tsx
+++ b/app/cliente/components/InscricoesTable.tsx
@@ -1,10 +1,12 @@
 'use client'
 import { useAuthGuard } from '@/lib/hooks/useAuthGuard'
-import { useEffect, useState } from 'react'
+import { useEffect, useMemo, useState } from 'react'
+import createPocketBase from '@/lib/pocketbase'
 import type { Inscricao } from '@/types'
 
 export default function InscricoesTable({ limit }: { limit?: number }) {
-  const { user, pb, authChecked } = useAuthGuard(['usuario'])
+  const { user, authChecked } = useAuthGuard(['usuario'])
+  const pb = useMemo(() => createPocketBase(), [])
   const [inscricoes, setInscricoes] = useState<Inscricao[]>([])
 
   useEffect(() => {

--- a/app/cliente/components/PedidosTable.tsx
+++ b/app/cliente/components/PedidosTable.tsx
@@ -1,10 +1,12 @@
 'use client'
 import { useAuthGuard } from '@/lib/hooks/useAuthGuard'
-import { useEffect, useState } from 'react'
+import { useEffect, useMemo, useState } from 'react'
+import createPocketBase from '@/lib/pocketbase'
 import type { Pedido } from '@/types'
 
 export default function PedidosTable({ limit }: { limit?: number }) {
-  const { user, pb, authChecked } = useAuthGuard(['usuario'])
+  const { user, authChecked } = useAuthGuard(['usuario'])
+  const pb = useMemo(() => createPocketBase(), [])
   const [pedidos, setPedidos] = useState<Pedido[]>([])
 
   useEffect(() => {

--- a/app/cliente/components/ProfileForm.tsx
+++ b/app/cliente/components/ProfileForm.tsx
@@ -1,11 +1,13 @@
 'use client'
 import { useAuthGuard } from '@/lib/hooks/useAuthGuard'
-import { useEffect, useState } from 'react'
+import { useEffect, useMemo, useState } from 'react'
+import createPocketBase from '@/lib/pocketbase'
 import { useToast } from '@/lib/context/ToastContext'
 import { FormField, TextField, InputWithMask } from '@/components'
 
 export default function ProfileForm() {
-  const { user, pb, authChecked } = useAuthGuard(['usuario'])
+  const { user, authChecked } = useAuthGuard(['usuario'])
+  const pb = useMemo(() => createPocketBase(), [])
   const { showSuccess, showError } = useToast()
 
   const [nome, setNome] = useState('')

--- a/app/loja/checkout/page.tsx
+++ b/app/loja/checkout/page.tsx
@@ -42,7 +42,6 @@ function CheckoutContent() {
   const [installments, setInstallments] = useState(1)
   const [redirecting, setRedirecting] = useState(false)
   const [campoId, setCampoId] = useState<string | null>(null)
-  const [liderId, setLiderId] = useState<string | null>(null)
 
   // 1. calcula total líquido
   const total = useMemo(
@@ -91,7 +90,6 @@ function CheckoutContent() {
         const campo =
           (u.expand?.campo as { id?: string; responsavel?: string }) || {}
         setCampoId((u as { campo?: string }).campo || campo.id || null)
-        setLiderId(typeof campo.responsavel === 'string' ? campo.responsavel : null)
       })
       .catch(() => {
         /* ignore */
@@ -135,7 +133,6 @@ function CheckoutContent() {
 
   const handleConfirm = async () => {
     setStatus('loading')
-    let pedidoId: string | undefined
     try {
       const itensPayload = await Promise.all(
         itens.map(async (i) => {
@@ -214,14 +211,13 @@ function CheckoutContent() {
       })
       const pedidoData = await pedidoRes.json()
       if (!pedidoRes.ok) throw new Error('Erro ao criar pedido')
-      pedidoId = pedidoData.pedidoId
 
       const payload = {
         valorBruto,
         paymentMethod,
         itens: itensPayload,
-        successUrl: `${window.location.origin}/loja/sucesso?pedido=${pedido.id}`,
-        errorUrl: `${window.location.origin}/loja/sucesso?pedido=${pedido.id}`,
+        successUrl: `${window.location.origin}/loja/sucesso?pedido=${pedidoData.pedidoId}`,
+        errorUrl: `${window.location.origin}/loja/sucesso?pedido=${pedidoData.pedidoId}`,
         clienteId: tenantId,
         usuarioId: user.id,
         cliente: {

--- a/app/loja/cliente/page.tsx
+++ b/app/loja/cliente/page.tsx
@@ -1,11 +1,13 @@
 'use client'
 
-import { useEffect, useState } from 'react'
+import { useEffect, useMemo, useState } from 'react'
 import { useAuthGuard } from '@/lib/hooks/useAuthGuard'
+import createPocketBase from '@/lib/pocketbase'
 import type { Inscricao, Pedido } from '@/types'
 
 export default function AreaCliente() {
-  const { user, pb, authChecked } = useAuthGuard(['usuario'])
+  const { user, authChecked } = useAuthGuard(['usuario'])
+  const pb = useMemo(() => createPocketBase(), [])
   const [inscricoes, setInscricoes] = useState<Inscricao[]>([])
   const [pedidos, setPedidos] = useState<Pedido[]>([])
 

--- a/app/loja/perfil/page.tsx
+++ b/app/loja/perfil/page.tsx
@@ -1,7 +1,8 @@
 'use client'
 
-import { useEffect, useState } from 'react'
+import { useEffect, useMemo, useState } from 'react'
 import { useAuthGuard } from '@/lib/hooks/useAuthGuard'
+import createPocketBase from '@/lib/pocketbase'
 import ModalEditarPerfil from '@/app/admin/perfil/components/ModalEditarPerfil'
 
 interface UsuarioAuthModel {
@@ -26,7 +27,8 @@ interface UsuarioAuthModel {
 }
 
 export default function PerfilPage() {
-  const { pb, authChecked } = useAuthGuard(['usuario'])
+  const { authChecked } = useAuthGuard(['usuario'])
+  const pb = useMemo(() => createPocketBase(), [])
   const [usuario, setUsuario] = useState<UsuarioAuthModel | null>(null)
   const [mostrarModal, setMostrarModal] = useState(false)
 

--- a/lib/hooks/useAuth.ts
+++ b/lib/hooks/useAuth.ts
@@ -33,6 +33,5 @@ export function useAuth() {
     user,
     token,
     isLoggedIn,
-    pb,
   }
 }

--- a/lib/hooks/useAuthGuard.ts
+++ b/lib/hooks/useAuthGuard.ts
@@ -9,7 +9,7 @@ import { useAuth } from './useAuth'
 export function useAuthGuard(
   rolesPermitidos: string[] = ['coordenador', 'lider'],
 ) {
-  const { user, isLoggedIn, pb } = useAuth()
+  const { user, isLoggedIn } = useAuth()
   const router = useRouter()
 
   const [authChecked, setAuthChecked] = useState(false)
@@ -20,12 +20,11 @@ export function useAuthGuard(
     const temPermissao = user && rolesPermitidos.includes(user.role)
 
     if (!isLoggedIn || !temPermissao) {
-      pb.authStore.clear()
       router.replace('/login')
     } else {
       setAuthChecked(true)
     }
-  }, [isLoggedIn, user, rolesPermitidos, pb, router])
+  }, [isLoggedIn, user, rolesPermitidos, router])
 
-  return { user, pb, authChecked }
+  return { user, authChecked }
 }


### PR DESCRIPTION
## Summary
- remove PocketBase instance from `useAuth`
- refactor `useAuthGuard` to only verify user and login state
- update components to create PocketBase locally instead of from the hook
- adjust unit tests
- fix lint issues in checkout page

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6856c1b85400832ca6531ba83d00e2bd