### PR TITLE
Atualizar fetch com cookies

### DIFF
--- a/app/cliente/components/DashboardHeader.tsx
+++ b/app/cliente/components/DashboardHeader.tsx
@@ -17,12 +17,12 @@ export default function DashboardHeader() {
       Authorization: `Bearer ${token}`,
       'X-PB-User': JSON.stringify(user),
     }
-    fetch('/api/inscricoes', { headers })
+    fetch('/api/inscricoes', { headers, credentials: 'include' })
       .then((res) => res.json())
       .then((data) => setInscricoes(Array.isArray(data) ? data : []))
       .catch(() => setInscricoes([]))
 
-    fetch('/api/pedidos', { headers })
+    fetch('/api/pedidos', { headers, credentials: 'include' })
       .then((res) => res.json())
       .then((data) => setPedidos(Array.isArray(data) ? data : []))
       .catch(() => setPedidos([]))

--- a/app/cliente/components/InscricoesTable.tsx
+++ b/app/cliente/components/InscricoesTable.tsx
@@ -16,7 +16,7 @@ export default function InscricoesTable({ limit }: { limit?: number }) {
       Authorization: `Bearer ${token}`,
       'X-PB-User': JSON.stringify(user),
     }
-    fetch('/api/inscricoes', { headers })
+    fetch('/api/inscricoes', { headers, credentials: 'include' })
       .then((res) => res.json())
       .then((data) =>
         setInscricoes(

--- a/app/cliente/components/PedidosTable.tsx
+++ b/app/cliente/components/PedidosTable.tsx
@@ -16,7 +16,7 @@ export default function PedidosTable({ limit }: { limit?: number }) {
       Authorization: `Bearer ${token}`,
       'X-PB-User': JSON.stringify(user),
     }
-    fetch('/api/pedidos', { headers })
+    fetch('/api/pedidos', { headers, credentials: 'include' })
       .then((res) => res.json())
       .then((data) =>
         setPedidos(

--- a/app/cliente/components/ProfileForm.tsx
+++ b/app/cliente/components/ProfileForm.tsx
@@ -37,6 +37,7 @@ export default function ProfileForm() {
       const res = await fetch(`/api/usuarios/${user.id}`, {
         method: 'PATCH',
         headers,
+        credentials: 'include',
         body: JSON.stringify({
           nome: nome.trim(),
           telefone: telefone.trim(),

--- a/app/loja/cliente/page.tsx
+++ b/app/loja/cliente/page.tsx
@@ -19,7 +19,7 @@ export default function AreaCliente() {
       'X-PB-User': JSON.stringify(user),
     }
 
-    fetch('/loja/api/minhas-inscricoes', { headers })
+    fetch('/loja/api/minhas-inscricoes', { headers, credentials: 'include' })
       .then((res) => res.json())
       .then((data) => setInscricoes(Array.isArray(data) ? data : []))
       .catch((err) => {
@@ -27,7 +27,7 @@ export default function AreaCliente() {
         setInscricoes([])
       })
 
-    fetch('/loja/api/pedidos', { headers })
+    fetch('/loja/api/pedidos', { headers, credentials: 'include' })
       .then((res) => res.json())
       .then((data) => setPedidos(Array.isArray(data) ? data : []))
       .catch((err) => {

--- a/lib/bankAccounts.ts
+++ b/lib/bankAccounts.ts
@@ -109,7 +109,9 @@ export async function getBankAccountsByTenant(
 export async function fetchBankAccounts(
   fetchFn: typeof fetch = fetch,
 ): Promise<ClienteContaBancariaRecord[]> {
-  const res = await fetchFn('/admin/api/bank-accounts')
+  const res = await fetchFn('/admin/api/bank-accounts', {
+    credentials: 'include',
+  })
   if (!res.ok) {
     throw new Error('Erro ao listar contas')
   }
@@ -119,7 +121,7 @@ export async function fetchBankAccounts(
 export async function fetchPixKeys(
   fetchFn: typeof fetch = fetch,
 ): Promise<PixKeyRecord[]> {
-  const res = await fetchFn('/admin/api/pix-keys')
+  const res = await fetchFn('/admin/api/pix-keys', { credentials: 'include' })
   if (!res.ok) {
     throw new Error('Erro ao listar pix')
   }
@@ -133,6 +135,7 @@ export async function createBankAccountApi(
   const res = await fetchFn('/admin/api/bank-accounts', {
     method: 'POST',
     headers: { 'Content-Type': 'application/json' },
+    credentials: 'include',
     body: JSON.stringify(account),
   })
   if (!res.ok) {
@@ -148,6 +151,7 @@ export async function createPixKeyApi(
   const res = await fetchFn('/admin/api/pix-keys', {
     method: 'POST',
     headers: { 'Content-Type': 'application/json' },
+    credentials: 'include',
     body: JSON.stringify(pix),
   })
   if (!res.ok) {


### PR DESCRIPTION
## Summary
- include `credentials: 'include'` in cliente components
- ensure loja cliente area requests send cookies
- include credentials on bank account API helpers

## Testing
- `npm test` *(fails: vitest not found)*
- `npm run lint` *(fails: next not found)*
- `npm run build` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_68570e001828832c8c8b8d816df086f0