### PR TITLE
Controlar compras sem inscrição aprovada

### DIFF
--- a/app/api/pedidos/route.ts
+++ b/app/api/pedidos/route.ts
@@ -42,7 +42,7 @@ export async function GET(req: NextRequest) {
     })
 
     return NextResponse.json(items)
-  } catch (err) {
+  } catch {
     return NextResponse.json({ error: 'Erro ao listar' }, { status: 500 })
   }
 }
@@ -167,7 +167,7 @@ export async function POST(req: NextRequest) {
       valor: pedido.valor,
       status: pedido.status,
     })
-  } catch (err: any) {
+  } catch (err: unknown) {
     await logConciliacaoErro(`Erro ao criar pedido: ${String(err)}`)
     return NextResponse.json({ erro: 'Erro ao criar pedido.' }, { status: 500 })
   }

--- a/components/molecules/AddToCartButton.tsx
+++ b/components/molecules/AddToCartButton.tsx
@@ -3,19 +3,33 @@ import { useCart } from '@/lib/context/CartContext'
 import { useToast } from '@/lib/context/ToastContext'
 import type { Produto } from '@/types'
 import { ShoppingCart } from 'lucide-react'
+import useInscricoes from '@/lib/hooks/useInscricoes'
 
 export default function AddToCartButton({ produto }: { produto: Produto }) {
   const { addItem } = useCart()
   const { showSuccess } = useToast()
+  const { inscricoes } = useInscricoes()
+
+  const aprovado = inscricoes.some(
+    (i) => i.evento === produto.evento_id && i.status === 'confirmado',
+  )
+
+  const disabled = produto.requer_inscricao_aprovada && !aprovado
 
   const handleClick = () => {
+    if (disabled) return
     addItem(produto)
     showSuccess('Item adicionado ao carrinho!')
   }
 
   return (
-    <button onClick={handleClick} className="block w-full btn btn-primary">
-      <ShoppingCart size={20} /> Adicionar ao Carrinho
+    <button
+      onClick={handleClick}
+      disabled={disabled}
+      className="block w-full btn btn-primary disabled:opacity-50 disabled:cursor-not-allowed"
+    >
+      <ShoppingCart size={20} />
+      {disabled ? ' Aguardando inscrição' : ' Adicionar ao Carrinho'}
     </button>
   )
 }

--- a/components/organisms/ProdutoInterativo.tsx
+++ b/components/organisms/ProdutoInterativo.tsx
@@ -5,6 +5,7 @@ import type { Produto } from '@/types'
 import { calculateGross } from '@/lib/asaasFees'
 
 import AddToCartButton from '@/components/molecules/AddToCartButton'
+import useInscricoes from '@/lib/hooks/useInscricoes'
 
 // Componente para seleção de gênero e tamanho (reutilizável)
 function DetalhesSelecao({
@@ -135,6 +136,11 @@ export default function ProdutoInterativo({
   const [cor, setCor] = useState(coresList[0] || '')
   const [indexImg, setIndexImg] = useState(0)
   const pauseRef = useRef(false)
+  const { inscricoes } = useInscricoes()
+  const aprovado = inscricoes.some(
+    (i) => i.evento === produto.evento_id && i.status === 'confirmado',
+  )
+  const precisaAprov = produto.requer_inscricao_aprovada && !aprovado
 
   const precoBruto = useMemo(
     () => calculateGross(preco, 'pix', 1).gross,
@@ -284,6 +290,9 @@ export default function ProdutoInterativo({
                 cores: cor ? [cor] : [],
               }}
             />
+            {precisaAprov && (
+              <p className="text-xs text-red-600 mt-2">Requer inscrição aprovada</p>
+            )}
           </div>
         </div>
         {/* Resto dos detalhes */}

--- a/components/organisms/ProdutosFiltrados.tsx
+++ b/components/organisms/ProdutosFiltrados.tsx
@@ -3,6 +3,7 @@
 import Image from 'next/image'
 import Link from 'next/link'
 import { useMemo, useState } from 'react'
+import useInscricoes from '@/lib/hooks/useInscricoes'
 import { calculateGross } from '@/lib/asaasFees'
 
 const faixasPreco = [
@@ -17,6 +18,8 @@ interface Produto {
   preco: number
   imagens: string[]
   slug: string
+  requer_inscricao_aprovada?: boolean
+  evento_id?: string
 }
 
 export default function ProdutosFiltrados({
@@ -27,6 +30,12 @@ export default function ProdutosFiltrados({
   const [busca, setBusca] = useState('')
   const [faixasSelecionadas, setFaixasSelecionadas] = useState<string[]>([])
   const [ordem, setOrdem] = useState('recentes')
+  const { inscricoes } = useInscricoes()
+
+  const possuiAprovacao = (prod: Produto) =>
+    inscricoes.some(
+      (i) => i.evento === prod.evento_id && i.status === 'confirmado',
+    )
 
   const filtrados = useMemo(() => {
     let res = produtos.filter((p) =>
@@ -108,12 +117,19 @@ export default function ProdutosFiltrados({
         <div className="grid grid-cols-2 sm:grid-cols-3 lg:grid-cols-4 gap-6">
           {filtrados.map((p) => {
             const precoBruto = calculateGross(p.preco, 'pix', 1).gross
+            const precisaAprov =
+              p.requer_inscricao_aprovada && !possuiAprovacao(p)
             return (
               <div
                 key={p.id}
                 className="bg-white rounded-2xl shadow-lg border border-[var(--accent-900)]/10 flex flex-col items-center p-4 transition hover:shadow-xl"
               >
                 <div className="w-full aspect-square overflow-hidden rounded-xl mb-2 bg-neutral-100 border border-[var(--accent)]/5 relative">
+                  {precisaAprov && (
+                    <span className="absolute top-2 left-2 bg-red-600 text-white text-xs font-semibold px-2 py-1 rounded z-10">
+                      Requer inscrição aprovada
+                    </span>
+                  )}
                   <Image
                     src={p.imagens[0]}
                     alt={p.nome}

--- a/types/index.ts
+++ b/types/index.ts
@@ -90,6 +90,10 @@ export type Produto = {
   slug: string
   descricao?: string
   detalhes?: string
+  /** Se true, exige aprovação de inscrição para compra */
+  requer_inscricao_aprovada?: boolean
+  /** ID do evento vinculado ao produto */
+  evento_id?: string
   checkout_url?: string
   exclusivo_user?: boolean
   ativo?: boolean


### PR DESCRIPTION
## Summary
- read approval flags in product types
- prevent adding products that require approved registration to cart
- show badge on products that require approval
- show message on product page when registration not approved
- fix lint errors in pedido API route

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68573c7d2be0832cbc7ff6ee49a66148