### PR TITLE
Implement user check on signup

### DIFF
--- a/__tests__/api/inscricoesLojaRoute.test.ts
+++ b/__tests__/api/inscricoesLojaRoute.test.ts
@@ -1,0 +1,91 @@
+import { describe, it, expect, vi } from 'vitest'
+import { POST } from '../../app/loja/api/inscricoes/route'
+import { NextRequest } from 'next/server'
+import createPocketBaseMock from '../mocks/pocketbase'
+
+const getFirstMock = vi.fn()
+const createUserMock = vi.fn()
+const createInscricaoMock = vi.fn()
+const pb = createPocketBaseMock()
+
+pb.collection.mockImplementation((name: string) => {
+  if (name === 'usuarios') {
+    return { getFirstListItem: getFirstMock, create: createUserMock }
+  }
+  if (name === 'inscricoes') {
+    return { create: createInscricaoMock }
+  }
+  return {} as any
+})
+
+vi.mock('../../lib/pocketbase', () => ({
+  default: vi.fn(() => pb),
+}))
+
+vi.mock('../../lib/getTenantFromHost', () => ({
+  getTenantFromHost: vi.fn().mockResolvedValue('cli1'),
+}))
+
+describe('POST /loja/api/inscricoes', () => {
+  it('cria usuario quando nao existe', async () => {
+    getFirstMock.mockRejectedValueOnce(new Error('not found'))
+    createUserMock.mockResolvedValueOnce({ id: 'u1' })
+    createInscricaoMock.mockResolvedValueOnce({ id: 'i1' })
+
+    const req = new Request('http://test', {
+      method: 'POST',
+      body: JSON.stringify({
+        user_first_name: 'J',
+        user_last_name: 'D',
+        user_email: 't@test.com',
+        user_phone: '11999999999',
+        user_cpf: '11111111111',
+        user_birth_date: '2000-01-01',
+        user_gender: 'masculino',
+        campo: 'c1',
+        evento: 'e1',
+      }),
+    })
+    const res = await POST(req as unknown as NextRequest)
+    expect(res.status).toBe(201)
+    expect(createUserMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        nome: 'J D',
+        email: 't@test.com',
+        cpf: '11111111111',
+        cliente: 'cli1',
+        campo: 'c1',
+        role: 'usuario',
+      }),
+    )
+    expect(createInscricaoMock).toHaveBeenCalledWith(
+      expect.objectContaining({ criado_por: 'u1' }),
+    )
+  })
+
+  it('usa usuario existente', async () => {
+    getFirstMock.mockResolvedValueOnce({ id: 'u2' })
+    createInscricaoMock.mockResolvedValueOnce({ id: 'i2' })
+
+    const req = new Request('http://test', {
+      method: 'POST',
+      body: JSON.stringify({
+        user_first_name: 'J',
+        user_last_name: 'D',
+        user_email: 't@test.com',
+        user_phone: '11999999999',
+        user_cpf: '11111111111',
+        user_birth_date: '2000-01-01',
+        user_gender: 'masculino',
+        campo: 'c1',
+        evento: 'e1',
+      }),
+    })
+    const res = await POST(req as unknown as NextRequest)
+    expect(res.status).toBe(201)
+    expect(createUserMock).not.toHaveBeenCalled()
+    expect(createInscricaoMock).toHaveBeenCalledWith(
+      expect.objectContaining({ criado_por: 'u2' }),
+    )
+  })
+})

--- a/app/admin/api/configuracoes/route.ts
+++ b/app/admin/api/configuracoes/route.ts
@@ -42,8 +42,7 @@ export async function PUT(req: NextRequest) {
   }
   const { pb, user } = auth
   try {
-    const { cor_primary, logo_url, font, confirma_inscricoes } =
-      await req.json()
+    const { cor_primary, font, confirma_inscricoes } = await req.json()
     const cfg = await pb
       .collection('clientes_config')
       .getFirstListItem(`cliente='${user.cliente}'`)

--- a/app/loja/api/inscricoes/route.ts
+++ b/app/loja/api/inscricoes/route.ts
@@ -15,6 +15,25 @@ export async function POST(req: NextRequest) {
       data.user_last_name || ''
     }`.trim()
 
+    let usuario
+    try {
+      usuario = await pb
+        .collection('usuarios')
+        .getFirstListItem(`email='${data.user_email}'`)
+    } catch {
+      if (!tenantId) {
+        return NextResponse.json({ error: 'Tenant não informado' }, { status: 400 })
+      }
+      usuario = await pb.collection('usuarios').create({
+        nome,
+        email: data.user_email,
+        cpf: String(data.user_cpf).replace(/\D/g, ''),
+        cliente: tenantId,
+        campo: data.campo,
+        role: 'usuario',
+      })
+    }
+
     const registroParaCriar = {
       nome,
       email: data.user_email,
@@ -25,6 +44,7 @@ export async function POST(req: NextRequest) {
       campo: data.campo,
       evento: data.evento,
       status: 'pendente',
+      criado_por: usuario.id,
       ...(tenantId ? { cliente: tenantId } : {}),
     }
 

--- a/docs/regras-inscricoes.md
+++ b/docs/regras-inscricoes.md
@@ -20,6 +20,9 @@ Este documento descreve como cada perfil acessa as inscri\u00e7\u00f5es, o proce
 2. Seleciona o campo desejado e confirma os termos de participa\u00e7\u00e3o.
 3. Escolhe o produto de inscri\u00e7\u00e3o (quando houver) e envia o formul\u00e1rio.
 4. A lideran\u00e7a aprova a inscri\u00e7\u00e3o caso o modo de confirma\u00e7\u00e3o manual esteja habilitado.
+5. A API verifica se já existe usuário com o e-mail informado.
+   - Se existir, o ID é usado em `criado_por`.
+   - Caso contrário, cria usuário e vincula o ID à inscrição.
 
 ## Par\u00e2metros da API
 

--- a/logs/DOC_LOG.md
+++ b/logs/DOC_LOG.md
@@ -354,3 +354,4 @@
 ## [2025-06-21] README atualizado instruindo definir cookie `tenantId` ou registrar domínio em `clientes_config` quando não houver domínio configurado. Lint e build executados.
 
 ## [2025-06-21] Adicionado campo exclusivo_user e componente FormWizard
+## [2025-07-25] Inscrições agora criam usuário automaticamente quando email não existe. Guia atualizado e novo teste. Lint e build executados.


### PR DESCRIPTION
## Summary
- auto-create `usuarios` when POSTing to /loja/api/inscricoes
- use created user ID in `criado_por`
- document signup flow
- log documentation change
- add route test
- fix lint in configuracoes route

## Testing
- `npm run lint`
- `npm run build`
- `npm test` *(fails: Cannot convert undefined or null to object)*

------
https://chatgpt.com/codex/tasks/task_e_685704b78e48832c80185c8cf58d0744