### PR TITLE
Sincroniza tenantId nas páginas do app

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,6 +95,8 @@ Com esse ID, o backend acessa `m24_clientes` e obtém as credenciais `asaas_api_
 Esta integração realiza chamadas HTTP diretamente na API do Asaas, sem utilizar o SDK oficial.
 Quando não há domínio configurado (ex.: durante testes em localhost), defina manualmente o cookie `tenantId` com o ID do cliente ou cadastre o domínio em `clientes_config` para que rotas como `/api/produtos` funcionem corretamente.
 
+Ao abrir páginas que utilizam informações do cliente (checkout, dashboard etc.), o frontend faz uma requisição GET para `/api/tenant` logo no carregamento. Assim o cookie `tenantId` permanece sincronizado com o servidor.
+
 ## Conectando ao PocketBase
 
 1. Defina `PB_URL` apontando para a URL onde o PocketBase está rodando, por exemplo. Se ela não estiver definida, o painel tentará usar `http://127.0.0.1:8090` em ambientes de desenvolvimento:

--- a/app/loja/checkout/page.tsx
+++ b/app/loja/checkout/page.tsx
@@ -15,6 +15,7 @@ import {
 } from '@/lib/constants'
 import { useMemo } from 'react'
 import type { Produto } from '@/types'
+import { useSyncTenant } from '@/lib/hooks/useSyncTenant'
 
 function formatCurrency(n: number) {
   return `R$ ${n.toFixed(2).replace('.', ',')}`
@@ -25,6 +26,7 @@ function CheckoutContent() {
 
   const router = useRouter()
   const { isLoggedIn, user, tenantId } = useAuthContext()
+  useSyncTenant()
   const { showSuccess, showError } = useToast()
 
   const [nome, setNome] = useState(user?.nome || '')

--- a/components/templates/LayoutWrapper.tsx
+++ b/components/templates/LayoutWrapper.tsx
@@ -6,6 +6,7 @@ import BackToTopButton from '@/app/admin/components/BackToTopButton'
 import NotificationBell from '@/app/admin/components/NotificationBell'
 import { useAuthContext } from '@/lib/context/AuthContext'
 import { useMemo } from 'react'
+import { useSyncTenant } from '@/lib/hooks/useSyncTenant'
 
 type UserRole = 'visitante' | 'usuario' | 'lider' | 'coordenador'
 
@@ -14,6 +15,7 @@ export default function LayoutWrapper({
 }: {
   children: React.ReactNode
 }) {
+  useSyncTenant()
   const { isLoggedIn, user } = useAuthContext()
   const role: UserRole = useMemo(() => {
     if (!isLoggedIn) return 'visitante'

--- a/components/templates/LayoutWrapperAdmin.tsx
+++ b/components/templates/LayoutWrapperAdmin.tsx
@@ -7,6 +7,7 @@ import BackToTopButton from '@/app/admin/components/BackToTopButton'
 import NotificationBell from '@/app/admin/components/NotificationBell'
 import TourIcon from '@/app/admin/components/TourIcon'
 import { useAuthContext } from '@/lib/context/AuthContext'
+import { useSyncTenant } from '@/lib/hooks/useSyncTenant'
 
 export default function LayoutWrapper({
   children,
@@ -17,6 +18,7 @@ export default function LayoutWrapper({
   const isInscricaoPublica = /^\/inscricoes\/[^/]+\/[^/]+$/.test(pathname)
 
   const { isLoggedIn, user } = useAuthContext()
+  useSyncTenant()
 
   return (
     <>

--- a/lib/hooks/useSyncTenant.ts
+++ b/lib/hooks/useSyncTenant.ts
@@ -1,0 +1,8 @@
+'use client'
+import { useEffect } from 'react'
+
+export function useSyncTenant() {
+  useEffect(() => {
+    fetch('/api/tenant', { credentials: 'include' }).catch(() => {})
+  }, [])
+}

--- a/logs/DOC_LOG.md
+++ b/logs/DOC_LOG.md
@@ -383,3 +383,4 @@
 ## [2025-06-22] Atualizado components_analysis.yaml removendo paths app/ e revisando componentes ausentes. - Lint: falhou (next not found) - Build: falhou (next not found)
 
 ## [2025-06-22] Ajustado layout da página de eventos em /inscricoes/[liderId] e adicionado overlay de carregamento no InscricaoWizard. Lint e build falharam (next not found).
+## [2025-06-22] README menciona sincronizacao do tenantId via /api/tenant e wrappers chamam a rota.


### PR DESCRIPTION
## Summary
- criar hook `useSyncTenant`
- sincronizar `tenantId` nos wrappers de layout e no checkout
- instruir README sobre a chamada a `/api/tenant`
- registrar atualização em `DOC_LOG.md`

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_685819473828832c99f2571fd214e98f