### PR TITLE
Fix register route client lookup

### DIFF
--- a/__tests__/api/registerRoute.test.ts
+++ b/__tests__/api/registerRoute.test.ts
@@ -3,10 +3,13 @@ import { POST } from '../../app/api/register/route'
 import { NextRequest } from 'next/server'
 import createPocketBaseMock from '../mocks/pocketbase'
 
-const getOneMock = vi.fn().mockRejectedValue(new Error('not found'))
+const getFirstListItemMock = vi.fn().mockRejectedValue(new Error('not found'))
 const createMock = vi.fn().mockResolvedValue({ id: 'u1' })
 const pb = createPocketBaseMock()
-pb.collection.mockReturnValue({ getOne: getOneMock, create: createMock })
+pb.collection.mockReturnValue({
+  getFirstListItem: getFirstListItemMock,
+  create: createMock,
+})
 vi.mock('../../lib/pocketbase', () => ({
   default: vi.fn(() => pb),
 }))
@@ -23,6 +26,7 @@ describe('POST /api/register', () => {
         data_nascimento: '2000-01-01',
         endereco: 'rua',
         numero: '1',
+        bairro: 'b',
         estado: 'BA',
         cep: '000',
         cidade: 'c',
@@ -37,7 +41,7 @@ describe('POST /api/register', () => {
   })
 
   it('cria usuario quando cliente existe', async () => {
-    getOneMock.mockResolvedValueOnce({ id: 'c1' })
+    getFirstListItemMock.mockResolvedValueOnce({ id: 'c1' })
     const payload = {
       nome: 'n',
       email: 'e',
@@ -46,6 +50,7 @@ describe('POST /api/register', () => {
       data_nascimento: '2000-01-01',
       endereco: 'rua',
       numero: '1',
+      bairro: 'b',
       estado: 'BA',
       cep: '000',
       cidade: 'c',
@@ -58,6 +63,8 @@ describe('POST /api/register', () => {
     })
     const res = await POST(req as unknown as NextRequest)
     expect(res.status).toBe(201)
-    expect(createMock).toHaveBeenCalledWith(expect.objectContaining(payload))
+    expect(createMock).toHaveBeenCalledWith(
+      expect.objectContaining({ ...payload, role: 'usuario' }),
+    )
   })
 })

--- a/app/api/register/route.ts
+++ b/app/api/register/route.ts
@@ -14,12 +14,13 @@ export async function POST(req: NextRequest) {
       data_nascimento,
       endereco,
       numero,
+      bairro,
       estado,
       cep,
       cidade,
       password,
       cliente,
-    } = await req.json()
+      } = await req.json()
     if (
       !nome ||
       !email ||
@@ -28,6 +29,7 @@ export async function POST(req: NextRequest) {
       !data_nascimento ||
       !endereco ||
       !numero ||
+      !bairro ||
       !estado ||
       !cep ||
       !cidade ||
@@ -40,7 +42,9 @@ export async function POST(req: NextRequest) {
       )
     }
     try {
-      await pb.collection('clientes_config').getOne(String(cliente))
+      await pb
+        .collection('clientes_config')
+        .getFirstListItem(`cliente='${String(cliente)}'`)
     } catch {
       return NextResponse.json(
         { error: 'Cliente não encontrado' },
@@ -56,11 +60,13 @@ export async function POST(req: NextRequest) {
       data_nascimento: String(data_nascimento),
       endereco: String(endereco).trim(),
       numero: String(numero).trim(),
+      bairro: String(bairro).trim(),
       estado: String(estado).trim(),
       cep: String(cep).trim(),
       cidade: String(cidade).trim(),
       password: String(password),
       passwordConfirm: String(password),
+      role: 'usuario',
     })
     logInfo('\u2705 Usu\u00E1rio registrado com sucesso')
     return NextResponse.json(novoUsuario, { status: 201 })

--- a/logs/ERR_LOG.md
+++ b/logs/ERR_LOG.md
@@ -177,3 +177,5 @@
 ## [2025-06-21] Suporte ao campo logo nos eventos e formulários. Rotas corrigidas - dev
 
 ## [2025-07-26] Erro 401 ao criar pedido na loja devido a token não enviado; rota ajustada para incluir cabeçalhos de autenticação - dev
+## [2025-07-27] Corrigido erro de cliente não encontrado ao registrar usuário; validação agora usa campo cliente em clientes_config - dev - 6967030
+## [2025-07-27] Registro de usuário não incluía role e bairro; rota atualizada para enviar role "usuario" e campo bairro - dev


### PR DESCRIPTION
## Summary
- validate cliente in register route using field instead of ID
- adjust register route test accordingly
- log the fix in ERR_LOG
- include bairro in validation and creation, role defaults to usuario

## Testing
- `npm run lint` *(fails: next not found)*
- `npm run build` *(fails: next not found)*
- `npm run test:ci` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_685729c48cac832c9b192c0733766b24