### PR TITLE
Support multiple roles on inscriptions API

### DIFF
--- a/__tests__/api/inscricoesRoute.test.ts
+++ b/__tests__/api/inscricoesRoute.test.ts
@@ -1,0 +1,90 @@
+import { describe, it, expect, vi } from 'vitest'
+import { GET } from '../../app/api/inscricoes/route'
+import { NextRequest } from 'next/server'
+import createPocketBaseMock from '../mocks/pocketbase'
+
+const getListMock = vi.fn().mockResolvedValue({ items: [] })
+const pb = createPocketBaseMock()
+pb.collection.mockReturnValue({ getList: getListMock })
+
+vi.mock('../../lib/apiAuth', () => ({ requireRole: vi.fn() }))
+import { requireRole } from '../../lib/apiAuth'
+
+vi.mock('../../lib/getTenantFromHost', () => ({ getTenantFromHost: vi.fn() }))
+import { getTenantFromHost } from '../../lib/getTenantFromHost'
+
+describe('GET /api/inscricoes', () => {
+  it('filtra por criado_por quando usuario', async () => {
+    ;(requireRole as unknown as { mockReturnValue: (v: any) => void }).mockReturnValue({
+      pb,
+      user: { id: 'u1', role: 'usuario' },
+    })
+    const req = new Request('http://test/api/inscricoes?perPage=5&status=pendente')
+    ;(req as any).nextUrl = new URL('http://test/api/inscricoes?perPage=5&status=pendente')
+    const res = await GET(req as unknown as NextRequest)
+    expect(res.status).toBe(200)
+    expect(getListMock).toHaveBeenCalledWith(
+      1,
+      5,
+      expect.objectContaining({
+        filter: "criado_por = \"u1\" && status='pendente'",
+        expand: 'evento',
+        sort: '-created',
+      }),
+    )
+  })
+
+  it('filtra por campo quando lider', async () => {
+    ;(requireRole as unknown as { mockReturnValue: (v: any) => void }).mockReturnValue({
+      pb,
+      user: { id: 'u1', role: 'lider', campo: 'c1' },
+    })
+    const req = new Request('http://test/api/inscricoes?perPage=20')
+    ;(req as any).nextUrl = new URL('http://test/api/inscricoes?perPage=20')
+    const res = await GET(req as unknown as NextRequest)
+    expect(res.status).toBe(200)
+    expect(getListMock).toHaveBeenLastCalledWith(
+      1,
+      20,
+      expect.objectContaining({
+        filter: 'campo = "c1"',
+        expand: 'evento',
+        sort: '-created',
+      }),
+    )
+  })
+
+  it('filtra por cliente quando coordenador', async () => {
+    ;(requireRole as unknown as { mockReturnValue: (v: any) => void }).mockReturnValue({
+      pb,
+      user: { id: 'u1', role: 'coordenador' },
+    })
+    ;(getTenantFromHost as unknown as { mockResolvedValue: (v: any) => void }).mockResolvedValue('t1')
+    const req = new Request('http://test/api/inscricoes?status=ativo')
+    ;(req as any).nextUrl = new URL('http://test/api/inscricoes?status=ativo')
+    const res = await GET(req as unknown as NextRequest)
+    expect(res.status).toBe(200)
+    expect(getTenantFromHost).toHaveBeenCalled()
+    expect(getListMock).toHaveBeenLastCalledWith(
+      1,
+      50,
+      expect.objectContaining({
+        filter: "cliente = \"t1\" && status='ativo'",
+        expand: 'evento',
+        sort: '-created',
+      }),
+    )
+  })
+
+  it('retorna 400 quando coordenador sem tenant', async () => {
+    ;(requireRole as unknown as { mockReturnValue: (v: any) => void }).mockReturnValue({
+      pb,
+      user: { id: 'u1', role: 'coordenador' },
+    })
+    ;(getTenantFromHost as unknown as { mockResolvedValue: (v: any) => void }).mockResolvedValue(null)
+    const req = new Request('http://test/api/inscricoes')
+    ;(req as any).nextUrl = new URL('http://test/api/inscricoes')
+    const res = await GET(req as unknown as NextRequest)
+    expect(res.status).toBe(400)
+  })
+})

--- a/__tests__/apiAuth.test.ts
+++ b/__tests__/apiAuth.test.ts
@@ -26,6 +26,17 @@ describe('requireRole', () => {
     expect(res).toEqual({ error: 'Acesso negado', status: 403 })
   })
 
+  it('retorna 403 quando papel nao incluso na lista', () => {
+    const pb = {}
+    vi.spyOn(headers, 'getUserFromHeaders').mockReturnValue({
+      user: { role: 'user' } as any,
+      pbSafe: pb as any,
+    })
+    const req = new Request('http://test')
+    const res = requireRole(req as unknown as NextRequest, ['admin', 'lider'])
+    expect(res).toEqual({ error: 'Acesso negado', status: 403 })
+  })
+
   it('retorna objeto RequireRoleOk quando papel correto', () => {
     const pb = { test: true }
     const user = { role: 'admin', id: 'u1' } as any
@@ -35,6 +46,18 @@ describe('requireRole', () => {
     })
     const req = new Request('http://test')
     const res = requireRole(req as unknown as NextRequest, 'admin')
+    expect(res).toEqual({ user, pb })
+  })
+
+  it('retorna objeto RequireRoleOk quando papel presente na lista', () => {
+    const pb = { test: true }
+    const user = { role: 'lider', id: 'u2' } as any
+    vi.spyOn(headers, 'getUserFromHeaders').mockReturnValue({
+      user,
+      pbSafe: pb as any,
+    })
+    const req = new Request('http://test')
+    const res = requireRole(req as unknown as NextRequest, ['admin', 'lider'])
     expect(res).toEqual({ user, pb })
   })
 })

--- a/lib/apiAuth.ts
+++ b/lib/apiAuth.ts
@@ -15,7 +15,7 @@ export type RequireRoleError = {
 
 export function requireRole(
   req: NextRequest,
-  role: string,
+  roles: string | string[],
 ): RequireRoleOk | RequireRoleError {
   const result = getUserFromHeaders(req)
 
@@ -25,7 +25,9 @@ export function requireRole(
 
   const { user, pbSafe } = result
 
-  if (user.role !== role) {
+  const allowed = Array.isArray(roles) ? roles : [roles]
+
+  if (!allowed.includes(user.role)) {
     return { error: 'Acesso negado', status: 403 }
   }
 


### PR DESCRIPTION
## Summary
- allow `requireRole` to check multiple roles
- add new tests for `requireRole`
- enhance `/api/inscricoes` route with tenant-based filters and query params
- add comprehensive tests for the route

## Testing
- `npm run lint` *(fails: next not found)*
- `npm run build` *(fails: next not found)*
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6856d4af125c832c94c0caf25eed5327