### PR TITLE
Adjust vitest setup import

### DIFF
--- a/vitest.setup.ts
+++ b/vitest.setup.ts
@@ -1,3 +1,3 @@
 import { expect } from 'vitest'
-import matchers from '@testing-library/jest-dom/matchers'
+import * as matchers from '@testing-library/jest-dom/matchers'
 expect.extend(matchers)


### PR DESCRIPTION
## Summary
- swap default import for wildcard in `vitest.setup.ts`

## Testing
- `npm run lint`
- `npm run build`
- `npm run test:ci` *(fails: 14 failed, 38 passed)*

------
https://chatgpt.com/codex/tasks/task_e_68570a747414832ca3342ce716a8725a