### PR TITLE
Refatorar criação de inscrição

### DIFF
--- a/__tests__/api/inscricoesLojaRoute.test.ts
+++ b/__tests__/api/inscricoesLojaRoute.test.ts
@@ -61,7 +61,11 @@ describe('POST /loja/api/inscricoes', () => {
       }),
     )
     expect(createInscricaoMock).toHaveBeenCalledWith(
-      expect.objectContaining({ criado_por: 'u1' }),
+      expect.objectContaining({
+        criado_por: 'u1',
+        status: 'pendente',
+        id: expect.stringMatching(/^insc_/),
+      }),
     )
   })
 
@@ -87,7 +91,11 @@ describe('POST /loja/api/inscricoes', () => {
     expect(res.status).toBe(201)
     expect(createUserMock).not.toHaveBeenCalled()
     expect(createInscricaoMock).toHaveBeenCalledWith(
-      expect.objectContaining({ criado_por: 'u2' }),
+      expect.objectContaining({
+        criado_por: 'u2',
+        status: 'pendente',
+        id: expect.stringMatching(/^insc_/),
+      }),
     )
   })
 })

--- a/__tests__/orderFlow.test.ts
+++ b/__tests__/orderFlow.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect } from 'vitest'
-import { criarInscricao, criarPedido } from '../lib/flows/orderFlow'
+import { criarPedido } from '../lib/flows/orderFlow'
+import { criarInscricao } from '../lib/templates/inscricao'
 
 const dadosValidos = {
   nome: 'Teste',
@@ -9,7 +10,8 @@ const dadosValidos = {
   data_nascimento: '2000-01-01',
   genero: 'masculino',
   evento: 'evt1',
-  liderId: 'lider1',
+  campo: 'c1',
+  criado_por: 'lider1',
   produto: 'Somente Pulseira',
   tamanho: 'M',
 }

--- a/app/api/inscricoes/route.ts
+++ b/app/api/inscricoes/route.ts
@@ -4,23 +4,8 @@ import { createPocketBase } from '@/lib/pocketbase'
 import { getTenantFromHost } from '@/lib/getTenantFromHost'
 import { logConciliacaoErro } from '@/lib/server/logger'
 import type { PaymentMethod } from '@/lib/asaasFees'
-interface DadosInscricao {
-  nome: string
-  email: string
-  telefone: string
-  cpf: string
-  data_nascimento: string
-  genero: string
-  evento: string
-  campo: string
-  criado_por: string
-  status: 'pendente'
-  produto: string
-  tamanho?: string
-  cliente?: string
-  paymentMethod: PaymentMethod
-  installments: number
-}
+import { criarInscricao, InscricaoTemplate } from '@/lib/templates/inscricao'
+import type { Inscricao } from '@/types'
 
 export async function GET(req: NextRequest) {
   const auth = requireRole(req, ['usuario', 'lider', 'coordenador'])
@@ -71,7 +56,7 @@ export async function POST(req: NextRequest) {
       tamanho,
       produtoId,
       genero,
-      paymentMethod = 'pix',
+      paymentMethod = 'pix' as PaymentMethod,
       installments = 1,
       liderId,
       eventoId,
@@ -155,7 +140,7 @@ export async function POST(req: NextRequest) {
     }
 
     // Cria inscrição SEM pedido
-    const dadosInscricao: DadosInscricao = {
+    const dadosBase: InscricaoTemplate = {
       nome,
       email,
       telefone: telefoneNumerico,
@@ -165,13 +150,18 @@ export async function POST(req: NextRequest) {
       evento: eventoIdFinal!,
       campo: campoId,
       criado_por: liderId,
-      status: 'pendente',
       produto: produtoId,
+      tamanho,
       cliente: lider.cliente,
+    }
+    const dadosInscricao: Inscricao & {
+      paymentMethod: PaymentMethod
+      installments: number
+    } = {
+      ...criarInscricao(dadosBase),
       paymentMethod,
       installments,
     }
-    if (tamanho) dadosInscricao.tamanho = tamanho
 
     const inscricao = await pb.collection('inscricoes').create(dadosInscricao)
 

--- a/app/loja/api/inscricoes/route.ts
+++ b/app/loja/api/inscricoes/route.ts
@@ -3,6 +3,7 @@ import createPocketBase from '@/lib/pocketbase'
 import { ClientResponseError } from 'pocketbase'
 import { getTenantFromHost } from '@/lib/getTenantFromHost'
 import { logConciliacaoErro } from '@/lib/server/logger'
+import { criarInscricao, InscricaoTemplate } from '@/lib/templates/inscricao'
 
 export async function POST(req: NextRequest) {
   const pb = createPocketBase()
@@ -36,7 +37,7 @@ export async function POST(req: NextRequest) {
       })
     }
 
-    const registroParaCriar = {
+    const base: InscricaoTemplate = {
       nome,
       email: data.user_email,
       telefone: String(data.user_phone).replace(/\D/g, ''),
@@ -45,10 +46,11 @@ export async function POST(req: NextRequest) {
       genero: data.user_gender.toLowerCase(),
       campo: data.campo,
       evento: data.evento,
-      status: 'pendente',
       criado_por: usuario.id,
       ...(tenantId ? { cliente: tenantId } : {}),
     }
+
+    const registroParaCriar = criarInscricao(base)
 
     const record = await pb.collection('inscricoes').create(registroParaCriar)
 

--- a/lib/flows/orderFlow.ts
+++ b/lib/flows/orderFlow.ts
@@ -1,50 +1,9 @@
 import { Inscricao, Pedido } from '@/types'
+import { criarInscricao as criarInscricaoTemplate, InscricaoTemplate } from '../templates/inscricao'
 
-export type DadosInscricao = {
-  nome: string
-  email: string
-  telefone: string
-  cpf: string
-  data_nascimento: string
-  genero: string
-  evento: string
-  liderId: string
-  produto: string
-  tamanho?: string
-}
+export type DadosInscricao = InscricaoTemplate & { liderId: string }
 
-let idCounter = 1
-
-export function criarInscricao(dados: DadosInscricao): Inscricao {
-  const obrigatorios = [
-    dados.nome,
-    dados.email,
-    dados.telefone,
-    dados.cpf,
-    dados.data_nascimento,
-    dados.genero,
-    dados.liderId,
-    dados.evento,
-  ]
-
-  if (obrigatorios.some((v) => !v || v.trim() === '')) {
-    throw new Error('Todos os campos são obrigatórios.')
-  }
-
-  return {
-    id: `insc_${idCounter++}`,
-    nome: dados.nome,
-    telefone: dados.telefone,
-    cpf: dados.cpf,
-    evento: dados.evento,
-    tamanho: dados.tamanho,
-    produto: dados.produto,
-    genero: dados.genero,
-    criado_por: dados.liderId,
-    data_nascimento: dados.data_nascimento,
-    status: 'pendente',
-  }
-}
+export const criarInscricao = criarInscricaoTemplate
 
 export function criarPedido(
   inscricao: Inscricao,

--- a/lib/templates/inscricao.ts
+++ b/lib/templates/inscricao.ts
@@ -1,0 +1,56 @@
+import type { Inscricao } from '@/types'
+import type { PaymentMethod } from '@/lib/asaasFees'
+
+export interface InscricaoTemplate {
+  nome: string
+  email: string
+  telefone: string
+  cpf: string
+  data_nascimento: string
+  genero: string
+  evento: string
+  campo: string
+  criado_por: string
+  produto?: string
+  tamanho?: string
+  cliente?: string
+  paymentMethod?: PaymentMethod
+  installments?: number
+}
+
+let inscricaoCounter = 1
+
+export function criarInscricao(dados: InscricaoTemplate): Inscricao {
+  const obrigatorios = [
+    dados.nome,
+    dados.email,
+    dados.telefone,
+    dados.cpf,
+    dados.data_nascimento,
+    dados.genero,
+    dados.evento,
+    dados.campo,
+    dados.criado_por,
+  ]
+
+  if (obrigatorios.some((v) => !v || (typeof v === 'string' && v.trim() === ''))) {
+    throw new Error('Todos os campos obrigatórios devem ser preenchidos.')
+  }
+
+  return {
+    id: `insc_${inscricaoCounter++}`,
+    nome: dados.nome,
+    email: dados.email,
+    telefone: dados.telefone,
+    cpf: dados.cpf,
+    data_nascimento: dados.data_nascimento,
+    genero: dados.genero,
+    evento: dados.evento,
+    campo: dados.campo,
+    criado_por: dados.criado_por,
+    produto: dados.produto,
+    tamanho: dados.tamanho,
+    cliente: dados.cliente,
+    status: 'pendente',
+  }
+}


### PR DESCRIPTION
## Summary
- mover `criarInscricao` para `lib/templates/inscricao`
- ajustar `orderFlow` para reutilizar o utilitário
- aplicar template nas rotas de inscrição
- atualizar testes relacionados

## Testing
- `npm run lint`
- `npm run build`
- `npm test` *(falhou: TypeError: Cannot convert undefined or null to object)*

------
https://chatgpt.com/codex/tasks/task_e_68570bfa9250832cb63952683722b099