### PR TITLE
Fix auth guard redirection

### DIFF
--- a/lib/hooks/useAuthGuard.ts
+++ b/lib/hooks/useAuthGuard.ts
@@ -15,14 +15,17 @@ export function useAuthGuard(
   const [authChecked, setAuthChecked] = useState(false)
 
   useEffect(() => {
-    if (!user && !isLoggedIn) return
+    if (!isLoggedIn) {
+      router.replace('/login')
+      return
+    }
 
     const temPermissao = user && rolesPermitidos.includes(user.role)
 
-    if (!isLoggedIn || !temPermissao) {
-      router.replace('/login')
-    } else {
+    if (temPermissao) {
       setAuthChecked(true)
+    } else {
+      router.replace('/login')
     }
   }, [isLoggedIn, user, rolesPermitidos, router])
 


### PR DESCRIPTION
## Summary
- ensure `useAuthGuard` redirects when logged out regardless of user object

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6856d9887d2c832c932f74473ae04081