### PR TITLE
Add header and login link to signup page

### DIFF
--- a/app/signup/page.tsx
+++ b/app/signup/page.tsx
@@ -11,6 +11,7 @@ import {
   Button,
   Spinner,
 } from '@/components'
+import { LayoutWrapper } from '@/components/templates'
 
 export default function SignUpPage() {
   const { login } = useAuthContext()
@@ -58,11 +59,12 @@ export default function SignUpPage() {
   }
 
   return (
-    <div className="max-w-md mx-auto px-4 py-8">
-      <h1 className="text-2xl font-bold mb-6 text-center text-[var(--accent)]">
-        Criar Conta
-      </h1>
-      <form onSubmit={handleSubmit} className="space-y-4">
+    <LayoutWrapper>
+      <div className="max-w-md mx-auto px-4 py-8">
+        <h1 className="text-2xl font-bold mb-6 text-center text-[var(--accent)]">
+          Criar Conta
+        </h1>
+        <form onSubmit={handleSubmit} className="space-y-4">
         <FormField label="Nome completo" htmlFor="signup-nome">
           <TextField
             id="signup-nome"
@@ -125,7 +127,17 @@ export default function SignUpPage() {
             'Avançar'
           )}
         </Button>
+        <p className="text-center text-sm text-[var(--text-secondary)]">
+          Já possui conta?{' '}
+          <a
+            href="/login"
+            className="underline hover:text-[var(--accent)] transition"
+          >
+            Fazer login
+          </a>
+        </p>
       </form>
     </div>
+    </LayoutWrapper>
   )
 }

--- a/components/organisms/FormWizard.tsx
+++ b/components/organisms/FormWizard.tsx
@@ -1,5 +1,5 @@
 'use client'
-import React, { useState } from 'react'
+import React, { useState, useEffect } from 'react'
 
 export interface WizardStep {
   title: string

--- a/components/organisms/InscricaoWizard.tsx
+++ b/components/organisms/InscricaoWizard.tsx
@@ -16,7 +16,6 @@ interface Produto {
 interface InscricaoWizardProps {
   liderId: string
   eventoId: string
-  loading?: boolean
 }
 
 export default function InscricaoWizard({
@@ -344,7 +343,6 @@ export default function InscricaoWizard({
     <FormWizard
       steps={steps}
       onFinish={handleSubmit}
-      loading={loading}
       className="max-w-lg mx-auto bg-white p-6 rounded-xl shadow"
     />
   )


### PR DESCRIPTION
## Summary
- show signup page wrapped in `LayoutWrapper`
- add link back to login on signup page
- fix missing `useEffect` import in `FormWizard`
- remove unused `loading` prop from `InscricaoWizard`

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_685748a30150832c8caf856fe64841f8