### PR TITLE
Implement user auto-creation on store inscriptions

### DIFF
--- a/__tests__/api/inscricoesLojaRoute.test.ts
+++ b/__tests__/api/inscricoesLojaRoute.test.ts
@@ -53,9 +53,11 @@ describe('POST /loja/api/inscricoes', () => {
         nome: 'J D',
         email: 't@test.com',
         cpf: '11111111111',
+        telefone: '11999999999',
+        data_nascimento: '2000-01-01',
         cliente: 'cli1',
         campo: 'c1',
-        role: 'usuario',
+        perfil: 'usuario',
       }),
     )
     expect(createInscricaoMock).toHaveBeenCalledWith(

--- a/app/loja/api/inscricoes/route.ts
+++ b/app/loja/api/inscricoes/route.ts
@@ -28,9 +28,11 @@ export async function POST(req: NextRequest) {
         nome,
         email: data.user_email,
         cpf: String(data.user_cpf).replace(/\D/g, ''),
+        telefone: String(data.user_phone).replace(/\D/g, ''),
+        data_nascimento: data.user_birth_date,
         cliente: tenantId,
         campo: data.campo,
-        role: 'usuario',
+        perfil: 'usuario',
       })
     }
 


### PR DESCRIPTION
## Summary
- create user with phone, birth date and `perfil` when not found
- test new user creation details and existing-user flow

## Testing
- `npm run lint`
- `npm run build`
- `npm run test` *(fails: TypeError in vitest.setup)*

------
https://chatgpt.com/codex/tasks/task_e_6857071bb15c832cb90e7e13e16b58ca