### PR TITLE
Add header and footer on inscrições pages

### DIFF
--- a/app/inscricoes/layout.tsx
+++ b/app/inscricoes/layout.tsx
@@ -1,0 +1,14 @@
+import '../globals.css'
+import LayoutWrapper from '@/components/templates/LayoutWrapper'
+
+export default function InscricoesLayout({
+  children,
+}: {
+  children: React.ReactNode
+}) {
+  return (
+    <div className="text-platinum font-sans">
+      <LayoutWrapper>{children}</LayoutWrapper>
+    </div>
+  )
+}

--- a/app/inscricoes/lider/[liderId]/evento/[eventoId]/page.tsx
+++ b/app/inscricoes/lider/[liderId]/evento/[eventoId]/page.tsx
@@ -4,7 +4,6 @@ import Image from 'next/image'
 import { useParams } from 'next/navigation'
 import { useState, useEffect } from 'react'
 import { InscricaoWizard } from '@/components/organisms'
-import { headers } from 'next/headers'
 
 export default function InscricaoPage() {
   // Extrai params apenas uma vez


### PR DESCRIPTION
## Summary
- add layout for /inscricoes so pages share header and footer
- fix unused import in inscrição page

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68583cc942b8832ca621ac6936fc75bb