### PR TITLE
Sanitize telefone and CPF

### DIFF
--- a/__tests__/api/signupRoute.test.ts
+++ b/__tests__/api/signupRoute.test.ts
@@ -1,0 +1,40 @@
+import { describe, it, expect, vi } from 'vitest'
+import { POST } from '../../app/api/signup/route'
+import { NextRequest } from 'next/server'
+import createPocketBaseMock from '../mocks/pocketbase'
+
+const createMock = vi.fn()
+const pb = createPocketBaseMock()
+pb.collection.mockReturnValue({ create: createMock })
+
+vi.mock('../../lib/pocketbase', () => ({
+  default: vi.fn(() => pb),
+}))
+
+vi.mock('../../lib/getTenantFromHost', () => ({
+  getTenantFromHost: vi.fn(async () => null),
+}))
+
+describe('POST /api/signup', () => {
+  it('remove caracteres nao numericos de telefone e cpf', async () => {
+    const req = new Request('http://test', {
+      method: 'POST',
+      body: JSON.stringify({
+        nome: 'Nome',
+        email: 'e@test.com',
+        telefone: '(11) 99999-9999',
+        cpf: '529.982.247-25',
+        senha: '123',
+      }),
+    })
+
+    const res = await POST(req as unknown as NextRequest)
+    expect(res.status).toBe(201)
+    expect(createMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        telefone: '11999999999',
+        cpf: '52998224725',
+      }),
+    )
+  })
+})

--- a/__tests__/api/usuariosPatchRoute.test.ts
+++ b/__tests__/api/usuariosPatchRoute.test.ts
@@ -1,0 +1,38 @@
+import { describe, it, expect, vi } from 'vitest'
+import { PATCH } from '../../app/api/usuarios/[id]/route'
+import { NextRequest } from 'next/server'
+
+vi.mock('../../lib/apiAuth', () => ({ requireRole: vi.fn() }))
+import { requireRole } from '../../lib/apiAuth'
+
+describe('PATCH /api/usuarios/[id]', () => {
+  it('remove caracteres nao numericos de telefone e cpf', async () => {
+    const updateMock = vi.fn().mockResolvedValue({})
+    ;(
+      requireRole as unknown as { mockReturnValue: (v: any) => void }
+    ).mockReturnValue({
+      pb: { collection: () => ({ update: updateMock }) } as any,
+      user: { id: 'u1', role: 'usuario' },
+    })
+
+    const req = new Request('http://test/api/usuarios/u1', {
+      method: 'PATCH',
+      body: JSON.stringify({
+        nome: 'Nome',
+        telefone: '(11) 99999-9999',
+        cpf: '529.982.247-25',
+      }),
+    })
+    ;(req as any).nextUrl = new URL('http://test/api/usuarios/u1')
+
+    const res = await PATCH(req as unknown as NextRequest)
+    expect(res.status).toBe(200)
+    expect(updateMock).toHaveBeenCalledWith('u1', {
+      nome: 'Nome',
+      telefone: '11999999999',
+      cpf: '52998224725',
+      data_nascimento: '',
+      role: 'usuario',
+    })
+  })
+})

--- a/app/api/signup/route.ts
+++ b/app/api/signup/route.ts
@@ -10,11 +10,13 @@ export async function POST(req: NextRequest) {
       return NextResponse.json({ error: 'Dados inválidos' }, { status: 400 })
     }
     const tenantId = await getTenantFromHost()
+    const telefoneNumerico = String(telefone).replace(/\D/g, '')
+    const cpfNumerico = String(cpf).replace(/\D/g, '')
     const usuario = await pb.collection('usuarios').create({
       nome: String(nome).trim(),
       email: String(email).trim(),
-      telefone: String(telefone).trim(),
-      cpf: String(cpf).trim(),
+      telefone: telefoneNumerico,
+      cpf: cpfNumerico,
       password: String(senha),
       passwordConfirm: String(senha),
       role: 'usuario',

--- a/app/api/usuarios/[id]/route.ts
+++ b/app/api/usuarios/[id]/route.ts
@@ -42,8 +42,8 @@ export async function PATCH(req: NextRequest) {
     const data = await req.json()
     await pb.collection('usuarios').update(id, {
       nome: String(data.nome || '').trim(),
-      telefone: String(data.telefone || '').trim(),
-      cpf: String(data.cpf || '').trim(),
+      telefone: String(data.telefone || '').replace(/\D/g, ''),
+      cpf: String(data.cpf || '').replace(/\D/g, ''),
       data_nascimento: String(data.data_nascimento || ''),
       ...(data.tour !== undefined ? { tour: Boolean(data.tour) } : {}),
       role: user.role,


### PR DESCRIPTION
## Summary
- sanitize `telefone` and `cpf` in signup API
- sanitize `telefone` and `cpf` on user update
- add tests for signup sanitization
- add tests for PATCH sanitization

## Testing
- `npm run lint` *(fails: 'loading' is defined but never used)*
- `npm run build` *(fails to compile)*
- `npm test` *(fails to run all tests)*

------
https://chatgpt.com/codex/tasks/task_e_68574ea7e4f4832cb856c8cf1ebda354