### PR TITLE
Corrigir tipagem das páginas de eventos

### DIFF
--- a/app/inscricoes/lider/evento/page.tsx
+++ b/app/inscricoes/lider/evento/page.tsx
@@ -1,21 +1,17 @@
-'use client'
 import { EventForm } from '@/components/organisms'
 
-export default function CadastroViaLider({
+export default async function CadastroViaLider({
   searchParams,
 }: {
-  searchParams: { lider?: string; evento?: string }
+  searchParams: Promise<{ lider?: string; evento?: string }>
 }) {
+  const { evento, lider } = await searchParams
+
   return (
     <main className="px-4 py-10 flex justify-center">
       <div className="w-full max-w-xl space-y-6">
         <h1 className="text-3xl font-bold text-center">Cadastro via Líder</h1>
-        {searchParams.evento && (
-          <EventForm
-            eventoId={searchParams.evento}
-            liderId={searchParams.lider}
-          />
-        )}
+        {evento && <EventForm eventoId={evento} liderId={lider} />}
       </div>
     </main>
   )

--- a/app/loja/eventos/page.tsx
+++ b/app/loja/eventos/page.tsx
@@ -1,17 +1,17 @@
-'use client'
-
 import { EventForm } from '@/components/organisms'
 
-export default function EventosFormPage({
+export default async function EventosFormPage({
   searchParams,
 }: {
-  searchParams: { evento?: string }
+  searchParams: Promise<{ evento?: string }>
 }) {
+  const { evento } = await searchParams
+
   return (
     <main className="px-4 py-10 flex justify-center">
       <div className="w-full max-w-xl space-y-6">
         <h1 className="text-3xl font-bold text-center">Inscrição em Evento</h1>
-        {searchParams.evento && <EventForm eventoId={searchParams.evento} />}
+        {evento && <EventForm eventoId={evento} />}
       </div>
     </main>
   )

--- a/logs/ERR_LOG.md
+++ b/logs/ERR_LOG.md
@@ -129,3 +129,4 @@
 ## [2025-07-30] Logout nao funcionava para coordenador e lider; botao agora usa logout() do contexto - dev - 6948482
 
 ## [2025-07-31] Erro ao buscar produto: ClientResponseError 404: The requested resource wasn't found. - production - 2df37e3
+## [2025-06-22] Corrigido erro de tipagem no Next.js para parametros de URL nas páginas de eventos. - dev


### PR DESCRIPTION
## Mudanças
- ajustar `searchParams` das páginas `/inscricoes/lider/evento` e `/loja/eventos`
- atualizar `ERR_LOG.md` com registro da correção

## Testes
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68582f48062c832cb462c3b633ff94c8