### PR TITLE
Allow public access to products

### DIFF
--- a/__tests__/api/produtoSlugRoute.test.ts
+++ b/__tests__/api/produtoSlugRoute.test.ts
@@ -4,22 +4,56 @@ import { NextRequest } from 'next/server'
 import createPocketBaseMock from '../mocks/pocketbase'
 
 const pb = createPocketBaseMock()
-pb.collection.mockReturnValue({ getFirstListItem: vi.fn() })
+const getFirstListItemMock = vi.fn()
+pb.collection.mockReturnValue({ getFirstListItem: getFirstListItemMock })
 vi.mock('../../lib/pocketbase', () => ({
   default: vi.fn(() => pb),
 }))
 
-vi.mock('../../lib/getTenantFromHost', () => ({
-  getTenantFromHost: vi.fn().mockResolvedValue(null),
+vi.mock('../../lib/getUserFromHeaders', () => ({
+  getUserFromHeaders: vi.fn(() => ({ error: 'Token ou usuário ausente.' })),
 }))
+
+let getTenantFromHostMock: any
+vi.mock('../../lib/getTenantFromHost', () => ({
+  getTenantFromHost: (...args: any[]) => getTenantFromHostMock(...args),
+}))
+getTenantFromHostMock = vi.fn().mockResolvedValue(null)
+
+beforeEach(() => {
+  getTenantFromHostMock.mockResolvedValue('t1')
+})
 
 describe('GET /api/produtos/[slug]', () => {
   it('retorna 400 quando tenant não informado', async () => {
+    getTenantFromHostMock.mockResolvedValueOnce(null)
     const req = new Request('http://test/produtos/p')
     ;(req as any).nextUrl = new URL('http://test/produtos/p')
     const res = await GET(req as unknown as NextRequest)
     expect(res.status).toBe(400)
     const body = await res.json()
     expect(body.error).toBe('Tenant não informado')
+  })
+
+  it('retorna produto quando visitante', async () => {
+    const produto = { id: 'p1', imagens: ['img1.jpg'], ativo: true }
+    getFirstListItemMock.mockResolvedValueOnce(produto)
+    pb.files.getURL.mockImplementation((_p, img) => `url/${img}`)
+    const req = new Request('http://test/produtos/p1')
+    ;(req as any).nextUrl = new URL('http://test/produtos/p1')
+    const res = await GET(req as unknown as NextRequest)
+    expect(res.status).toBe(200)
+    const body = await res.json()
+    expect(body.imagens[0]).toBe('url/img1.jpg')
+  })
+
+  it('não retorna produto exclusivo para visitante', async () => {
+    const produto = { id: 'p1', imagens: ['img1.jpg'], ativo: true, exclusivo_user: true }
+    getFirstListItemMock.mockResolvedValueOnce(produto)
+    pb.files.getURL.mockImplementation((_p, img) => `url/${img}`)
+    const req = new Request('http://test/produtos/p1')
+    ;(req as any).nextUrl = new URL('http://test/produtos/p1')
+    const res = await GET(req as unknown as NextRequest)
+    expect(res.status).toBe(404)
   })
 })

--- a/__tests__/api/produtosRoute.test.ts
+++ b/__tests__/api/produtosRoute.test.ts
@@ -4,8 +4,9 @@ import { NextRequest } from 'next/server'
 import createPocketBaseMock from '../mocks/pocketbase'
 
 const pb = createPocketBaseMock()
+const getFullListMock = vi.fn().mockRejectedValue(new Error('fail'))
 pb.collection.mockReturnValue({
-  getFullList: vi.fn().mockRejectedValue(new Error('fail')),
+  getFullList: getFullListMock,
 })
 vi.mock('../../lib/pocketbase', () => ({
   default: vi.fn(() => pb),
@@ -13,6 +14,9 @@ vi.mock('../../lib/pocketbase', () => ({
 
 vi.mock('../../lib/products', () => ({
   filtrarProdutos: vi.fn((p) => p),
+}))
+vi.mock('../../lib/getUserFromHeaders', () => ({
+  getUserFromHeaders: vi.fn(() => ({ error: 'Token ou usuário ausente.' })),
 }))
 let getTenantFromHostMock: any
 vi.mock('../../lib/getTenantFromHost', () => ({
@@ -22,6 +26,7 @@ getTenantFromHostMock = vi.fn()
 
 beforeEach(() => {
   getTenantFromHostMock.mockResolvedValue('t1')
+  getFullListMock.mockRejectedValue(new Error('fail'))
 })
 
 describe('GET /api/produtos', () => {
@@ -42,5 +47,35 @@ describe('GET /api/produtos', () => {
     expect(res.status).toBe(400)
     const body = await res.json()
     expect(body.error).toBe('Tenant não informado')
+  })
+
+  it('retorna lista quando visitante sem autenticação', async () => {
+    const produtos = [
+      { id: 'p1', imagens: ['img1.jpg'], ativo: true, exclusivo_user: false },
+    ]
+    getFullListMock.mockResolvedValueOnce(produtos)
+    pb.files.getURL.mockImplementation((_p, img) => `url/${img}`)
+    const req = new Request('http://test')
+    ;(req as any).nextUrl = new URL('http://test')
+    const res = await GET(req as unknown as NextRequest)
+    expect(res.status).toBe(200)
+    const body = await res.json()
+    expect(body[0].imagens[0]).toBe('url/img1.jpg')
+  })
+
+  it('filtra produtos exclusivos para visitantes', async () => {
+    const produtos = [
+      { id: 'p1', imagens: ['img1.jpg'], ativo: true, exclusivo_user: true },
+      { id: 'p2', imagens: ['img2.jpg'], ativo: true, exclusivo_user: false },
+    ]
+    getFullListMock.mockResolvedValueOnce(produtos)
+    pb.files.getURL.mockImplementation((_p, img) => `url/${img}`)
+    const req = new Request('http://test')
+    ;(req as any).nextUrl = new URL('http://test')
+    const res = await GET(req as unknown as NextRequest)
+    expect(res.status).toBe(200)
+    const body = await res.json()
+    expect(body).toHaveLength(1)
+    expect(body[0].id).toBe('p2')
   })
 })

--- a/app/api/produtos/[slug]/route.ts
+++ b/app/api/produtos/[slug]/route.ts
@@ -1,12 +1,12 @@
 import { NextRequest, NextResponse } from 'next/server'
 import createPocketBase from '@/lib/pocketbase'
 import { getTenantFromHost } from '@/lib/getTenantFromHost'
-import { requireRole } from '@/lib/apiAuth'
+import { getUserFromHeaders } from '@/lib/getUserFromHeaders'
 import type { Produto } from '@/types'
 
 export async function GET(req: NextRequest) {
-  const auth = requireRole(req, ['usuario', 'lider', 'coordenador'])
-  const pb = 'error' in auth ? createPocketBase() : auth.pb
+  const auth = getUserFromHeaders(req)
+  const pb = 'error' in auth ? createPocketBase(false) : auth.pbSafe
   const role = 'error' in auth ? null : auth.user.role
   const tenantId = await getTenantFromHost()
 
@@ -14,7 +14,7 @@ export async function GET(req: NextRequest) {
     return NextResponse.json({ error: 'Tenant não informado' }, { status: 400 })
   }
   const slug = req.nextUrl.pathname.split('/').pop() ?? ''
-  let filter = `slug = '${slug}' && cliente='${tenantId}'`
+  let filter = `ativo = true && slug = '${slug}' && cliente='${tenantId}'`
   if (!role) {
     filter += " && exclusivo_user = false"
   }

--- a/app/api/produtos/route.ts
+++ b/app/api/produtos/route.ts
@@ -1,12 +1,12 @@
 import { NextRequest, NextResponse } from 'next/server'
 import createPocketBase from '@/lib/pocketbase'
 import { filtrarProdutos, ProdutoRecord } from '@/lib/products'
-import { requireRole } from '@/lib/apiAuth'
+import { getUserFromHeaders } from '@/lib/getUserFromHeaders'
 import { getTenantFromHost } from '@/lib/getTenantFromHost'
 
 export async function GET(req: NextRequest) {
-  const auth = requireRole(req, ['usuario', 'lider', 'coordenador'])
-  const pb = 'error' in auth ? createPocketBase() : auth.pb
+  const auth = getUserFromHeaders(req)
+  const pb = 'error' in auth ? createPocketBase(false) : auth.pbSafe
   const role = 'error' in auth ? null : auth.user.role
   const categoria = req.nextUrl.searchParams.get('categoria') || undefined
   const tenantId = await getTenantFromHost()

--- a/lib/pocketbase.ts
+++ b/lib/pocketbase.ts
@@ -10,14 +10,17 @@ if (!process.env.PB_URL) {
 
 const basePb = new PocketBase(PB_URL)
 
-export function createPocketBase() {
+export function createPocketBase(copyAuth = true) {
   const pbWithClone = basePb as PocketBase & { clone?: () => PocketBase }
   const pb =
     typeof pbWithClone.clone === 'function'
       ? pbWithClone.clone()
       : new PocketBase(PB_URL)
-
-  pb.authStore.save(basePb.authStore.token, basePb.authStore.model)
+  if (copyAuth) {
+    pb.authStore.save(basePb.authStore.token, basePb.authStore.model)
+  } else {
+    pb.authStore.clear()
+  }
   pb.beforeSend = (url, opt) => {
     opt.credentials = 'include'
     return { url, options: opt }

--- a/stories/FormWizard.stories.tsx
+++ b/stories/FormWizard.stories.tsx
@@ -20,12 +20,11 @@ export default meta
 type Story = StoryObj<typeof meta>
 
 export const Basic: Story = {
-  render: () => (
-    <FormWizard
-      steps={[
-        { title: 'Passo 1', content: <div>Conteúdo 1</div> },
-        { title: 'Passo 2', content: <div>Conteúdo 2</div> },
-      ]}
-    />
-  ),
+  args: {
+    steps: [
+      { title: 'Passo 1', content: <div>Conteúdo 1</div> },
+      { title: 'Passo 2', content: <div>Conteúdo 2</div> },
+    ],
+  },
+  render: (args) => <FormWizard {...args} />,
 }


### PR DESCRIPTION
## Summary
- allow products and product details to be fetched without authentication
- restrict public detail lookups to active products
- test unauthenticated access to product listing and details
- fix leaked PocketBase auth when unauthenticated
- fix FormWizard storybook args to satisfy TypeScript

## Testing
- `npm run lint`
- `npm run build`
- `npm test` *(fails: vitest setup error)*

------
https://chatgpt.com/codex/tasks/task_e_685701d042f0832c82fde45073c79a82