### PR TITLE
Add evento selection to produto forms

### DIFF
--- a/app/admin/produtos/page.tsx
+++ b/app/admin/produtos/page.tsx
@@ -85,6 +85,11 @@ export default function AdminProdutosPage() {
     } else if (form.cores) {
       formData.set('cores', String(form.cores))
     }
+    if (form.evento_id) formData.set('evento_id', String(form.evento_id))
+    formData.set(
+      'requer_inscricao_aprovada',
+      String(form.requer_inscricao_aprovada ? 'true' : 'false'),
+    )
     formData.set('ativo', String(form.ativo ? 'true' : 'false'))
     if (form.imagens && form.imagens instanceof FileList) {
       Array.from(form.imagens).forEach((file) =>


### PR DESCRIPTION
## Summary
- allow new product modal to link evento and toggle requirement
- fetch eventos on product edit page and new modal open
- store selected evento and requirement in product CRUD

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68581a60536c832c930267ad4167ef3c