### PR TITLE
Fix auth guard hooks and notification

### DIFF
--- a/app/admin/components/NotificationBell.tsx
+++ b/app/admin/components/NotificationBell.tsx
@@ -6,12 +6,16 @@ import type { Inscricao } from '@/types'
 import { useAuthContext } from '@/lib/context/AuthContext'
 
 export default function NotificationBell() {
-  const { tenantId } = useAuthContext()
+  const { tenantId, isLoggedIn, isLoading } = useAuthContext()
   const [count, setCount] = useState(0)
   const [inscricoes, setInscricoes] = useState<Inscricao[]>([])
   const [open, setOpen] = useState(false)
 
   useEffect(() => {
+    if (isLoading || !isLoggedIn) {
+      return
+    }
+
     const fetchData = async () => {
       try {
         const [insRes, pedRes] = await Promise.all([
@@ -43,7 +47,7 @@ export default function NotificationBell() {
     fetchData()
     const id = setInterval(fetchData, 30000)
     return () => clearInterval(id)
-  }, [tenantId])
+  }, [tenantId, isLoggedIn, isLoading])
 
   return (
     <div className="fixed bottom-20 right-4 z-50">

--- a/lib/hooks/useAuthGuard.ts
+++ b/lib/hooks/useAuthGuard.ts
@@ -4,17 +4,21 @@
 
 import { useEffect, useState } from 'react'
 import { useRouter } from 'next/navigation'
-import { useAuth } from './useAuth'
+import { useAuthContext } from '../context/AuthContext'
 
 export function useAuthGuard(
   rolesPermitidos: string[] = ['coordenador', 'lider'],
 ) {
-  const { user, isLoggedIn } = useAuth()
+  const { user, isLoggedIn, isLoading } = useAuthContext()
   const router = useRouter()
 
   const [authChecked, setAuthChecked] = useState(false)
 
   useEffect(() => {
+    if (isLoading) {
+      return
+    }
+
     if (!isLoggedIn) {
       router.replace('/login')
       return
@@ -27,7 +31,7 @@ export function useAuthGuard(
     } else {
       router.replace('/login')
     }
-  }, [isLoggedIn, user, rolesPermitidos, router])
+  }, [isLoggedIn, isLoading, user, rolesPermitidos, router])
 
   return { user, authChecked }
 }

--- a/logs/DOC_LOG.md
+++ b/logs/DOC_LOG.md
@@ -344,3 +344,4 @@
 ## [2025-07-21] Criados docs/regras-pedidos.md e atualizadas instru\u00e7\u00f5es de confirma\u00e7\u00e3o no guia de inscri\u00e7\u00f5es e README. Lint e build executados.
 ## [2025-07-22] Adicionada valida\u00e7\u00e3o de PB_URL em runtime e documenta\u00e7\u00e3o atualizada. Lint e build executados.
 ## [2025-07-23] Adicionado fallback para PB_URL e mensagens de aviso. Documentação e .env.example atualizados. Lint e build executados.
+## [2025-06-21] Correção de proteções de autenticação e notificação usando useAuthContext. Lint e build executados.


### PR DESCRIPTION
## Summary
- use `useAuthContext` in `useAuthGuard`
- add early return for loading state
- prevent NotificationBell API calls when user is loading or logged out
- document fixes

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6856e5000864832cb0f0d42d9b59fa0e