### PR TITLE
Fix order creation when product missing

### DIFF
--- a/__tests__/api/pedidosRoute.test.ts
+++ b/__tests__/api/pedidosRoute.test.ts
@@ -162,6 +162,19 @@ describe('POST /api/pedidos', () => {
     expect(getFirstMock).not.toHaveBeenCalled()
   })
 
+  it('retorna 404 quando produto não encontrado', async () => {
+    getOneMock.mockRejectedValueOnce(new Error('not found'))
+    const req = new Request('http://test/api/pedidos', {
+      method: 'POST',
+      body: JSON.stringify({ produto: ['pX'], valor: 5 }),
+    })
+    const res = await (
+      await import('../../app/api/pedidos/route')
+    ).POST(req as unknown as NextRequest)
+    expect(res.status).toBe(404)
+    expect(createMock).not.toHaveBeenCalled()
+  })
+
   it('bloqueia quando requer inscricao aprovada e usuario nao possui', async () => {
     getOneMock.mockResolvedValueOnce({
       id: 'p2',

--- a/app/api/pedidos/route.ts
+++ b/app/api/pedidos/route.ts
@@ -173,6 +173,14 @@ export async function POST(req: NextRequest) {
         console.error('[PEDIDOS][POST] Erro ao buscar produto pelo id:', e)
       }
 
+      if (!produtoRecord) {
+        console.log('[PEDIDOS][POST] Produto não encontrado')
+        return NextResponse.json(
+          { erro: 'Produto não encontrado.' },
+          { status: 404 },
+        )
+      }
+
       if (produtoRecord?.requer_inscricao_aprovada) {
         try {
           const possui = await pb

--- a/logs/ERR_LOG.md
+++ b/logs/ERR_LOG.md
@@ -147,3 +147,5 @@
 ## [2025-06-22] Erro ao criar cobrança: status 400 | {"errors":[{"code":"invalid_action","description":"Wallet [906c2a75-b67a-4263-bee1-6bccca34feb3] inexistente."}]} - development
 
 ## [2025-06-22] Erro ao gerar link de pagamento Asaas: Error: Erro ao criar cobrança - development
+
+## [2025-06-22] Erro ao criar pedido sem inscrição quando produto inexistente retornava 400. Rota agora responde 404 antes de criar. - dev - e21e01f


### PR DESCRIPTION
## Summary
- return 404 when product id does not exist in `/api/pedidos`
- add test for missing product
- log error resolution

## Testing
- `npm run lint` *(fails: next not found)*
- `npm run build` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_68587783c01c832ca42faaaaef6a1502