### PR TITLE
Add middleware tenant header test

### DIFF
--- a/__tests__/middleware.test.ts
+++ b/__tests__/middleware.test.ts
@@ -1,0 +1,26 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { NextRequest } from 'next/server'
+import createPocketBaseMock from './mocks/pocketbase'
+
+const pb = createPocketBaseMock()
+vi.mock('../lib/pocketbase', () => ({ default: vi.fn(() => pb) }))
+
+import { middleware } from '../middleware'
+
+let getFirstListItemMock: any
+
+beforeEach(() => {
+  getFirstListItemMock = vi.fn().mockResolvedValue({ cliente: 'cli1' })
+  pb.collection.mockReturnValue({ getFirstListItem: getFirstListItemMock })
+})
+
+describe('middleware', () => {
+  it('adiciona cabecalho x-tenant-id e reescreve cookie tenantId', async () => {
+    const req = new NextRequest('http://tenant.com/test', {
+      headers: { host: 'tenant.com', cookie: 'tenantId=old' },
+    })
+    const res = await middleware(req)
+    expect(res.headers.get('x-tenant-id')).toBe('cli1')
+    expect(res.headers.get('set-cookie')).toContain('tenantId=cli1')
+  })
+})


### PR DESCRIPTION
## Summary
- add middleware test checking x-tenant-id header and tenantId cookie

## Testing
- `npm run lint`
- `npm run build` *(fails: Property 'get' does not exist on type 'Promise<ReadonlyRequestCookies>')*
- `npm run test` *(fails: 21 test files failed)*

------
https://chatgpt.com/codex/tasks/task_e_68581ab98e2c832c86ec98acd0a0bcfb