### PR TITLE
Fix product id not sent on signup

### DIFF
--- a/app/api/eventos/[id]/route.ts
+++ b/app/api/eventos/[id]/route.ts
@@ -12,7 +12,9 @@ export async function GET(req: NextRequest) {
   try {
     const evento = await pb
       .collection('eventos')
-      .getOne<EventoRecord>(id, { expand: 'produtos' })
+      .getOne<EventoRecord>(id, {
+        expand: 'produtos,produto_inscricao',
+      })
     const fileName = evento.imagem || evento.logo
     const withUrl = {
       ...evento,

--- a/app/api/eventos/route.ts
+++ b/app/api/eventos/route.ts
@@ -17,7 +17,7 @@ export async function GET() {
     const eventos = await pb.collection('eventos').getFullList<EventoRecord>({
       sort: '-data',
       filter: `cliente='${tenant}'`,
-      expand: 'produtos',
+      expand: 'produtos,produto_inscricao',
     })
     await atualizarStatus(eventos, pb)
     const comUrls = eventos.map((e) => {

--- a/components/organisms/EventForm.tsx
+++ b/components/organisms/EventForm.tsx
@@ -78,9 +78,21 @@ export default function EventForm({ eventoId, liderId }: EventFormProps) {
         }
         const eventoData = eventoRes.ok ? await eventoRes.json() : null
         setCobraInscricao(Boolean(eventoData?.cobra_inscricao))
-        const lista = Array.isArray(eventoData?.expand?.produtos)
-          ? // eslint-disable-next-line @typescript-eslint/no-explicit-any
-            (eventoData.expand.produtos as any[]).map((p) => ({
+        let lista: Produto[] = []
+        if (Array.isArray(eventoData?.expand?.produtos)) {
+          lista = (eventoData.expand.produtos as any[]).map((p) => ({
+            id: p.id,
+            nome: p.nome,
+            tamanhos: Array.isArray(p.tamanhos)
+              ? p.tamanhos
+              : p.tamanhos
+                ? [p.tamanhos]
+                : undefined,
+          }))
+        } else if (eventoData?.expand?.produto_inscricao) {
+          const p = eventoData.expand.produto_inscricao as any
+          lista = [
+            {
               id: p.id,
               nome: p.nome,
               tamanhos: Array.isArray(p.tamanhos)
@@ -88,8 +100,12 @@ export default function EventForm({ eventoId, liderId }: EventFormProps) {
                 : p.tamanhos
                   ? [p.tamanhos]
                   : undefined,
-            }))
-          : []
+            },
+          ]
+        }
+        else if (eventoData?.produto_inscricao) {
+          lista = [{ id: eventoData.produto_inscricao, nome: 'Produto' }]
+        }
         setProdutos(lista)
         if (lista.length > 0) {
           setForm((prev) => ({ ...prev, produtoId: lista[0].id }))


### PR DESCRIPTION
## Summary
- include `produto_inscricao` expansion when fetching events
- fallback to `produto_inscricao` id in `EventForm`

## Testing
- `npm run lint` *(fails: next not found)*
- `npm run build` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_6858ad227518832c9f85ca51754d6cf8