### PR TITLE
Padroniza envio de produto por ID

### DIFF
--- a/__tests__/admin/asaasRoute.test.ts
+++ b/__tests__/admin/asaasRoute.test.ts
@@ -56,7 +56,7 @@ describe('POST /admin/api/asaas', () => {
               id: 'p1',
               id_inscricao: 'i1',
               responsavel: 'u1',
-              produto: 'Produto',
+              produto: ['Produto'],
             }),
             update: vi.fn(),
           }

--- a/__tests__/admin/pedidosRoute.test.ts
+++ b/__tests__/admin/pedidosRoute.test.ts
@@ -34,7 +34,7 @@ describe('POST /admin/api/pedidos', () => {
     pb.authStore.model = undefined
     const req = new Request('http://test', {
       method: 'POST',
-      body: JSON.stringify({ produto: 'P' }),
+      body: JSON.stringify({ produto: ['P'] }),
     })
     const res = await POST(req as unknown as NextRequest)
     expect(res.status).toBe(401)
@@ -49,7 +49,7 @@ describe('POST /admin/api/pedidos', () => {
     const req = new Request('http://test', {
       method: 'POST',
       body: JSON.stringify({
-        produto: 'Produto',
+        produto: ['Produto'],
         valor: 10,
         tamanho: 'M',
         cor: 'Azul',

--- a/__tests__/api/pedidosRoute.test.ts
+++ b/__tests__/api/pedidosRoute.test.ts
@@ -153,7 +153,7 @@ describe('POST /api/pedidos', () => {
     })
     const req = new Request('http://test/api/pedidos', {
       method: 'POST',
-      body: JSON.stringify({ produto: 'p1', valor: 5 }),
+      body: JSON.stringify({ produto: ['p1'], valor: 5 }),
     })
     const res = await (
       await import('../../app/api/pedidos/route')
@@ -171,7 +171,7 @@ describe('POST /api/pedidos', () => {
     getFirstMock.mockRejectedValueOnce(new Error('not found'))
     const req = new Request('http://test/api/pedidos', {
       method: 'POST',
-      body: JSON.stringify({ produto: 'p2', valor: 10 }),
+      body: JSON.stringify({ produto: ['p2'], valor: 10 }),
     })
     const res = await (
       await import('../../app/api/pedidos/route')
@@ -195,7 +195,7 @@ describe('POST /api/pedidos', () => {
     })
     const req = new Request('http://test/api/pedidos', {
       method: 'POST',
-      body: JSON.stringify({ produto: 'p3', valor: 15 }),
+      body: JSON.stringify({ produto: ['p3'], valor: 15 }),
     })
     const res = await (
       await import('../../app/api/pedidos/route')
@@ -216,7 +216,7 @@ describe('POST /api/pedidos', () => {
 
     const req = new Request('http://test/api/pedidos', {
       method: 'POST',
-      body: JSON.stringify({ produto: 'p', email: 'e@test.com', valor: 10 }),
+      body: JSON.stringify({ produto: ['p'], email: 'e@test.com', valor: 10 }),
     })
     const res = await POST(req as unknown as NextRequest)
     expect(res.status).toBe(200)
@@ -239,7 +239,7 @@ describe('POST /api/pedidos', () => {
 
     const req = new Request('http://test/api/pedidos', {
       method: 'POST',
-      body: JSON.stringify({ inscricaoId: 'ins1' }),
+      body: JSON.stringify({ id_inscricao: 'ins1' }),
     })
 
     const res = await POST(req as unknown as NextRequest)

--- a/__tests__/orderFlow.test.ts
+++ b/__tests__/orderFlow.test.ts
@@ -16,8 +16,8 @@ const dadosValidos = {
   tamanho: 'M',
 }
 
-const pulseira = { nome: 'Somente Pulseira', preco: 10 }
-const kit = { nome: 'Kit Camisa + Pulseira', preco: 50 }
+const pulseira = { id: 'p1', nome: 'Somente Pulseira', preco: 10 }
+const kit = { id: 'p2', nome: 'Kit Camisa + Pulseira', preco: 50 }
 
 describe('Fluxo de inscrição e pedido', () => {
   it('cria inscrição válida com status pendente', () => {
@@ -38,6 +38,7 @@ describe('Fluxo de inscrição e pedido', () => {
     expect(pedido.valor).toBe('10.00')
     expect(pedido.status).toBe('pendente')
     expect(pedido.canal).toBe('inscricao')
+    expect(pedido.produto).toEqual([pulseira.id])
   })
 
   it('gera pedido para kit completo com valor 50', () => {
@@ -50,5 +51,6 @@ describe('Fluxo de inscrição e pedido', () => {
     expect(pedido.email).toBe('teste@example.com')
     expect(pedido.status).toBe('pendente')
     expect(pedido.canal).toBe('inscricao')
+    expect(pedido.produto).toEqual([kit.id])
   })
 })

--- a/app/admin/inscricoes/componentes/ModalVisualizarPedido.tsx
+++ b/app/admin/inscricoes/componentes/ModalVisualizarPedido.tsx
@@ -14,7 +14,7 @@ type PedidoExpandido = {
   id: string
   valor: number
   status: string
-  produto: string
+  produto: string[]
   cor?: string
   tamanho?: string
   genero?: string
@@ -125,7 +125,7 @@ export default function ModalVisualizarPedido({ pedidoId, onClose }: Props) {
               <strong>Status:</strong> {pedido.status}
             </p>
             <p>
-              <strong>Produto:</strong> {pedido.produto}
+              <strong>Produto:</strong> {pedido.produto.join(', ')}
             </p>
             <p>
               <strong>Tamanho:</strong> {pedido.tamanho || '—'}

--- a/app/admin/inscricoes/page.tsx
+++ b/app/admin/inscricoes/page.tsx
@@ -274,10 +274,10 @@ const confirmarInscricao = async (id: string) => {
         credentials: 'include',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({
-          inscricaoId: id,
+          id_inscricao: id,
           valor: precoProduto,
           status: 'pendente',
-          produto: produtoRecord.nome || 'Produto',
+          produto: [produtoRecord?.id || produtoId].filter(Boolean),
           cor: Array.isArray(produtoRecord.cores)
             ? produtoRecord.cores[0] || 'Roxo'
             : (produtoRecord.cores as string | undefined) || 'Roxo',

--- a/app/admin/pedidos/componentes/ModalEditarPedido.tsx
+++ b/app/admin/pedidos/componentes/ModalEditarPedido.tsx
@@ -22,7 +22,10 @@ export default function ModalEditarPedido({ pedido, onClose, onSave }: Props) {
     e: React.ChangeEvent<HTMLInputElement | HTMLSelectElement>,
   ) => {
     const { name, value } = e.target
-    setFormState((prev) => ({ ...prev, [name]: value }))
+    setFormState((prev) => ({
+      ...prev,
+      [name]: name === 'produto' ? [value] : value,
+    }))
   }
 
   const handleSubmit = async (e: FormEvent<HTMLFormElement>) => {
@@ -38,7 +41,9 @@ export default function ModalEditarPedido({ pedido, onClose, onSave }: Props) {
           <Input
             name="produto"
             label="Produto"
-            value={formState.produto || ''}
+            value={Array.isArray(formState.produto)
+              ? formState.produto.join(', ')
+              : formState.produto || ''}
             onChange={handleChange}
           />
           <Input

--- a/app/api/asaas/route.ts
+++ b/app/api/asaas/route.ts
@@ -246,7 +246,9 @@ export async function POST(req: NextRequest) {
       billingType,
       value: gross,
       dueDate: dueDateStr,
-      description: pedido.produto || 'Produto',
+      description: Array.isArray(pedido.produto)
+        ? pedido.produto.join(', ')
+        : pedido.produto || 'Produto',
       split: [
         {
           walletId: process.env.WALLETID_M24,

--- a/app/api/inscricoes/route.ts
+++ b/app/api/inscricoes/route.ts
@@ -205,7 +205,7 @@ export async function POST(req: NextRequest) {
         const pedidoRes = await fetch(`${base}/api/pedidos`, {
           method: 'POST',
           headers: { 'Content-Type': 'application/json' },
-          body: JSON.stringify({ inscricaoId: inscricao.id }),
+          body: JSON.stringify({ id_inscricao: inscricao.id }),
         })
 
         if (pedidoRes.ok) {

--- a/app/loja/checkout/page.tsx
+++ b/app/loja/checkout/page.tsx
@@ -196,7 +196,7 @@ function CheckoutContent() {
         credentials: 'include',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({
-          produto: firstItem?.id || firstItem?.nome || 'Produto',
+          produto: [firstItem?.id || firstItem?.nome || 'Produto'],
           tamanho: Array.isArray(firstItem?.tamanhos)
             ? firstItem.tamanhos[0]
             : firstItem.tamanho,

--- a/docs/manual-aprovacao-inscricao.md
+++ b/docs/manual-aprovacao-inscricao.md
@@ -22,7 +22,7 @@ const coresSelecionadas = Array.isArray(produto.cores) && produto.cores.length >
 
 const pedidoPayload = {
   id_inscricao: inscricao.id,
-  produto: [produto.id], // agora múltiplo
+  produto: [produto.id], // IDs enviados em array
   cores: coresSelecionadas,
   tamanho: inscricao.tamanho ?? (Array.isArray(produto.tamanhos) ? produto.tamanhos[0] : 'M'),
   genero: inscricao.genero ?? (Array.isArray(produto.generos) ? produto.generos[0] : 'feminino'),
@@ -47,7 +47,8 @@ const pedidoPayload = {
 {
   "pedido": "ID_DO_PEDIDO",
   "status": "aguardando_pagamento",
-  "confirmado_por_lider": true
+  "confirmado_por_lider": true,
+  "aprovada": true
 }
 ```
 

--- a/lib/flows/orderFlow.ts
+++ b/lib/flows/orderFlow.ts
@@ -11,6 +11,7 @@ export const criarInscricao = criarInscricaoTemplate
 export function criarPedido(
   inscricao: Inscricao,
   produto: {
+    id: string
     nome?: string
     preco: number
     tamanhos?: string[] | string
@@ -24,7 +25,7 @@ export function criarPedido(
     id: `ped_${inscricao.id}`,
     id_pagamento: '',
     id_inscricao: inscricao.id,
-    produto: produto.nome ?? inscricao.produto ?? 'Kit Camisa + Pulseira',
+    produto: [produto.id],
     tamanho: inscricao.tamanho || first(produto.tamanhos),
     status: 'pendente',
     cor: 'Roxo',

--- a/logs/DOC_LOG.md
+++ b/logs/DOC_LOG.md
@@ -389,3 +389,5 @@
 ## [2025-08-07] Cadastro passa a enviar endereco completo e role do usuario pela loja.
 ## [2025-06-22] Atualizado docs/function-index.md listando métodos GET e PATCH para inscricoes/[id].
 ## [2025-06-22] Documentado fluxo manual de inscrições e campo produto múltiplo em pedidos.
+## [2025-06-22] Padronizado envio do campo produto como array de IDs e exemplos atualizados no manual de aprovação.
+## [2025-06-22] Corrigido envio do ID do produto na confirmação de inscrições.

--- a/types/index.ts
+++ b/types/index.ts
@@ -44,7 +44,7 @@ export type Pedido = {
   id: string
   id_pagamento: string
   id_inscricao: string
-  produto: string
+  produto: string[]
   tamanho?: string
   status: 'pendente' | 'pago' | 'cancelado'
   cor: string


### PR DESCRIPTION
## Summary
- ensure product ID is used when confirming inscrições
- send array with product ID from loja checkout
- allow editing pedido with product ID array
- document the fix for product ID handling

## Testing
- `npm run lint`
- `npm run build` *(partially logged)*

------
https://chatgpt.com/codex/tasks/task_e_685865b774f4832ca951213b22ab3488