### PR TITLE
Add GET/PATCH to inscricoes route

### DIFF
--- a/app/api/inscricoes/[id]/route.ts
+++ b/app/api/inscricoes/[id]/route.ts
@@ -1,5 +1,85 @@
 import { NextRequest, NextResponse } from 'next/server'
 import { requireRole } from '@/lib/apiAuth'
+import { getTenantFromHost } from '@/lib/getTenantFromHost'
+import type { Inscricao } from '@/types'
+import type { RecordModel } from 'pocketbase'
+
+async function checkAccess(
+  inscricao: Inscricao,
+  user: RecordModel,
+): Promise<{ ok: true } | { error: string; status: number }> {
+  if (user.role === 'usuario') {
+    if (inscricao.criado_por !== user.id) {
+      return { error: 'Acesso negado', status: 403 }
+    }
+  } else if (user.role === 'lider') {
+    if (inscricao.campo !== user.campo) {
+      return { error: 'Acesso negado', status: 403 }
+    }
+  } else {
+    const tenantId = await getTenantFromHost()
+    if (!tenantId) {
+      return { error: 'Tenant não informado', status: 400 }
+    }
+    if (inscricao.cliente !== tenantId) {
+      return { error: 'Acesso negado', status: 403 }
+    }
+  }
+  return { ok: true }
+}
+
+export async function GET(req: NextRequest) {
+  const id = req.nextUrl.pathname.split('/').pop() || ''
+  if (!id) return NextResponse.json({ error: 'ID inválido' }, { status: 400 })
+  const auth = requireRole(req, ['usuario', 'lider', 'coordenador'])
+  if ('error' in auth) {
+    return NextResponse.json({ error: auth.error }, { status: auth.status })
+  }
+  const { pb, user } = auth
+  try {
+    const expand = req.nextUrl.searchParams.get('expand') || 'evento,campo,pedido'
+    const record = await pb
+      .collection('inscricoes')
+      .getOne<Inscricao>(id, { expand })
+    const access = await checkAccess(record, user)
+    if ('error' in access) {
+      return NextResponse.json(
+        { error: access.error },
+        { status: access.status },
+      )
+    }
+    return NextResponse.json(record)
+  } catch (err) {
+    console.error('Erro ao obter inscricao:', err)
+    return NextResponse.json({ error: 'Erro ao obter' }, { status: 500 })
+  }
+}
+
+export async function PATCH(req: NextRequest) {
+  const id = req.nextUrl.pathname.split('/').pop() || ''
+  if (!id) return NextResponse.json({ error: 'ID inválido' }, { status: 400 })
+  const auth = requireRole(req, ['usuario', 'lider', 'coordenador'])
+  if ('error' in auth) {
+    return NextResponse.json({ error: auth.error }, { status: auth.status })
+  }
+  const { pb, user } = auth
+  try {
+    const inscricao = await pb.collection('inscricoes').getOne<Inscricao>(id)
+    const access = await checkAccess(inscricao, user)
+    if ('error' in access) {
+      return NextResponse.json(
+        { error: access.error },
+        { status: access.status },
+      )
+    }
+    const data = await req.json()
+    const updated = await pb.collection('inscricoes').update(id, data)
+    return NextResponse.json(updated)
+  } catch (err) {
+    console.error('Erro ao atualizar inscricao:', err)
+    return NextResponse.json({ error: 'Erro ao atualizar' }, { status: 500 })
+  }
+}
 
 export async function DELETE(req: NextRequest) {
   const id = req.nextUrl.pathname.split('/').pop() || ''

--- a/docs/function-index.md
+++ b/docs/function-index.md
@@ -182,6 +182,8 @@
 - **app/api/eventos/route.ts**
   - GET
 - **app/api/inscricoes/[id]/route.ts**
+  - GET
+  - PATCH
   - DELETE
 - **app/api/inscricoes/route.ts**
   - GET

--- a/logs/DOC_LOG.md
+++ b/logs/DOC_LOG.md
@@ -387,3 +387,4 @@
 ## [2025-08-06] Ajustado cadastro da loja para enviar produto e senha definidos no EventForm. Passo de criação de senha adicionado ao formulário.
 
 ## [2025-08-07] Cadastro passa a enviar endereco completo e role do usuario pela loja.
+## [2025-06-22] Atualizado docs/function-index.md listando métodos GET e PATCH para inscricoes/[id].

--- a/logs/ERR_LOG.md
+++ b/logs/ERR_LOG.md
@@ -131,3 +131,4 @@
 ## [2025-07-31] Erro ao buscar produto: ClientResponseError 404: The requested resource wasn't found. - production - 2df37e3
 
 ## [2025-06-22] Corrigido erro de tipagem no Next.js para parametros de URL nas páginas de eventos. - dev
+## [2025-06-22] Erro 405 ao acessar /api/inscricoes/[id]; implementados métodos GET e PATCH para correção - development - 1cf1de4


### PR DESCRIPTION
## Summary
- add GET/PATCH handlers to `/api/inscricoes/[id]`
- document new methods in `docs/function-index.md`
- log the update in `DOC_LOG.md` and `ERR_LOG.md`

## Testing
- `npm run lint` *(fails: `next` not found)*
- `npm run build` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_68584acc2e58832cb2f48513156cc3c8