### PR TITLE
Enable controlled value for InputWithMask

### DIFF
--- a/__tests__/InputWithMask.test.tsx
+++ b/__tests__/InputWithMask.test.tsx
@@ -1,0 +1,23 @@
+/* @vitest-environment jsdom */
+import React from 'react'
+import { describe, it, expect, vi } from 'vitest'
+import { render, screen, fireEvent } from '@testing-library/react'
+import { InputWithMask } from '../components/molecules/InputWithMask'
+
+describe('InputWithMask', () => {
+  it('aplica mascara no valor inicial e nas mudancas', () => {
+    const handleChange = vi.fn()
+    render(
+      <InputWithMask mask="cpf" value="52998224725" onChange={handleChange} />,
+    )
+    const input = screen.getByRole('textbox') as HTMLInputElement
+    expect(input.value).toBe('529.982.247-25')
+
+    fireEvent.change(input, { target: { value: '93541134780' } })
+    expect(input.value).toBe('935.411.347-80')
+    expect(handleChange).toHaveBeenCalled()
+    const event = handleChange.mock
+      .calls[0][0] as React.ChangeEvent<HTMLInputElement>
+    expect(event.target.value).toBe('935.411.347-80')
+  })
+})

--- a/components/molecules/InputWithMask.tsx
+++ b/components/molecules/InputWithMask.tsx
@@ -1,4 +1,4 @@
-import React from 'react'
+import React, { useEffect, useState, useCallback } from 'react'
 import { TextField } from '../atoms/TextField'
 
 export interface InputWithMaskProps
@@ -11,31 +11,50 @@ export function InputWithMask({
   mask,
   className = '',
   onChange,
+  value,
   ...props
 }: InputWithMaskProps) {
-  const applyMask = (value: string) => {
-    if (mask === 'cpf') {
-      return value
-        .replace(/\D/g, '')
-        .replace(/(\d{3})(\d)/, '$1.$2')
-        .replace(/(\d{3})(\d)/, '$1.$2')
-        .replace(/(\d{3})(\d{1,2})$/, '$1-$2')
-    }
-    if (mask === 'telefone') {
-      return value
-        .replace(/\D/g, '')
-        .replace(/(\d{2})(\d)/, '($1) $2')
-        .replace(/(\d{5})(\d)/, '$1-$2')
-        .replace(/(-\d{4})\d+?$/, '$1')
-    }
-    return value
-  }
+  const applyMask = useCallback(
+    (val: string) => {
+      if (mask === 'cpf') {
+        return val
+          .replace(/\D/g, '')
+          .replace(/(\d{3})(\d)/, '$1.$2')
+          .replace(/(\d{3})(\d)/, '$1.$2')
+          .replace(/(\d{3})(\d{1,2})$/, '$1-$2')
+      }
+      if (mask === 'telefone') {
+        return val
+          .replace(/\D/g, '')
+          .replace(/(\d{2})(\d)/, '($1) $2')
+          .replace(/(\d{5})(\d)/, '$1-$2')
+          .replace(/(-\d{4})\d+?$/, '$1')
+      }
+      return val
+    },
+    [mask],
+  )
+  const [maskedValue, setMaskedValue] = useState(() =>
+    applyMask(String(value ?? '')),
+  )
+
+  useEffect(() => {
+    setMaskedValue(applyMask(String(value ?? '')))
+  }, [value, applyMask])
 
   const handleChange = (e: React.ChangeEvent<HTMLInputElement>) => {
-    const value = applyMask(e.target.value)
-    e.target.value = value
+    const val = applyMask(e.target.value)
+    setMaskedValue(val)
+    e.target.value = val
     onChange?.(e)
   }
 
-  return <TextField className={className} onChange={handleChange} {...props} />
+  return (
+    <TextField
+      className={className}
+      value={maskedValue}
+      onChange={handleChange}
+      {...props}
+    />
+  )
 }

--- a/components/organisms/InscricaoWizard.tsx
+++ b/components/organisms/InscricaoWizard.tsx
@@ -21,7 +21,6 @@ interface InscricaoWizardProps {
 export default function InscricaoWizard({
   liderId,
   eventoId,
-  loading,
 }: InscricaoWizardProps) {
   const { config } = useTenant()
   const { showSuccess, showError } = useToast()

--- a/stories/InputWithMask.stories.tsx
+++ b/stories/InputWithMask.stories.tsx
@@ -16,7 +16,7 @@ type Story = StoryObj<typeof meta>
 export const CPF: Story = {
   args: { mask: 'cpf' },
   render: (args) => {
-    const [value, setValue] = useState('')
+    const [value, setValue] = useState('52998224725')
     return (
       <InputWithMask
         {...args}


### PR DESCRIPTION
## Summary
- allow `InputWithMask` to control its value
- adjust `InscricaoWizard` props
- show a pre-filled example in storybook
- test masking logic

## Testing
- `npm run lint`
- `npm run test` *(fails: 19 failed, 34 passed)*
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68574e8d72e4832c8f805a6bdd9c6346