### PR TITLE
Expand pedidos GET handler

### DIFF
--- a/app/api/pedidos/route.ts
+++ b/app/api/pedidos/route.ts
@@ -34,6 +34,7 @@ export async function GET(req: NextRequest) {
     const { items } = await pb.collection('pedidos').getList(page, perPage, {
       filter: filtro,
       sort: '-created',
+      expand: 'campo,id_inscricao',
     })
     return NextResponse.json(items)
   } catch (err) {


### PR DESCRIPTION
## Summary
- include campo names and inscription info when fetching pedidos
- fetch campo names for filtering

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6856ea4600ec832c85006ac89c945682