### PR TITLE
Retorna id e status de inscrição no detalhe do produto

### DIFF
--- a/components/molecules/AddToCartButton.tsx
+++ b/components/molecules/AddToCartButton.tsx
@@ -4,20 +4,57 @@ import { useToast } from '@/lib/context/ToastContext'
 import type { Produto } from '@/types'
 import { ShoppingCart } from 'lucide-react'
 import useInscricoes from '@/lib/hooks/useInscricoes'
+import Link from 'next/link'
+import { useRouter } from 'next/navigation'
 
 export default function AddToCartButton({ produto }: { produto: Produto }) {
   const { addItem } = useCart()
   const { showSuccess } = useToast()
   const { inscricoes } = useInscricoes()
+  const router = useRouter()
 
-  const aprovado = inscricoes.some(
-    (i) => i.evento === produto.evento_id && i.status === 'confirmado',
-  )
+  const inscricao = inscricoes.find((i) => i.evento === produto.evento_id)
+  const pago = inscricao?.status === 'confirmado'
+  const aprovado = Boolean(inscricao?.aprovada || pago)
 
-  const disabled = produto.requer_inscricao_aprovada && !aprovado
+  if (produto.requer_inscricao_aprovada && produto.evento_id) {
+    if (!inscricao) {
+      return (
+        <Link href={`/loja/eventos/${produto.evento_id}`} className="btn btn-primary block w-full">
+          Fazer Inscrição
+        </Link>
+      )
+    }
+
+    if (!aprovado) {
+      return (
+        <button className="btn btn-primary block w-full" disabled>
+          Aguardando aprovação
+        </button>
+      )
+    }
+
+    if (pago) {
+      return (
+        <button className="btn btn-primary block w-full" disabled>
+          Produto já adquirido
+        </button>
+      )
+    }
+
+    const handlePagar = () => {
+      addItem(produto)
+      router.push('/loja/checkout')
+    }
+
+    return (
+      <button onClick={handlePagar} className="btn btn-primary block w-full">
+        Pagar Inscrição
+      </button>
+    )
+  }
 
   const handleClick = () => {
-    if (disabled) return
     addItem(produto)
     showSuccess('Item adicionado ao carrinho!')
   }
@@ -25,11 +62,9 @@ export default function AddToCartButton({ produto }: { produto: Produto }) {
   return (
     <button
       onClick={handleClick}
-      disabled={disabled}
-      className="block w-full btn btn-primary disabled:opacity-50 disabled:cursor-not-allowed"
+      className="block w-full btn btn-primary"
     >
-      <ShoppingCart size={20} />
-      {disabled ? ' Aguardando inscrição' : ' Adicionar ao Carrinho'}
+      <ShoppingCart size={20} /> Adicionar ao Carrinho
     </button>
   )
 }

--- a/components/organisms/ProdutoInterativo.tsx
+++ b/components/organisms/ProdutoInterativo.tsx
@@ -5,7 +5,6 @@ import type { Produto } from '@/types'
 import { calculateGross } from '@/lib/asaasFees'
 
 import AddToCartButton from '@/components/molecules/AddToCartButton'
-import useInscricoes from '@/lib/hooks/useInscricoes'
 
 // Componente para seleção de gênero e tamanho (reutilizável)
 function DetalhesSelecao({
@@ -136,11 +135,6 @@ export default function ProdutoInterativo({
   const [cor, setCor] = useState(coresList[0] || '')
   const [indexImg, setIndexImg] = useState(0)
   const pauseRef = useRef(false)
-  const { inscricoes } = useInscricoes()
-  const aprovado = inscricoes.some(
-    (i) => i.evento === produto.evento_id && i.status === 'confirmado',
-  )
-  const precisaAprov = produto.requer_inscricao_aprovada && !aprovado
 
   const precoBruto = useMemo(
     () => calculateGross(preco, 'pix', 1).gross,
@@ -290,11 +284,6 @@ export default function ProdutoInterativo({
                 cores: cor ? [cor] : [],
               }}
             />
-            {precisaAprov && (
-              <p className="text-xs text-red-600 mt-2">
-                Requer inscrição aprovada
-              </p>
-            )}
           </div>
         </div>
         {/* Resto dos detalhes */}

--- a/components/organisms/ProdutosFiltrados.tsx
+++ b/components/organisms/ProdutosFiltrados.tsx
@@ -34,7 +34,8 @@ export default function ProdutosFiltrados({
 
   const possuiAprovacao = (prod: Produto) =>
     inscricoes.some(
-      (i) => i.evento === prod.evento_id && i.status === 'confirmado',
+      (i) =>
+        i.evento === prod.evento_id && (i.aprovada || i.status === 'confirmado'),
     )
 
   const filtrados = useMemo(() => {

--- a/logs/DOC_LOG.md
+++ b/logs/DOC_LOG.md
@@ -397,3 +397,5 @@
 ## [2025-06-22] Corrigido envio do ID do produto na confirmação de inscrições.
 
 ## [2025-06-22] Padronizado envio do campo produto como array de IDs e exemplos atualizados no manual de aprovação.
+## [2025-06-22] /api/produtos/[slug] passa a retornar objeto de inscrição do usuário (inscricao, inscricaoId e inscricaoAprovada) quando o produto possui evento. Lint e build executados.
+## [2025-06-23] Botão de compra ajustado para inscrições: redireciona para pagamento quando aprovado e bloqueia se já pago.


### PR DESCRIPTION
## Summary
- retorna `inscricaoId`, `inscricaoAprovada` e o objeto `inscricao` ao consultar um produto com evento
- permite adicionar ao carrinho se a inscrição estiver aprovada
- ajustar compra de inscricoes: redireciona para pagamento quando aprovado

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68587a8fb90c832ca0bf9c5bb19c7a2a