### PR TITLE
Corrige logout para coordenadores e líderes

### DIFF
--- a/components/templates/HeaderAdmin.tsx
+++ b/components/templates/HeaderAdmin.tsx
@@ -3,8 +3,7 @@
 import Link from 'next/link'
 import { usePathname } from 'next/navigation'
 import { useAuthContext } from '@/lib/context/AuthContext'
-import { useMemo, useState } from 'react'
-import createPocketBase from '@/lib/pocketbase'
+import { useState } from 'react'
 import Image from 'next/image'
 import {
   Menu,
@@ -38,8 +37,7 @@ const getNavLinks = (role?: string) => {
 
 export default function Header() {
   const pathname = usePathname()
-  const { isLoggedIn, user } = useAuthContext()
-  const pb = useMemo(() => createPocketBase(), [])
+  const { isLoggedIn, user, logout } = useAuthContext()
   const [menuAberto, setMenuAberto] = useState(false)
   const [perfilAberto, setPerfilAberto] = useState(false)
   const [financeiroAberto, setFinanceiroAberto] = useState(false)
@@ -73,8 +71,7 @@ export default function Header() {
         ]
 
   const handleLogout = () => {
-    pb.authStore.clear()
-    localStorage.removeItem('pb_user')
+    logout()
     window.location.href = '/login'
   }
 

--- a/lib/context/AuthContext.tsx
+++ b/lib/context/AuthContext.tsx
@@ -164,6 +164,9 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
     fetch('/api/auth/logout', { method: 'POST' })
     pb.authStore.clear()
     clearBaseAuth()
+    if (typeof window !== 'undefined') {
+      localStorage.removeItem('pb_user')
+    }
     setUser(null)
     setTenantId(null)
     setIsLoggedIn(false)

--- a/logs/ERR_LOG.md
+++ b/logs/ERR_LOG.md
@@ -1,3 +1,5 @@
+## [2025-07-30] Logout nao funcionava para coordenador e lider; botao agora usa logout() do contexto - dev - 6948482
+
 ## [2025-06-07] Corrigido erro de importacao no blog - dev - 1f6facf
 
 ## [2025-06-07] Removidos tipos do React 19 e downgrade para React 18.2 para resolver erros em tempo de execução - dev - 469ca13


### PR DESCRIPTION
## Summary
- corrigir handleLogout do HeaderAdmin para usar `logout` do AuthContext
- limpar `pb_user` no `AuthContext.logout`
- registrar correção no `ERR_LOG`

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_685752c1d1bc832cab222476d62403c6