### PR TITLE
Fix InscricaoWizard prop warning

### DIFF
--- a/components/admin/ModalProdutoForm.tsx
+++ b/components/admin/ModalProdutoForm.tsx
@@ -1,6 +1,7 @@
 'use client'
 
 import { useEffect, useRef, useState } from 'react'
+import Image from 'next/image'
 import * as Dialog from '@radix-ui/react-dialog'
 import { AnimatePresence, motion } from 'framer-motion'
 import { TextField } from '@/components/atoms/TextField'
@@ -200,9 +201,11 @@ export default function ModalProdutoForm({
                         onChange={handleImageChange}
                       />
                       {preview && (
-                        <img
+                        <Image
                           src={preview}
                           alt="Pré-visualização"
+                          width={160}
+                          height={160}
                           className="mt-2 max-h-40 rounded-md"
                         />
                       )}

--- a/components/organisms/FormWizard.tsx
+++ b/components/organisms/FormWizard.tsx
@@ -1,5 +1,6 @@
 'use client'
-import React, { useState } from 'react'
+import React, { useState, useEffect } from 'react'
+import LoadingOverlay from './LoadingOverlay'
 
 export interface WizardStep {
   title: string
@@ -17,6 +18,7 @@ export default function FormWizard({
   steps,
   onFinish,
   className = '',
+  loading = false,
 }: FormWizardProps) {
   const [current, setCurrent] = useState(0)
   const [message, setMessage] = useState('')
@@ -38,6 +40,7 @@ export default function FormWizard({
 
   return (
     <div className={className}>
+      <LoadingOverlay show={loading} text="Processando..." />
       <div className="w-full bg-neutral-200 rounded-full h-2 mb-4">
         <div
           className="bg-[var(--accent)] h-2 rounded-full transition-all duration-300"
@@ -57,12 +60,17 @@ export default function FormWizard({
         <button
           type="button"
           onClick={prev}
-          disabled={current === 0}
+          disabled={current === 0 || loading}
           className="btn"
         >
           Voltar
         </button>
-        <button type="button" onClick={next} className="btn btn-primary">
+        <button
+          type="button"
+          onClick={next}
+          className="btn btn-primary"
+          disabled={loading}
+        >
           {isLast ? 'Concluir' : 'Avançar'}
         </button>
       </div>

--- a/components/organisms/InscricaoWizard.tsx
+++ b/components/organisms/InscricaoWizard.tsx
@@ -22,6 +22,7 @@ interface InscricaoWizardProps {
 export default function InscricaoWizard({
   liderId,
   eventoId,
+  loading,
 }: InscricaoWizardProps) {
   const { config } = useTenant()
   const { showSuccess, showError } = useToast()


### PR DESCRIPTION
## Summary
- add `LoadingOverlay` to FormWizard so `loading` prop is used
- disable navigation buttons while processing

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68574820e6a4832cb63466810589af20