### PR TITLE
Support logo field for eventos

### DIFF
--- a/app/admin/api/eventos/[id]/route.ts
+++ b/app/admin/api/eventos/[id]/route.ts
@@ -1,6 +1,7 @@
 import { NextRequest, NextResponse } from 'next/server'
 import { requireRole } from '@/lib/apiAuth'
 import { logConciliacaoErro } from '@/lib/server/logger'
+import type { EventoRecord } from '@/lib/events'
 
 export async function GET(req: NextRequest) {
   const { pathname } = req.nextUrl
@@ -12,12 +13,11 @@ export async function GET(req: NextRequest) {
   }
   const { pb } = auth
   try {
-    const evento = await pb.collection('eventos').getOne(id, {
+    const evento = await pb.collection('eventos').getOne<EventoRecord>(id, {
       expand: 'produtos',
     })
-    const imagemUrl = evento.imagem
-      ? pb.files.getURL(evento, evento.imagem)
-      : undefined
+    const fileName = evento.imagem || evento.logo
+    const imagemUrl = fileName ? pb.files.getURL(evento, fileName) : undefined
     return NextResponse.json({ ...evento, imagemUrl }, { status: 200 })
   } catch (err) {
     await logConciliacaoErro(`Erro ao obter evento: ${String(err)}`)

--- a/app/admin/eventos/editar/[id]/page.tsx
+++ b/app/admin/eventos/editar/[id]/page.tsx
@@ -123,13 +123,13 @@ export default function EditarEventoPage() {
     e.preventDefault()
     const formElement = e.currentTarget as HTMLFormElement
     const formData = new FormData(formElement)
-    const imagemInput = formElement.querySelector<HTMLInputElement>(
-      "input[name='imagem']",
+    const logoInput = formElement.querySelector<HTMLInputElement>(
+      "input[name='logo']",
     )
-    const files = imagemInput?.files
-    formData.delete('imagem')
+    const files = logoInput?.files
+    formData.delete('logo')
     if (files && files.length > 0) {
-      formData.append('imagem', files[0])
+      formData.append('logo', files[0])
     }
     formData.delete('produtos')
     selectedProdutos.forEach((p) => formData.append('produtos', p))
@@ -194,7 +194,7 @@ export default function EditarEventoPage() {
           />
           <input
             type="file"
-            name="imagem"
+            name="logo"
             accept="image/*"
             className="input-base"
           />

--- a/app/admin/eventos/novo/page.tsx
+++ b/app/admin/eventos/novo/page.tsx
@@ -91,13 +91,13 @@ export default function NovoEventoPage() {
     e.preventDefault()
     const formElement = e.currentTarget as HTMLFormElement
     const formData = new FormData(formElement)
-    const imagemInput = formElement.querySelector<HTMLInputElement>(
-      "input[name='imagem']",
+    const logoInput = formElement.querySelector<HTMLInputElement>(
+      "input[name='logo']",
     )
-    const files = imagemInput?.files
-    formData.delete('imagem')
+    const files = logoInput?.files
+    formData.delete('logo')
     if (files && files.length > 0) {
-      formData.append('imagem', files[0])
+      formData.append('logo', files[0])
     }
     formData.delete('produtos')
     selectedProdutos.forEach((p) => formData.append('produtos', p))
@@ -150,7 +150,7 @@ export default function NovoEventoPage() {
           <input className="input-base" name="cidade" required />
           <input
             type="file"
-            name="imagem"
+            name="logo"
             accept="image/*"
             className="input-base"
           />

--- a/app/api/eventos/[id]/route.ts
+++ b/app/api/eventos/[id]/route.ts
@@ -1,6 +1,7 @@
 import { NextRequest, NextResponse } from 'next/server'
 import createPocketBase from '@/lib/pocketbase'
 import { logConciliacaoErro } from '@/lib/server/logger'
+import type { EventoRecord } from '@/lib/events'
 
 export async function GET(req: NextRequest) {
   const { pathname } = req.nextUrl
@@ -11,12 +12,11 @@ export async function GET(req: NextRequest) {
   try {
     const evento = await pb
       .collection('eventos')
-      .getOne(id, { expand: 'produtos' })
+      .getOne<EventoRecord>(id, { expand: 'produtos' })
+    const fileName = evento.imagem || evento.logo
     const withUrl = {
       ...evento,
-      imagem: evento.imagem
-        ? pb.files.getURL(evento, evento.imagem)
-        : undefined,
+      imagem: fileName ? pb.files.getURL(evento, fileName) : undefined,
     }
     return NextResponse.json(withUrl, { status: 200 })
   } catch (err) {

--- a/app/api/eventos/route.ts
+++ b/app/api/eventos/route.ts
@@ -20,10 +20,13 @@ export async function GET() {
       expand: 'produtos',
     })
     await atualizarStatus(eventos, pb)
-    const comUrls = eventos.map((e) => ({
-      ...e,
-      imagem: e.imagem ? pb.files.getURL(e, e.imagem) : undefined,
-    }))
+    const comUrls = eventos.map((e) => {
+      const fileName = e.imagem || e.logo
+      return {
+        ...e,
+        imagem: fileName ? pb.files.getURL(e, fileName) : undefined,
+      }
+    })
     return NextResponse.json(comUrls)
   } catch (err) {
     await logConciliacaoErro(`Erro ao listar eventos: ${String(err)}`)

--- a/lib/events.ts
+++ b/lib/events.ts
@@ -5,6 +5,7 @@ export interface EventoRecord {
   data: string
   cidade: string
   imagem?: string
+  logo?: string
   status: 'realizado' | 'em breve'
   [key: string]: unknown
 }

--- a/logs/ERR_LOG.md
+++ b/logs/ERR_LOG.md
@@ -174,3 +174,4 @@
 
 ## [2025-06-21] Corrigido erro 403 no dashboard requisitando admin/api/usuarios/${user.id} - dev - ab8a6ee
 ## [2025-06-21] Erro ao atualizar configuracoes: ClientResponseError 400: Failed to update record. - development
+## [2025-06-21] Suporte ao campo logo nos eventos e formulários. Rotas corrigidas - dev

--- a/stories/FormWizard.stories.tsx
+++ b/stories/FormWizard.stories.tsx
@@ -20,12 +20,11 @@ export default meta
 type Story = StoryObj<typeof meta>
 
 export const Basic: Story = {
-  render: () => (
-    <FormWizard
-      steps={[
-        { title: 'Passo 1', content: <div>Conteúdo 1</div> },
-        { title: 'Passo 2', content: <div>Conteúdo 2</div> },
-      ]}
-    />
-  ),
+  args: {
+    steps: [
+      { title: 'Passo 1', content: <div>Conteúdo 1</div> },
+      { title: 'Passo 2', content: <div>Conteúdo 2</div> },
+    ],
+  },
+  render: (args) => <FormWizard {...args} />,
 }

--- a/types/index.ts
+++ b/types/index.ts
@@ -118,6 +118,7 @@ export type Evento = {
   data: string
   cidade: string
   imagem?: string
+  logo?: string
   status: 'realizado' | 'em breve'
   cobra_inscricao?: boolean
   /** Produto associado à inscrição do evento */


### PR DESCRIPTION
## Summary
- handle `logo` field in events API
- update admin event forms to upload `logo`
- fix failing FormWizard story
- log bugfix

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_685700c4c374832c9d46c23ef28b3bce