### PR TITLE
Add product info to inscriptions list

### DIFF
--- a/app/api/inscricoes/[id]/route.ts
+++ b/app/api/inscricoes/[id]/route.ts
@@ -38,7 +38,7 @@ export async function GET(req: NextRequest) {
   const { pb, user } = auth
   try {
     const expand =
-      req.nextUrl.searchParams.get('expand') || 'evento,campo,pedido'
+      req.nextUrl.searchParams.get('expand') || 'evento,campo,pedido,produto'
     const record = await pb
       .collection('inscricoes')
       .getOne<Inscricao>(id, { expand })

--- a/app/api/inscricoes/route.ts
+++ b/app/api/inscricoes/route.ts
@@ -34,7 +34,7 @@ export async function GET(req: NextRequest) {
     const filtro = status ? `${baseFilter} && status='${status}'` : baseFilter
     const { items } = await pb.collection('inscricoes').getList(1, perPage, {
       filter: filtro,
-      expand: 'evento,campo,pedido',
+      expand: 'evento,campo,pedido,produto',
       sort: '-created',
     })
     return NextResponse.json(items, { status: 200 })

--- a/logs/DOC_LOG.md
+++ b/logs/DOC_LOG.md
@@ -401,3 +401,7 @@
 ## [2025-06-22] /api/produtos/[slug] passa a retornar objeto de inscrição do usuário (inscricao, inscricaoId e inscricaoAprovada) quando o produto possui evento. Lint e build executados.
 
 ## [2025-06-23] Botão de compra ajustado para inscrições: redireciona para pagamento quando aprovado e bloqueia se já pago.
+
+## [2025-06-23] Tabela de inscrições agora exibe nome do produto e tamanho. Rotas de inscrições incluem expand de produto. Lint e build falharam (next not found).
+## [2025-06-23] Corrigido lista de inscrições exibindo ID do produto; agora mostra nome. Lint e build falharam (next not found).
+## [2025-06-23] Ajuste de tipagem na lista de inscrições para remover uso de any. Lint e build executados com sucesso.


### PR DESCRIPTION
## Summary
- expand `produto` in inscription routes
- fetch product details on admin inscriptions page
- show product name and size in table
- document the change in DOC_LOG
- fix product column to display name instead of ID
- remove `any` usage when mapping product names

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68594f7ba5ac832c9bba304d808ddf45