### PR TITLE
Fix registro inscricao sem ID

### DIFF
--- a/app/api/inscricoes/route.ts
+++ b/app/api/inscricoes/route.ts
@@ -176,11 +176,14 @@ export async function POST(req: NextRequest) {
       tamanho,
       cliente: lider.cliente,
     }
-    const dadosInscricao: Inscricao & {
+    const { id: _inscricaoId, ...dadosBaseSemId } = criarInscricao(dadosBase)
+    void _inscricaoId
+
+    const dadosInscricao: Omit<Inscricao, 'id'> & {
       paymentMethod: PaymentMethod
       installments: number
     } = {
-      ...criarInscricao(dadosBase),
+      ...dadosBaseSemId,
       paymentMethod,
       installments,
     }

--- a/app/loja/api/inscricoes/route.ts
+++ b/app/loja/api/inscricoes/route.ts
@@ -64,8 +64,11 @@ export async function POST(req: NextRequest) {
       : 'pix'
     const installments = Number(data.installments) || 1
 
+    const { id: _inscricaoId, ...inscricaoSemId } = criarInscricao(base)
+    void _inscricaoId
+
     const registroParaCriar = {
-      ...criarInscricao(base),
+      ...inscricaoSemId,
       paymentMethod,
       installments,
     }

--- a/logs/DOC_LOG.md
+++ b/logs/DOC_LOG.md
@@ -379,3 +379,5 @@
 ## [2025-08-02] Rotas de inscrições reorganizadas sob `/inscricoes/lider` e `EventForm` passou a solicitar forma de pagamento.
 
 ## [2025-08-03] Unificado InscricaoWizard e InscricaoLojaWizard no EventForm. Páginas agora recebem evento via searchParams. Lint e build falharam (next not found).
+
+## [2025-08-04] Ajustado rotas de inscrição para remover campo id antes de criar registros no PocketBase. Lint e build executados com sucesso.


### PR DESCRIPTION
## Summary
- avoid sending `id` when creating inscricoes
- note change in DOC_LOG

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68583961dfb0832cbc38c9869dfca341