### PR TITLE
Fix product lookup using plano field

### DIFF
--- a/app/admin/inscricoes/page.tsx
+++ b/app/admin/inscricoes/page.tsx
@@ -41,6 +41,7 @@ type Inscricao = {
   data_nascimento?: string
   criado_por?: string
   pedido_id?: string | null
+  plano?: string
 }
 
 export default function ListaInscricoesPage() {
@@ -121,7 +122,7 @@ export default function ListaInscricoesPage() {
           created: r.created ?? '',
           campo: r.expand?.campo?.nome ?? '—',
           tamanho: r.tamanho ?? '',
-          produto: r.produto ?? '',
+          plano: r.plano ?? '',
           genero: r.genero ?? '',
           data_nascimento: r.data_nascimento ?? '',
           criado_por: r.criado_por ?? '',
@@ -182,9 +183,9 @@ export default function ListaInscricoesPage() {
       console.log('[confirmarInscricao] Iniciando confirmação para id:', id)
       setConfirmandoId(id)
 
-      // 1. Buscar inscrição com expand do campo, produto e pedido
+      // 1. Buscar inscrição com expand do campo, plano e pedido
       const inscricaoRes = await fetch(
-        `/api/inscricoes/${id}?expand=campo,produto,pedido`,
+        `/api/inscricoes/${id}?expand=campo,plano,pedido`,
         { credentials: 'include' },
       )
       console.log(
@@ -193,7 +194,7 @@ export default function ListaInscricoesPage() {
       )
       const inscricao: InscricaoRecord & {
         expand?: {
-          produtos?: Produto | Produto[]
+          plano?: Produto | Produto[]
           pedido?: { status: 'pendente' | 'pago' | 'cancelado'; link_pagamento?: string }
         }
       } = await inscricaoRes.json()
@@ -213,27 +214,27 @@ export default function ListaInscricoesPage() {
         }
       }
 
-      // Checar campo correto: produto ou produtos
-      type InscricaoWithProdutos = InscricaoRecord & { produtos?: string }
+      // Checar campo correto: plano ou produto
+      type InscricaoWithPlano = InscricaoRecord & { plano?: string }
       const produtoId =
-        inscricao.produto || (inscricao as InscricaoWithProdutos).produtos
+        inscricao.plano || inscricao.produto || (inscricao as InscricaoWithPlano).plano
       console.log('[confirmarInscricao] produtoId:', produtoId)
 
       // Extrair produto do expand (array ou objeto)
       let produtoRecord: Produto | undefined = undefined
 
-      // Se expand já trouxe produtos (array ou objeto)
-      if (inscricao.expand?.produtos) {
-        if (Array.isArray(inscricao.expand.produtos)) {
-          produtoRecord = inscricao.expand.produtos.find(
-            (p: Produto) => p.id === produtoId || p.id === inscricao.produto,
+      // Se expand já trouxe plano (array ou objeto)
+      if (inscricao.expand?.plano) {
+        if (Array.isArray(inscricao.expand.plano)) {
+          produtoRecord = inscricao.expand.plano.find(
+            (p: Produto) => p.id === produtoId || p.id === inscricao.plano,
           )
           console.log(
             '[confirmarInscricao] produtoRecord (array):',
             produtoRecord,
           )
-        } else if (typeof inscricao.expand.produtos === 'object') {
-          produtoRecord = inscricao.expand.produtos as Produto
+        } else if (typeof inscricao.expand.plano === 'object') {
+          produtoRecord = inscricao.expand.plano as Produto
           console.log(
             '[confirmarInscricao] produtoRecord (obj):',
             produtoRecord,

--- a/app/api/inscricoes/route.ts
+++ b/app/api/inscricoes/route.ts
@@ -55,6 +55,7 @@ export async function POST(req: NextRequest) {
       data_nascimento,
       tamanho,
       produtoId,
+      planoId,
       genero,
       paymentMethod = 'pix' as PaymentMethod,
       installments = 1,
@@ -62,6 +63,8 @@ export async function POST(req: NextRequest) {
       eventoId,
       evento: eventoBody,
     } = body
+
+    const planoIdFinal: string | undefined = planoId || produtoId
 
     // Limpa CPF e telefone
     const cpfNumerico = cpf.replace(/\D/g, '')
@@ -172,7 +175,7 @@ export async function POST(req: NextRequest) {
       evento: eventoIdFinal!,
       campo: campoId,
       criado_por: usuario.id,
-      produto: produtoId,
+      plano: planoIdFinal,
       tamanho,
       cliente: lider.cliente,
     }
@@ -240,7 +243,7 @@ export async function POST(req: NextRequest) {
       nome,
       email,
       tamanho,
-      produto: produtoId,
+      plano: planoIdFinal,
       genero,
       responsavel: liderId,
     }

--- a/app/api/pedidos/route.ts
+++ b/app/api/pedidos/route.ts
@@ -252,12 +252,13 @@ export async function POST(req: NextRequest) {
     const campoId = inscricao.expand?.campo?.id
     const responsavelId = inscricao.expand?.criado_por
     let produtoRecord: Produto | undefined
+    const produtoIdInscricao = inscricao.plano || inscricao.produto
 
     try {
-      if (inscricao.produto) {
+      if (produtoIdInscricao) {
         produtoRecord = await pb
           .collection('produtos')
-          .getOne(inscricao.produto)
+          .getOne(produtoIdInscricao)
         console.log('[PEDIDOS][POST] produtoRecord pelo id:', produtoRecord)
       }
     } catch (e) {
@@ -270,7 +271,7 @@ export async function POST(req: NextRequest) {
           const lista = Array.isArray(ev.expand?.produtos)
             ? (ev.expand.produtos as Produto[])
             : []
-          produtoRecord = lista.find((p) => p.id === inscricao.produto)
+          produtoRecord = lista.find((p) => p.id === produtoIdInscricao)
           console.log(
             '[PEDIDOS][POST] produtoRecord via evento:',
             produtoRecord,
@@ -288,7 +289,12 @@ export async function POST(req: NextRequest) {
       id_inscricao: inscricaoId,
       valor,
       status: 'pendente',
-      produto: inscricao.produto ? [inscricao.produto] : produtoRecord ? [produtoRecord.id] : [],
+      produto:
+        produtoIdInscricao
+          ? [produtoIdInscricao]
+          : produtoRecord
+          ? [produtoRecord.id]
+          : [],
       cor: 'Roxo',
       tamanho:
         inscricao.tamanho ||

--- a/app/loja/api/inscricoes/route.ts
+++ b/app/loja/api/inscricoes/route.ts
@@ -63,7 +63,7 @@ export async function POST(req: NextRequest) {
       campo: data.campo,
       evento: data.evento,
       criado_por: usuario.id,
-      produto: data.produtoId,
+      plano: data.produtoId,
       tamanho: data.tamanho,
       ...(tenantId ? { cliente: tenantId } : {}),
     }

--- a/lib/templates/inscricao.ts
+++ b/lib/templates/inscricao.ts
@@ -12,6 +12,7 @@ export interface InscricaoTemplate {
   campo: string
   criado_por: string
   produto?: string
+  plano?: string
   tamanho?: string
   cliente?: string
   paymentMethod?: PaymentMethod
@@ -51,6 +52,7 @@ export function criarInscricao(dados: InscricaoTemplate): Inscricao {
     campo: dados.campo,
     criado_por: dados.criado_por,
     produto: dados.produto,
+    plano: dados.plano,
     tamanho: dados.tamanho,
     cliente: dados.cliente,
     status: 'pendente',

--- a/types/index.ts
+++ b/types/index.ts
@@ -6,6 +6,8 @@ export type Inscricao = {
   status?: 'pendente' | 'aguardando_pagamento' | 'confirmado' | 'cancelado'
   tamanho?: string
   produto?: string
+  /** Produto selecionado na inscrição */
+  plano?: string
   genero?: string
   evento?: string
   data_nascimento?: string
@@ -31,6 +33,7 @@ export type Inscricao = {
       status: 'pago' | 'pendente' | 'cancelado'
       valor: number | string
     }
+    plano?: Produto
     id_inscricao?: {
       nome: string
       telefone?: string


### PR DESCRIPTION
## Summary
- read `plano` field on inscriptions when confirming payment
- update order API to fetch product id from new `plano` field
- propagate `plano` throughout inscription creation and types

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6858ade018c4832c8bf2c3583c6c28e0