### PR TITLE
Fix 500 on missing event

### DIFF
--- a/app/api/eventos/[id]/route.ts
+++ b/app/api/eventos/[id]/route.ts
@@ -1,6 +1,7 @@
 import { NextRequest, NextResponse } from 'next/server'
 import createPocketBase from '@/lib/pocketbase'
 import { logConciliacaoErro } from '@/lib/server/logger'
+import { ClientResponseError } from 'pocketbase'
 
 export async function GET(req: NextRequest) {
   const { pathname } = req.nextUrl
@@ -20,6 +21,9 @@ export async function GET(req: NextRequest) {
     }
     return NextResponse.json(withUrl, { status: 200 })
   } catch (err) {
+    if (err instanceof ClientResponseError && err.status === 404) {
+      return NextResponse.json({ error: 'Evento não encontrado' }, { status: 404 })
+    }
     await logConciliacaoErro(`Erro ao obter evento: ${String(err)}`)
     return NextResponse.json({ error: 'Erro ao obter' }, { status: 500 })
   }

--- a/logs/ERR_LOG.md
+++ b/logs/ERR_LOG.md
@@ -174,3 +174,4 @@
 
 ## [2025-06-21] Corrigido erro 403 no dashboard requisitando admin/api/usuarios/${user.id} - dev - ab8a6ee
 ## [2025-06-21] Erro ao atualizar configuracoes: ClientResponseError 400: Failed to update record. - development
+## [2025-06-21] Corrigido retorno 500 em eventos inexistentes; agora responde 404 - dev


### PR DESCRIPTION
## Summary
- handle PocketBase 404 on GET /api/eventos/[id]
- log fix entry

## Testing
- `npm run lint` *(fails: next not found)*
- `npm run build` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_6856fbf110cc832c934e4622ef4cd32b