### PR TITLE
Adjust inscricoes list to show expanded pedido and campo

### DIFF
--- a/app/api/inscricoes/route.ts
+++ b/app/api/inscricoes/route.ts
@@ -49,7 +49,7 @@ export async function GET(req: NextRequest) {
     const filtro = status ? `${baseFilter} && status='${status}'` : baseFilter
     const { items } = await pb.collection('inscricoes').getList(1, perPage, {
       filter: filtro,
-      expand: 'evento',
+      expand: 'evento,campo,pedido',
       sort: '-created',
     })
     return NextResponse.json(items, { status: 200 })


### PR DESCRIPTION
## Summary
- update inscricoes GET API to expand `evento`, `campo` and `pedido`
- run lint and build to ensure no type or build errors

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6856ea48979c832cb6f947cd868d7d1f