### PR TITLE
Improve tenant detection docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,14 +88,14 @@ Crie um arquivo `.env.local` na raiz e defina as seguintes variáveis:
 - `NEXT_PUBLIC_BRASILAPI_URL` - base para chamadas à BrasilAPI
 - `NEXT_PUBLIC_N8N_WEBHOOK_URL` - URL do webhook do n8n para receber inscrições
 
-Os servidores identificam automaticamente o tenant pelo domínio de cada requisição usando `getTenantFromHost`, que consulta a coleção `clientes_config` para descobrir o ID do cliente.
+Os servidores identificam automaticamente o tenant **priorizando o domínio** de cada requisição por meio da função `getTenantFromHost`, que consulta a coleção `clientes_config` para descobrir o ID do cliente.
 
 Com esse ID, o backend acessa `m24_clientes` e obtém as credenciais `asaas_api_key` e `asaas_account_id` da subconta correspondente, garantindo que cada domínio utilize sua própria chave Asaas.
 
 Esta integração realiza chamadas HTTP diretamente na API do Asaas, sem utilizar o SDK oficial.
 Quando não há domínio configurado (ex.: durante testes em localhost), defina manualmente o cookie `tenantId` com o ID do cliente ou cadastre o domínio em `clientes_config` para que rotas como `/api/produtos` funcionem corretamente.
 
-Ao abrir páginas que utilizam informações do cliente (checkout, dashboard etc.), o frontend faz uma requisição GET para `/api/tenant` logo no carregamento. Assim o cookie `tenantId` permanece sincronizado com o servidor.
+Ao abrir páginas que utilizam informações do cliente (checkout, dashboard etc.), o frontend faz uma requisição GET para `/api/tenant` logo no carregamento. Essa rota serve apenas para **confirmar** o ID detectado via domínio e garantir que o cookie `tenantId` permaneça sincronizado com o servidor.
 
 ## Conectando ao PocketBase
 

--- a/docs/design-system.md
+++ b/docs/design-system.md
@@ -190,8 +190,10 @@ O portal permite ajustar fonte, cor primária e logotipo dinamicamente. As confi
 Ao montar, o provedor executa a seguinte sequência:
 
 1. tenta ler as configurações armazenadas no `localStorage`. Se existirem e ainda estiverem válidas, elas são usadas diretamente;
-2. quando não há dados ou eles estão desatualizados, consulta `/api/tenant` para descobrir o ID do cliente e então carrega a coleção `clientes_config` **filtrando pelo campo `cliente`**, e não pelo ID do documento;
+2. quando não há dados ou eles estão desatualizados, consulta `/api/tenant` para **confirmar** o ID detectado pelo domínio e então carrega a coleção `clientes_config` **filtrando pelo campo `cliente`**, e não pelo ID do documento;
 3. caso o usuário esteja autenticado, permite editar as preferências via `/admin/api/configuracoes`.
+
+A detecção do tenant sempre prioriza o **domínio** informado na requisição. A rota `/api/tenant` serve apenas para confirmar esse valor e manter o cookie sincronizado em ambientes sem domínio configurado.
 
 Quando `updateConfig` é chamado, os dados são enviados para essa mesma rota e gravados no `localStorage`, mantendo navegador e PocketBase sincronizados.
 

--- a/logs/DOC_LOG.md
+++ b/logs/DOC_LOG.md
@@ -385,3 +385,4 @@
 ## [2025-06-22] Ajustado layout da página de eventos em /inscricoes/[liderId] e adicionado overlay de carregamento no InscricaoWizard. Lint e build falharam (next not found).
 ## [2025-06-22] README menciona sincronizacao do tenantId via /api/tenant e wrappers chamam a rota.
 ## [2025-07-31] getTenantFromHost prioriza domínio, atualiza cookie tenantId e fetchTenantConfig segue mesma lógica. Testes adicionados. Lint e build executados.
+## [2025-08-01] README e docs do design system destacam que a detecção do tenant prioriza o domínio e que `/api/tenant` serve apenas para confirmação. Nenhum código alterado.


### PR DESCRIPTION
## Summary
- clarify domain priority in tenant detection and confirm via `/api/tenant`
- log documentation update

## Testing
- `npm run lint` *(fails: next not found)*
- `npm run build` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_68581b573c6c832c973c901bf5783782