### PR TITLE
Fix inscricao rejection workflow

### DIFF
--- a/app/admin/inscricoes/page.tsx
+++ b/app/admin/inscricoes/page.tsx
@@ -14,7 +14,6 @@ import { type PaymentMethod } from '@/lib/asaasFees'
 import type {
   Evento,
   Inscricao as InscricaoRecord,
-  Pedido,
   Produto,
 } from '@/types'
 
@@ -42,6 +41,7 @@ type Inscricao = {
   tamanho?: string
   genero?: string
   confirmado_por_lider?: boolean
+  aprovada?: boolean
   data_nascimento?: string
   criado_por?: string
   pedido_id?: string | null
@@ -130,6 +130,7 @@ export default function ListaInscricoesPage() {
           data_nascimento: r.data_nascimento ?? '',
           criado_por: r.criado_por ?? '',
           confirmado_por_lider: r.confirmado_por_lider ?? false,
+          aprovada: r.aprovada ?? false,
           pedido_status: r.expand?.pedido?.status ?? null,
           pedido_id: r.expand?.pedido?.id ?? null,
         }))
@@ -262,11 +263,13 @@ export default function ListaInscricoesPage() {
         credentials: 'include',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({
-          id_inscricao: id,
+          inscricaoId: id,
           valor: precoProduto,
           status: 'pendente',
           produto: produtoRecord.nome || 'Produto',
-          cor: 'Roxo',
+          cor: Array.isArray(produtoRecord.cores)
+            ? produtoRecord.cores[0] || 'Roxo'
+            : (produtoRecord.cores as string | undefined) || 'Roxo',
           tamanho:
             inscricao.tamanho ||
             (Array.isArray(produtoRecord.tamanhos)
@@ -286,14 +289,14 @@ export default function ListaInscricoesPage() {
       })
 
       // Agora sim, apenas aguardamos o JSON retornado
-      const pedido: Pedido = await pedidoRes.json()
+      const pedido: { pedidoId: string } = await pedidoRes.json()
 
       // 3. Gerar link de pagamento via Asaas
       const asaasRes = await fetch('/api/asaas', {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({
-          pedidoId: pedido.id,
+          pedidoId: pedido.pedidoId,
           valorBruto: precoProduto,
           paymentMethod: metodo,
           installments: parcelas,
@@ -311,9 +314,10 @@ export default function ListaInscricoesPage() {
         credentials: 'include',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({
-          pedido: pedido.id,
+          pedido: pedido.pedidoId,
           status: 'aguardando_pagamento',
           confirmado_por_lider: true,
+          aprovada: true,
         }),
       })
 
@@ -325,6 +329,7 @@ export default function ListaInscricoesPage() {
                 ...i,
                 status: 'aguardando_pagamento',
                 confirmado_por_lider: true,
+                aprovada: true,
               }
             : i,
         ),
@@ -340,7 +345,7 @@ export default function ListaInscricoesPage() {
           cpf: inscricao.cpf,
           evento: inscricao.evento,
           liderId: campo?.responsavel,
-          pedidoId: pedido.id,
+          pedidoId: pedido.pedidoId,
           cliente: tenantId,
           valor: gross,
           url_pagamento: checkout.url,
@@ -663,12 +668,21 @@ export default function ListaInscricoesPage() {
                     method: 'PATCH',
                     credentials: 'include',
                     headers: { 'Content-Type': 'application/json' },
-                    body: JSON.stringify({ status: 'cancelado' }),
+                    body: JSON.stringify({
+                      status: 'cancelado',
+                      confirmado_por_lider: true,
+                      aprovada: false,
+                    }),
                   })
                   setInscricoes((prev) =>
                     prev.map((i) =>
                       i.id === inscricaoParaRecusar.id
-                        ? { ...i, status: 'cancelado' }
+                        ? {
+                            ...i,
+                            status: 'cancelado',
+                            confirmado_por_lider: true,
+                            aprovada: false,
+                          }
                         : i,
                     ),
                   )

--- a/logs/ERR_LOG.md
+++ b/logs/ERR_LOG.md
@@ -131,3 +131,8 @@
 ## [2025-07-31] Erro ao buscar produto: ClientResponseError 404: The requested resource wasn't found. - production - 2df37e3
 
 ## [2025-06-22] Corrigido erro de tipagem no Next.js para parametros de URL nas páginas de eventos. - dev
+
+## [2025-06-22] Erro ao confirmar inscrição: API /api/asaas retornava "pedidoId e valorBruto são obrigatórios" devido ao uso de pedido.id na página admin/inscricoes. Corrigido para usar pedido.pedidoId. - dev - c89ca25
+## [2025-06-22] Falha ao criar pedido ao aprovar inscrição; página admin/inscricoes enviava `id_inscricao` em vez de `inscricaoId`. Ajustado para enviar o campo correto. - dev - 36974c3
+## [2025-06-22] Campo `aprovada` não era enviado ao confirmar inscrições, impedindo a compra de produtos que exigem aprovação. Página admin/inscricoes agora define `aprovada: true`. - dev - e7773fb
+## [2025-06-22] Recusar inscrição não atualizava `aprovada` nem `confirmado_por_lider`. Ajustado para enviar ambos ao cancelar. - dev - 76c0333


### PR DESCRIPTION
## Summary
- update cancel action to set `aprovada: false` and `confirmado_por_lider`
- log rejection fix in `ERR_LOG.md`

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_685850c55a00832c89351a9877090bba