### PR TITLE
Improve pedidos route tests

### DIFF
--- a/__tests__/admin/pedidosRoute.test.ts
+++ b/__tests__/admin/pedidosRoute.test.ts
@@ -1,14 +1,67 @@
-import { describe, it, expect } from 'vitest'
+import { describe, it, expect, vi, beforeEach } from 'vitest'
 import { POST } from '../../app/api/pedidos/route'
 import { NextRequest } from 'next/server'
+import createPocketBaseMock from '../mocks/pocketbase'
+
+const pb = createPocketBaseMock()
+vi.mock('../../lib/pocketbase', () => ({
+  default: vi.fn(() => pb),
+}))
+
+let getTenantFromHostMock: any
+vi.mock('../../lib/getTenantFromHost', () => ({
+  getTenantFromHost: (...args: any[]) => getTenantFromHostMock(...args),
+}))
+
+beforeEach(() => {
+  getTenantFromHostMock = vi.fn().mockResolvedValue('cli1')
+  pb.collection.mockReset()
+  pb.authStore.model = { id: 'u1' }
+})
 
 describe('POST /admin/api/pedidos', () => {
-  it('retorna 400 quando inscricaoId ausente', async () => {
+  it('retorna 400 quando tenant nao encontrado', async () => {
+    getTenantFromHostMock.mockResolvedValueOnce(null)
     const req = new Request('http://test', {
       method: 'POST',
       body: JSON.stringify({}),
     })
     const res = await POST(req as unknown as NextRequest)
     expect(res.status).toBe(400)
+  })
+
+  it('retorna 401 quando usuario nao autenticado', async () => {
+    pb.authStore.model = undefined
+    const req = new Request('http://test', {
+      method: 'POST',
+      body: JSON.stringify({ produto: 'P' }),
+    })
+    const res = await POST(req as unknown as NextRequest)
+    expect(res.status).toBe(401)
+  })
+
+  it('cria pedido da loja e retorna id', async () => {
+    const createMock = vi
+      .fn()
+      .mockResolvedValue({ id: 'p1', valor: 10, status: 'pendente' })
+    pb.collection.mockReturnValue({ create: createMock })
+
+    const req = new Request('http://test', {
+      method: 'POST',
+      body: JSON.stringify({
+        produto: 'Produto',
+        valor: 10,
+        tamanho: 'M',
+        cor: 'Azul',
+        genero: 'M',
+        campoId: 'c1',
+        email: 'x@y.com',
+      }),
+    })
+
+    const res = await POST(req as unknown as NextRequest)
+    expect(res.status).toBe(200)
+    const body = await res.json()
+    expect(body.pedidoId).toBe('p1')
   })
 })


### PR DESCRIPTION
## Summary
- expand `pedidosRoute` tests with success and failure scenarios

## Testing
- `npm run lint` *(fails: `@typescript-eslint/no-unused-vars` errors)*
- `npm run test:ci` *(fails: `TypeError: Cannot convert undefined or null to object` in `vitest.setup.ts`)*

------
https://chatgpt.com/codex/tasks/task_e_6856d6e762e0832c96644d865e53dc97