### PR TITLE
Adicionar regras de visualização de inscrições

### DIFF
--- a/README.md
+++ b/README.md
@@ -259,6 +259,8 @@ O sistema possui três níveis de usuário:
 Coordenadores visualizam as métricas financeiras completas no painel.
 Líderes veem apenas a quantidade de inscrições e pedidos do seu campo.
 
+Para mais detalhes de visualização das inscrições e parâmetros de filtro da API, consulte [docs/regras-inscricoes.md](docs/regras-inscricoes.md).
+
 ## Blog e CMS
 
 Os posts agora ficam na coleção `posts` do PocketBase, em vez de arquivos `.mdx`.

--- a/docs/regras-inscricoes.md
+++ b/docs/regras-inscricoes.md
@@ -1,0 +1,29 @@
+# Regras de Visualiza\u00e7\u00e3o e Inscri\u00e7\u00f5es
+
+Este documento descreve como cada perfil acessa as inscri\u00e7\u00f5es, o processo de cria\u00e7\u00e3o realizado pelo usu\u00e1rio e os par\u00e2metros dispon\u00edveis na API.
+
+## Perfis Dispon\u00edveis
+
+- **Coordenador**
+- **L\u00edder**
+- **Usu\u00e1rio**
+
+## Escopo de Visualiza\u00e7\u00e3o
+
+- **Coordenador** – visualiza todas as inscri\u00e7\u00f5es de todos os campos e pode aprovar ou cancelar cada uma.
+- **L\u00edder** – visualiza somente as inscri\u00e7\u00f5es vinculadas ao seu campo.
+- **Usu\u00e1rio** – visualiza apenas as inscri\u00e7\u00f5es feitas por ele na p\u00e1gina `/loja/cliente`.
+
+## Cria\u00e7\u00e3o de Inscri\u00e7\u00e3o
+
+1. O usu\u00e1rio acessa o formul\u00e1rio de inscri\u00e7\u00e3o e preenche seus dados pessoais.
+2. Seleciona o campo desejado e confirma os termos de participa\u00e7\u00e3o.
+3. Escolhe o produto de inscri\u00e7\u00e3o (quando houver) e envia o formul\u00e1rio.
+4. A lideran\u00e7a aprova a inscri\u00e7\u00e3o caso o modo de confirma\u00e7\u00e3o manual esteja habilitado.
+
+## Par\u00e2metros da API
+
+A rota `GET /api/inscricoes` aceita os seguintes filtros:
+
+- `status` – filtra por status da inscri\u00e7\u00e3o (ex.: `pendente`, `aprovado`, `cancelado`).
+- `perPage` – define a quantidade de registros retornados por p\u00e1gina.

--- a/logs/DOC_LOG.md
+++ b/logs/DOC_LOG.md
@@ -339,3 +339,4 @@
 ## [2025-07-19] Rotas lider, inscricoes, pedidos, n8n e asaas movidas de /admin/api para /api. Documentação e testes atualizados. Lint e build executados.
 
 ## [2025-06-21] Rotas publicas para tenant-config, produtos e pedidos criadas. Frontend da loja agora usa fetch nas novas rotas e não expõe PocketBase. Lint e build executados.
+## [2025-07-20] Documentadas regras de acesso às inscrições e filtros da API.


### PR DESCRIPTION
## Summary
- documentar perfis e filtros da API de inscrições
- linkar novas regras no README
- registrar atualização no DOC_LOG

## Testing
- `npm run lint` *(falhou: 'pb' is assigned a value but never used)*
- `npm run build` *(falhou na mesma etapa do lint)*

------
https://chatgpt.com/codex/tasks/task_e_6856d4b083bc832cade685a76aa35882