### PR TITLE
Fix build errors and lint warnings

### DIFF
--- a/components/admin/ModalProdutoForm.tsx
+++ b/components/admin/ModalProdutoForm.tsx
@@ -1,6 +1,7 @@
 'use client'
 
 import { useEffect, useRef, useState } from 'react'
+import Image from 'next/image'
 import * as Dialog from '@radix-ui/react-dialog'
 import { AnimatePresence, motion } from 'framer-motion'
 import { TextField } from '@/components/atoms/TextField'
@@ -200,9 +201,11 @@ export default function ModalProdutoForm({
                         onChange={handleImageChange}
                       />
                       {preview && (
-                        <img
+                        <Image
                           src={preview}
                           alt="Pré-visualização"
+                          width={160}
+                          height={160}
                           className="mt-2 max-h-40 rounded-md"
                         />
                       )}

--- a/components/organisms/FormWizard.tsx
+++ b/components/organisms/FormWizard.tsx
@@ -1,5 +1,5 @@
 'use client'
-import React, { useState } from 'react'
+import React, { useState, useEffect } from 'react'
 
 export interface WizardStep {
   title: string

--- a/components/organisms/InscricaoWizard.tsx
+++ b/components/organisms/InscricaoWizard.tsx
@@ -22,6 +22,7 @@ interface InscricaoWizardProps {
 export default function InscricaoWizard({
   liderId,
   eventoId,
+  loading,
 }: InscricaoWizardProps) {
   const { config } = useTenant()
   const { showSuccess, showError } = useToast()


### PR DESCRIPTION
## Summary
- import `useEffect` in `FormWizard`
- switch product preview to `<Image>` component
- plumb `loading` prop into `InscricaoWizard`

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68574820e6a4832cb63466810589af20