### PR TITLE
Fix pedidoId handling

### DIFF
--- a/app/admin/inscricoes/page.tsx
+++ b/app/admin/inscricoes/page.tsx
@@ -286,14 +286,14 @@ export default function ListaInscricoesPage() {
       })
 
       // Agora sim, apenas aguardamos o JSON retornado
-      const pedido: Pedido = await pedidoRes.json()
+      const pedido: { pedidoId: string } = await pedidoRes.json()
 
       // 3. Gerar link de pagamento via Asaas
       const asaasRes = await fetch('/api/asaas', {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({
-          pedidoId: pedido.id,
+          pedidoId: pedido.pedidoId,
           valorBruto: precoProduto,
           paymentMethod: metodo,
           installments: parcelas,
@@ -311,7 +311,7 @@ export default function ListaInscricoesPage() {
         credentials: 'include',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({
-          pedido: pedido.id,
+          pedido: pedido.pedidoId,
           status: 'aguardando_pagamento',
           confirmado_por_lider: true,
         }),
@@ -340,7 +340,7 @@ export default function ListaInscricoesPage() {
           cpf: inscricao.cpf,
           evento: inscricao.evento,
           liderId: campo?.responsavel,
-          pedidoId: pedido.id,
+          pedidoId: pedido.pedidoId,
           cliente: tenantId,
           valor: gross,
           url_pagamento: checkout.url,

--- a/app/admin/inscricoes/page.tsx
+++ b/app/admin/inscricoes/page.tsx
@@ -262,7 +262,7 @@ export default function ListaInscricoesPage() {
         credentials: 'include',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({
-          id_inscricao: id,
+          inscricaoId: id,
           valor: precoProduto,
           status: 'pendente',
           produto: produtoRecord.nome || 'Produto',

--- a/logs/ERR_LOG.md
+++ b/logs/ERR_LOG.md
@@ -131,3 +131,5 @@
 ## [2025-07-31] Erro ao buscar produto: ClientResponseError 404: The requested resource wasn't found. - production - 2df37e3
 
 ## [2025-06-22] Corrigido erro de tipagem no Next.js para parametros de URL nas páginas de eventos. - dev
+
+## [2025-06-22] Erro ao confirmar inscrição: API /api/asaas retornava "pedidoId e valorBruto são obrigatórios" devido ao uso de pedido.id na página admin/inscricoes. Corrigido para usar pedido.pedidoId. - dev - c89ca25

--- a/logs/ERR_LOG.md
+++ b/logs/ERR_LOG.md
@@ -133,3 +133,4 @@
 ## [2025-06-22] Corrigido erro de tipagem no Next.js para parametros de URL nas páginas de eventos. - dev
 
 ## [2025-06-22] Erro ao confirmar inscrição: API /api/asaas retornava "pedidoId e valorBruto são obrigatórios" devido ao uso de pedido.id na página admin/inscricoes. Corrigido para usar pedido.pedidoId. - dev - c89ca25
+## [2025-06-22] Falha ao criar pedido ao aprovar inscrição; página admin/inscricoes enviava `id_inscricao` em vez de `inscricaoId`. Ajustado para enviar o campo correto. - dev - 36974c3


### PR DESCRIPTION
## Summary
- fix admin Inscrições page to use `pedidoId`
- log the bugfix

## Testing
- `npm run lint` *(fails: next not found)*
- `npm run build` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_685850c55a00832c89351a9877090bba