### PR TITLE
Fix register route client lookup

### DIFF
--- a/__tests__/api/registerRoute.test.ts
+++ b/__tests__/api/registerRoute.test.ts
@@ -3,10 +3,13 @@ import { POST } from '../../app/api/register/route'
 import { NextRequest } from 'next/server'
 import createPocketBaseMock from '../mocks/pocketbase'
 
-const getOneMock = vi.fn().mockRejectedValue(new Error('not found'))
+const getFirstListItemMock = vi.fn().mockRejectedValue(new Error('not found'))
 const createMock = vi.fn().mockResolvedValue({ id: 'u1' })
 const pb = createPocketBaseMock()
-pb.collection.mockReturnValue({ getOne: getOneMock, create: createMock })
+pb.collection.mockReturnValue({
+  getFirstListItem: getFirstListItemMock,
+  create: createMock,
+})
 vi.mock('../../lib/pocketbase', () => ({
   default: vi.fn(() => pb),
 }))
@@ -37,7 +40,7 @@ describe('POST /api/register', () => {
   })
 
   it('cria usuario quando cliente existe', async () => {
-    getOneMock.mockResolvedValueOnce({ id: 'c1' })
+    getFirstListItemMock.mockResolvedValueOnce({ id: 'c1' })
     const payload = {
       nome: 'n',
       email: 'e',

--- a/app/api/register/route.ts
+++ b/app/api/register/route.ts
@@ -40,7 +40,9 @@ export async function POST(req: NextRequest) {
       )
     }
     try {
-      await pb.collection('clientes_config').getOne(String(cliente))
+      await pb
+        .collection('clientes_config')
+        .getFirstListItem(`cliente='${String(cliente)}'`)
     } catch {
       return NextResponse.json(
         { error: 'Cliente não encontrado' },

--- a/logs/ERR_LOG.md
+++ b/logs/ERR_LOG.md
@@ -177,3 +177,4 @@
 ## [2025-06-21] Suporte ao campo logo nos eventos e formulários. Rotas corrigidas - dev
 
 ## [2025-07-26] Erro 401 ao criar pedido na loja devido a token não enviado; rota ajustada para incluir cabeçalhos de autenticação - dev
+## [2025-07-27] Corrigido erro de cliente não encontrado ao registrar usuário; validação agora usa campo cliente em clientes_config - dev - 6967030


### PR DESCRIPTION
## Summary
- validate cliente in register route using field instead of ID
- adjust register route test accordingly
- log the fix in ERR_LOG

## Testing
- `npx --yes next lint`
- `npm run build`
- `npm run test:ci` *(fails: TransferenciasPage and API tests)*

------
https://chatgpt.com/codex/tasks/task_e_685729c48cac832c9b192c0733766b24