### PR TITLE
Include a11y tests in vitest config

### DIFF
--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -12,7 +12,7 @@ export default defineConfig({
     },
   },
   test: {
-    include: ['__tests__/**/*.{test.ts,test.tsx}'],
+    include: ['__tests__/**/*.{test.ts,test.tsx,a11y.test.tsx}'],
     environment: 'jsdom',
     globals: true,
     setupFiles: './vitest.setup.ts',


### PR DESCRIPTION
## Summary
- update the include pattern in `vitest.config.ts`
- run linter, build and tests

## Testing
- `npm run lint`
- `npm run build`
- `npm run test`
- `npm run test:ci`


------
https://chatgpt.com/codex/tasks/task_e_68570a77f6f8832c8f0516db1cb6bf81