### PR TITLE
Add product names to orders table

### DIFF
--- a/app/admin/inscricoes/componentes/ModalVisualizarPedido.tsx
+++ b/app/admin/inscricoes/componentes/ModalVisualizarPedido.tsx
@@ -28,6 +28,7 @@ type PedidoExpandido = {
       cpf: string
       evento: string
     }
+    produto?: { nome: string } | { nome: string }[]
   }
 }
 
@@ -125,7 +126,10 @@ export default function ModalVisualizarPedido({ pedidoId, onClose }: Props) {
               <strong>Status:</strong> {pedido.status}
             </p>
             <p>
-              <strong>Produto:</strong> {pedido.produto.join(', ')}
+              <strong>Produto:</strong>{' '}
+              {Array.isArray(pedido.expand?.produto)
+                ? pedido.expand.produto.map((p) => p.nome).join(', ')
+                : pedido.expand?.produto?.nome || pedido.produto.join(', ')}
             </p>
             <p>
               <strong>Tamanho:</strong> {pedido.tamanho || '—'}

--- a/app/admin/pedidos/page.tsx
+++ b/app/admin/pedidos/page.tsx
@@ -2,7 +2,7 @@
 
 import { useEffect, useState } from 'react'
 import { useAuthGuard } from '@/lib/hooks/useAuthGuard'
-import { Pedido } from '@/types'
+import type { Pedido, Produto } from '@/types'
 import { saveAs } from 'file-saver'
 import LoadingOverlay from '@/components/organisms/LoadingOverlay'
 import ModalEditarPedido from './componentes/ModalEditarPedido'
@@ -69,9 +69,10 @@ export default function PedidosPage() {
     const matchCampo =
       filtroCampo === '' ||
       p.expand?.campo?.nome?.toLowerCase().includes(filtroCampo.toLowerCase())
-    const produtoStr = Array.isArray(p.produto)
-      ? p.produto.join(', ')
-      : (p.produto ?? '')
+    const produtoStr = Array.isArray(p.expand?.produto)
+      ? p.expand.produto.map((prod: Produto) => prod.nome).join(', ')
+      : (p.expand?.produto as Produto | undefined)?.nome ||
+        (Array.isArray(p.produto) ? p.produto.join(', ') : (p.produto ?? ''))
 
     const matchBuscaGlobal =
       buscaGlobal === '' ||
@@ -104,7 +105,9 @@ export default function PedidosPage() {
     ]
 
     const linhas = pedidosFiltrados.map((p) => [
-      p.produto,
+      Array.isArray(p.expand?.produto)
+        ? p.expand.produto.map((prod: Produto) => prod.nome).join(', ')
+        : (p.expand?.produto as Produto | undefined)?.nome || p.produto,
       p.expand?.id_inscricao?.nome || '',
       p.email,
       p.tamanho || '',
@@ -199,9 +202,14 @@ export default function PedidosPage() {
               {pedidosFiltrados.map((pedido) => (
                 <tr key={pedido.id}>
                   <td className="font-medium">
-                    {Array.isArray(pedido.produto)
-                      ? pedido.produto.join(', ')
-                      : pedido.produto}
+                    {Array.isArray(pedido.expand?.produto)
+                      ? pedido.expand?.produto
+                          .map((p: Produto) => p.nome)
+                          .join(', ')
+                      : (pedido.expand?.produto as Produto | undefined)?.nome ||
+                        (Array.isArray(pedido.produto)
+                          ? pedido.produto.join(', ')
+                          : pedido.produto)}
                   </td>
                   <td>{pedido.expand?.id_inscricao?.nome || '—'}</td>
                   <td>{pedido.email}</td>

--- a/app/api/pedidos/route.ts
+++ b/app/api/pedidos/route.ts
@@ -112,8 +112,29 @@ export async function GET(req: NextRequest) {
     const { items } = await pb.collection('pedidos').getList(page, perPage, {
       filter: filtro,
       sort: '-created',
-      expand: 'campo,id_inscricao',
+      expand: 'campo,id_inscricao,produto',
     })
+
+    // Caso a expansão de produto falhe, buscar manualmente
+    for (const item of items) {
+      if (!item.expand?.produto && item.produto) {
+        const ids = Array.isArray(item.produto) ? item.produto : [item.produto]
+        const produtos = await Promise.all(
+          ids.map((id) =>
+            pb
+              .collection('produtos')
+              .getOne<Produto>(id)
+              .catch(() => null),
+          ),
+        )
+        const valid = produtos.filter(Boolean) as Produto[]
+        item.expand = {
+          ...item.expand,
+          produto: ids.length > 1 ? valid : valid[0],
+        }
+      }
+    }
+
     console.log('[PEDIDOS][GET] Retornando pedidos:', items.length)
     return NextResponse.json(items)
   } catch (err) {

--- a/types/index.ts
+++ b/types/index.ts
@@ -79,6 +79,8 @@ export type Pedido = {
       cpf?: string
     }
     evento?: Evento
+    /** Produto associado ao pedido */
+    produto?: Produto | Produto[]
   }
 }
 


### PR DESCRIPTION
## Summary
- expand produto relation in pedidos API endpoints and fallback fetch product records if expansion missing
- show product names in admin orders table with fallback to IDs

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68594f291b88832c9dc67d9025021081