### PR TITLE
Fix email route admin auth

### DIFF
--- a/app/api/email/route.ts
+++ b/app/api/email/route.ts
@@ -43,6 +43,22 @@ export async function POST(req: NextRequest) {
       )
     }
 
+    if (!pb.authStore.isValid) {
+      console.log('🔐 Autenticando admin PocketBase...')
+      try {
+        await pb.admins.authWithPassword(
+          process.env.PB_ADMIN_EMAIL!,
+          process.env.PB_ADMIN_PASSWORD!,
+        )
+      } catch (err) {
+        console.error('❌ Falha ao autenticar admin PocketBase:', err)
+        return NextResponse.json(
+          { error: 'Falha na autenticação do servidor' },
+          { status: 500 },
+        )
+      }
+    }
+
     const cfg = await pb.collection('clientes_config').getOne(tenantId)
     console.log('⚙️ Configurações do tenant:', cfg)
 


### PR DESCRIPTION
## Summary
- ensure PocketBase admin login before reading tenant config in email route

## Testing
- `npm run lint` *(fails: next not found)*
- `npm run build` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_6859f28cf058832cb26fab40db4ae972