### PR TITLE
Add log entry: reutiliza link pagamento

### DIFF
--- a/logs/DOC_LOG.md
+++ b/logs/DOC_LOG.md
@@ -399,3 +399,4 @@
 ## [2025-06-22] Padronizado envio do campo produto como array de IDs e exemplos atualizados no manual de aprovação.
 
 ## [2025-06-22] /api/produtos/[slug] passa a retornar objeto de inscrição do usuário (inscricao, inscricaoId e inscricaoAprovada) quando o produto possui evento. Lint e build executados.
+## [2025-08-08] Aprovação de inscrições reutiliza link de pagamento existente ao invés de criar novo pedido. Impacto: evita pedidos duplicados.


### PR DESCRIPTION
## Summary
- document that approval of inscriptions reuses existing payment links

## Testing
- `npm run lint` *(fails: next not found)*
- `npm run build` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_68589a911c94832c873c13afeb6e8b68