### PR TITLE
Add product flow documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -249,6 +249,16 @@ em `/api/asaas/saldo`.
 O painel possui o modal `BankAccountModal` para registrar contas bancárias do cliente. O formulário possui campos **Nome do titular** (`ownerName`) e **Nome da conta** (`accountName`) para identificar a conta cadastrada. O campo **Banco** possui filtragem que consulta a BrasilAPI (`NEXT_PUBLIC_BRASILAPI_URL`); quando vazio, apresenta uma lista inicial com quinze bancos. Ao escolher um banco, `bankCode` e `ispb` são preenchidos automaticamente (este último fica oculto no formulário). Agora é possível alternar entre **Conta Bancária** e **PIX** por meio de abas com `SmoothTabs`. Quando selecionado PIX, o modal exibe os campos `pixAddressKey`, `pixAddressKeyType`, `description` e `scheduleDate`. O envio salva na coleção `clientes_pix` ou `clientes_contas_bancarias` conforme o tipo escolhido. A seleção de tipo de conta inclui a opção **Conta Salário**.
 Na página **Transferências**, um botão **Nova conta** abre este modal para facilitar o cadastro durante o fluxo de transferências. O `ModalAnimated` recebeu um `z-index` superior para evitar que elementos fixos como a navbar sobreponham o conteúdo do modal.
 
+## Tipos de Produto e Fluxos de Venda
+
+Existem três formatos principais de produtos:
+
+1. **Independente** – vendido diretamente na loja. O pedido gerado recebe o campo `canal` igual a `loja`.
+2. **Vinculado a evento (sem aprovação)** – criado a partir de um evento que não exige aprovação. O pedido é gerado automaticamente e `canal` passa a ser `inscricao`.
+3. **Vinculado a evento (com aprovação)** – associado a um evento onde `confirmaInscricoes` está habilitado. O usuário vê a mensagem "Requer inscrição aprovada" e o botão de compra permanece desativado até a aprovação.
+
+O fluxograma completo está disponível em [docs/fluxos.md](docs/fluxos.md).
+
 ## Perfis de Acesso
 
 O sistema possui três níveis de usuário:

--- a/app/admin/produtos/novo/ModalProduto.tsx
+++ b/app/admin/produtos/novo/ModalProduto.tsx
@@ -1,5 +1,11 @@
 'use client'
 
+/**
+ * Quando `confirmaInscricoes` está habilitado no TenantContext e o usuário não
+ * possui inscrição aprovada para o evento vinculado, o modal exibe a mensagem
+ * "Requer inscrição aprovada" e o botão de compra permanece desativado.
+ */
+
 import { useEffect, useRef, useState } from 'react'
 import { useAuthContext } from '@/lib/context/AuthContext'
 import { calculateGross } from '@/lib/asaasFees'

--- a/docs/fluxos.md
+++ b/docs/fluxos.md
@@ -1,0 +1,9 @@
+# Fluxos de Venda
+
+Este fluxograma ilustra o comportamento ao adicionar um produto no carrinho.
+
+1. O produto possui evento vinculado?
+   - **Não**: cria um pedido com `canal` = `loja`.
+   - **Sim**: verificar se o evento exige aprovação.
+     - **Não exige**: cria o pedido normalmente (`canal` = `inscricao`).
+     - **Exige aprovação**: exibe o aviso "Requer inscrição aprovada" e o botão de compra fica desativado até a liberação.

--- a/logs/DOC_LOG.md
+++ b/logs/DOC_LOG.md
@@ -358,3 +358,4 @@
 ## [2025-07-26] Mover utilitario criarInscricao para components/templates e gerar senha temporaria na rota da loja. Lint e build falharam localmente.
 ## [2025-07-27] Ajustado fluxo da API de inscrições para criar usuário automaticamente e documentação atualizada com fluxograma.
 ## [2025-07-28] Integrado componente InscricaoWizard na pagina de inscricao e documentado etapas.
+## [2025-06-21] Documentado fluxo de venda e tipos de produtos.


### PR DESCRIPTION
## Summary
- document product types and sales flow in README
- describe when purchase requires approved registration
- add product flow diagram doc
- log documentation update

## Testing
- `npm run lint` *(fails: next not found)*
- `npm run build` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_68573a239bdc832ca3ebecb86a4b28c9