### PR TITLE
Atualiza docs de inscrição e pedidos

### DIFF
--- a/README.md
+++ b/README.md
@@ -136,6 +136,8 @@ Ao abrir páginas que utilizam informações do cliente (checkout, dashboard etc
   uma chamada para `/api/asaas` informando `valorBruto`, `paymentMethod`
   e `installments` para gerar o boleto e salvar o link de pagamento no pedido
   correspondente.
+- Para o passo a passo completo do modo manual consulte
+  [docs/manual-aprovacao-inscricao.md](docs/manual-aprovacao-inscricao.md).
 - **Compras de Loja** – os produtos adicionados ao carrinho são processados na
   página `/loja/checkout`. Esse fluxo usa `/api/asaas/checkout` para
   criar um link de checkout do Asaas e redirecionar o usuário automaticamente.

--- a/docs/manual-aprovacao-inscricao.md
+++ b/docs/manual-aprovacao-inscricao.md
@@ -1,0 +1,122 @@
+# ✅ Aprovação Manual da Inscrição – Codex
+
+Este documento detalha as **duas possibilidades de ação manual** sobre uma inscrição no painel administrativo, quando `confirma_inscricoes = true`.
+
+---
+
+## 📌 Opções de Ação Manual
+
+### ✅ 1. Confirmar Inscrição
+
+> Aprova a inscrição e inicia o fluxo de pagamento.
+
+#### Regras:
+
+* A cor deve ser extraída do campo `cores` do produto (coleção `produtos`). Caso haja mais de uma, utilizar a primeira cor como padrão (ex: `produto.cores[0]`).
+
+```ts
+// Exemplo de extração da cor do produto e montagem do array
+const coresSelecionadas = Array.isArray(produto.cores) && produto.cores.length > 0
+  ? [produto.cores[0]]
+  : ['Roxo']; // fallback padrão
+
+const pedidoPayload = {
+  id_inscricao: inscricao.id,
+  produto: [produto.id], // agora múltiplo
+  cores: coresSelecionadas,
+  tamanho: inscricao.tamanho ?? (Array.isArray(produto.tamanhos) ? produto.tamanhos[0] : 'M'),
+  genero: inscricao.genero ?? (Array.isArray(produto.generos) ? produto.generos[0] : 'feminino'),
+  email: inscricao.email,
+  valor: produto.preco,
+  status: 'pendente',
+  campo: campo?.id,
+  responsavel: inscricao.criado_por,
+  cliente: tenantId,
+  canal: 'inscricao'
+};
+
+// Enviar para /api/pedidos com esse payload
+```
+
+* Atualizar campo `aprovada` → `true`
+* Atualizar campo `confirmado_por_lider` → `true`
+* Gerar link de pagamento via Asaas (`/api/asaas`)
+* Atualizar inscrição com:
+
+```json
+{
+  "pedido": "ID_DO_PEDIDO",
+  "status": "aguardando_pagamento",
+  "confirmado_por_lider": true
+}
+```
+
+#### Resultado:
+
+Inscrição segue normalmente para pagamento e posterior confirmação.
+
+---
+
+### ❌ 2. Recusar Inscrição
+
+> Marca a inscrição como recusada. Não gera pedido nem cobrança.
+
+#### Regras:
+
+* Atualizar campo `aprovada` → `false`
+* Atualizar campo `confirmado_por_lider` → `true`
+* Atualizar campo `status` → `cancelado`
+
+#### Resultado:
+
+Inscrição é considerada **avaliada**, mas rejeitada. Não será faturada.
+
+---
+
+## 🛠️ Fluxo de Atualização
+
+| Ação      | `aprovada` | `confirmado_por_lider` | `status`               | Pedido                            |
+| --------- | ---------- | ---------------------- | ---------------------- | --------------------------------- |
+| Confirmar | `true`     | `true`                 | `aguardando_pagamento` | Criado via API com `id_inscricao` |
+| Recusar   | `false`    | `true`                 | `cancelado`            | —                                 |
+
+---
+
+## 🔐 Permissões
+
+Apenas os seguintes perfis podem executar essas ações:
+
+* `coordenador`
+* `lider` (desde que vinculado ao campo da inscrição)
+
+---
+
+## 📎 Referências Técnicas
+
+* Campo `aprovada`: booleano, define se a inscrição será processada financeiramente
+* Campo `confirmado_por_lider`: booleano, marca que houve análise manual
+* Campo `pedido`: referência à coleção `pedidos`
+* Campo `id_inscricao` em `pedidos`: relação direta com `id` da inscrição
+* Status possíveis: `pendente`, `aguardando_pagamento`, `confirmado`, `cancelado`
+
+**Estrutura esperada da coleção `pedidos`:**
+
+| Campo            | Tipo    | Obrigatório | Observações                       |
+| ---------------- | ------- | ----------- | --------------------------------- |
+| `id`             | String  | Sim         | Identificador único               |
+| `id_pagamento`   | String  | Não         | ID retornado do Asaas             |
+| `id_inscricao`   | Rel.    | Sim         | Relacionado à inscrição           |
+| `produto`        | Rel.[]  | Sim         | Produtos vinculados               |
+| `cores`          | Array   | Sim         | Cores escolhidas                  |
+| `tamanho`        | Enum    | Sim         | `PP` • `P` • `M` • `G` • `GG`     |
+| `email`          | String  | Sim         | E-mail do inscrito                |
+| `status`         | Enum    | Sim         | `pendente` • `pago` • `cancelado` |
+| `campo`          | Rel.    | Sim         | Campo da inscrição                |
+| `responsavel`    | Rel.    | Sim         | Usuário que aprovou               |
+| `genero`         | Enum    | Sim         | `feminino` • `masculino`          |
+| `valor`          | Number  | Sim         | Valor total do pedido             |
+| `link_pagamento` | String  | Sim         | URL gerada pelo Asaas             |
+| `cliente`        | Rel.    | Sim         | Cliente (tenant) relacionado      |
+| `canal`          | Enum    | Sim         | `inscricao` • `loja`              |
+| `created`        | Date    | Auto        | Data de criação                   |
+| `updated`        | Date    | Auto        | Última atualização                |

--- a/docs/regras-pedidos.md
+++ b/docs/regras-pedidos.md
@@ -23,3 +23,15 @@ Em ambos os casos o pedido recebe status `pendente` inicialmente e passa a `pago
 - **Desativado** – o pedido é criado imediatamente junto à inscrição, agilizando o fluxo.
 
 Consulte também [docs/regras-inscricoes.md](docs/regras-inscricoes.md) para detalhes sobre o escopo das inscrições.
+
+### Estrutura da coleção `pedidos`
+
+O campo `produto` agora aceita **múltiplos** produtos vinculados ao mesmo pedido. O payload de criação deve enviar `produto: [idProduto]` e a tabela de campos fica:
+
+| Campo      | Tipo    | Observações                         |
+| ---------- | ------- | ---------------------------------- |
+| `id`       | String  | Identificador do pedido             |
+| `produto`  | Rel.[]  | IDs dos produtos selecionados       |
+| `valor`    | Number  | Valor total do pedido               |
+| `status`   | Enum    | `pendente`, `pago` ou `cancelado`   |
+| `canal`    | Enum    | `inscricao` ou `loja`               |

--- a/logs/DOC_LOG.md
+++ b/logs/DOC_LOG.md
@@ -388,3 +388,4 @@
 
 ## [2025-08-07] Cadastro passa a enviar endereco completo e role do usuario pela loja.
 ## [2025-06-22] Atualizado docs/function-index.md listando métodos GET e PATCH para inscricoes/[id].
+## [2025-06-22] Documentado fluxo manual de inscrições e campo produto múltiplo em pedidos.


### PR DESCRIPTION
## Summary
- registra no DOC_LOG
- cria manual-aprovacao-inscricao.md
- ajusta guia de pedidos com produto múltiplo
- referencia no README o novo fluxo manual

## Testing
- `npm run lint` *(fails: next not found)*
- `npm run build` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_6858612bdcc8832cb61312b48e1ddf17