### PR TITLE
Fix code block and docs

### DIFF
--- a/arquitetura.md
+++ b/arquitetura.md
@@ -67,6 +67,12 @@ Todas coexistem no mesmo projeto Next.js (App Router) hospedado na **Vercel**.
 /scripts/                  # Scripts auxiliares
 /stories/                  # Storybook de componentes
 components/                # Componentes reutilizáveis compartilhados
+lib/                     # Funções principais
+utils/                   # Utilitários do projeto
+public/                  # Arquivos estáticos
+types/                   # Definições TypeScript
+logs/                    # Registros de documentação e erros
+```
 
 ---
 
@@ -94,7 +100,7 @@ components/                # Componentes reutilizáveis compartilhados
 
 ---
 
--## 🛠️ Admin – Boas Práticas
+## 🛠️ Admin – Boas Práticas
 
 - Rotas protegidas com `useAuthGuard` e validação de `role`
 - Algumas rotas de confirmação de inscrição são públicas:
@@ -133,4 +139,3 @@ components/                # Componentes reutilizáveis compartilhados
 ## 📌 Considerações Finais
 
 Esta estrutura busca garantir **clareza, escalabilidade e manutenibilidade** do projeto M24Vendas, atendendo tanto ao público final quanto às lideranças administrativas. Deve ser evoluída com base no crescimento do projeto, mantendo a consistência na organização e nos princípios de performance e segurança.
-```

--- a/logs/DOC_LOG.md
+++ b/logs/DOC_LOG.md
@@ -375,3 +375,4 @@
 ## [2025-06-21] README menciona que o campo 'canal' indica a origem do pedido e testes de pedidos atualizados.
 
 ## [2025-06-21] Implementado fluxo de venda validando inscrição aprovada (commit fe7e6f64893832d14d36b6c8452365f5ecfdd576). Lint e build falharam localmente.
+## [2025-07-30] Corrigido fechamento do bloco de código em arquitetura.md, incluídos diretórios faltantes e ajustado título do Admin. Documentação mais clara.


### PR DESCRIPTION
## Summary
- close the folder map block in `arquitetura.md`
- mention missing directories in the structure list
- fix heading for Admin best practices
- log the documentation update

## Testing
- `npm run lint` *(fails: next not found)*
- `npm run build` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_6857527e2880832c8fc7199f511706b8