### PR TITLE
Fix missing token when creating orders

### DIFF
--- a/app/api/inscricoes/route.ts
+++ b/app/api/inscricoes/route.ts
@@ -177,9 +177,16 @@ export async function POST(req: NextRequest) {
       if (cfg?.confirma_inscricoes === false && evento.cobra_inscricao) {
         const base = req.nextUrl.origin
 
+        const token = pb.authStore.token
+        const headers = {
+          'Content-Type': 'application/json',
+          Authorization: `Bearer ${token}`,
+          'X-PB-User': JSON.stringify(lider),
+        }
+
         const pedidoRes = await fetch(`${base}/api/pedidos`, {
           method: 'POST',
-          headers: { 'Content-Type': 'application/json' },
+          headers,
           body: JSON.stringify({ inscricaoId: inscricao.id }),
         })
 

--- a/app/api/pedidos/route.ts
+++ b/app/api/pedidos/route.ts
@@ -1,5 +1,6 @@
 import { NextRequest, NextResponse } from 'next/server'
 import createPocketBase from '@/lib/pocketbase'
+import { getUserFromHeaders } from '@/lib/getUserFromHeaders'
 import { requireRole } from '@/lib/apiAuth'
 import { getTenantFromHost } from '@/lib/getTenantFromHost'
 import { logConciliacaoErro } from '@/lib/server/logger'
@@ -44,7 +45,8 @@ export async function GET(req: NextRequest) {
 }
 
 export async function POST(req: NextRequest) {
-  const pb = createPocketBase()
+  const auth = getUserFromHeaders(req)
+  const pb = 'error' in auth ? createPocketBase(false) : auth.pbSafe
   try {
     const body = await req.json()
     const { inscricaoId } = body
@@ -59,7 +61,7 @@ export async function POST(req: NextRequest) {
         )
       }
       const { produto, tamanho, cor, genero, campoId, email, valor } = body
-      const userId = pb.authStore.model?.id as string | undefined
+      const userId = 'error' in auth ? undefined : (auth.user.id as string)
 
       if (!userId) {
         return NextResponse.json(

--- a/logs/ERR_LOG.md
+++ b/logs/ERR_LOG.md
@@ -175,3 +175,5 @@
 ## [2025-06-21] Corrigido erro 403 no dashboard requisitando admin/api/usuarios/${user.id} - dev - ab8a6ee
 ## [2025-06-21] Erro ao atualizar configuracoes: ClientResponseError 400: Failed to update record. - development
 ## [2025-06-21] Suporte ao campo logo nos eventos e formulários. Rotas corrigidas - dev
+
+## [2025-07-26] Erro 401 ao criar pedido na loja devido a token não enviado; rota ajustada para incluir cabeçalhos de autenticação - dev


### PR DESCRIPTION
## Summary
- retrieve PocketBase auth from request headers in `POST /api/pedidos`
- forward auth headers when creating a pedido from `/api/inscricoes`
- log fix for 401 error in ERR_LOG

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_685726df6e28832c940c4cfed4261cb8