### PR TITLE
Remove static images

### DIFF
--- a/app/admin/layout.tsx
+++ b/app/admin/layout.tsx
@@ -3,15 +3,7 @@ import '@/app/globals.css'
 import LayoutWrapper from '@/components/templates/LayoutWrapperAdmin'
 
 export const metadata = {
-  icons: {
-    icon: [
-      { url: '/favicon.ico' },
-      { url: '/apple-icon.png', sizes: '32x32', type: 'image/png' },
-      { url: '/icon-192x192.png', sizes: '16x16', type: 'image/png' },
-    ],
-    apple: '/apple-icon.png',
-  },
-  manifest: '/manifest.json',
+  manifest: '/api/manifest.json',
 }
 
 export default function RootLayout({

--- a/app/admin/posts/editar/[slug]/page.tsx
+++ b/app/admin/posts/editar/[slug]/page.tsx
@@ -108,14 +108,7 @@ export default function EditarPostPage() {
 
           <div className="flex flex-wrap items-center gap-4 text-[0.9375rem] mb-6">
             <div className="flex items-center gap-2 min-w-0">
-              <Image
-                src="/img/avatar_m24.webp"
-                alt="Autor"
-                width={40}
-                height={40}
-                className="flex-shrink-0 w-9 h-9 rounded-full object-cover"
-              />
-              <span>Redação M24</span>
+              <span className="font-semibold">Redação M24</span>
             </div>
 
             <div className="flex items-center gap-1">

--- a/app/blog/page.tsx
+++ b/app/blog/page.tsx
@@ -19,7 +19,7 @@ export async function generateMetadata(): Promise<Metadata> {
     ? isExternalUrl(first.thumbnail)
       ? first.thumbnail
       : `${siteUrl}${first.thumbnail}`
-    : '/img/og-default.jpg'
+    : undefined
   const title = `Blog - ${first.title}`
   const description = first.summary || ''
   return {
@@ -28,7 +28,7 @@ export async function generateMetadata(): Promise<Metadata> {
     openGraph: {
       title,
       description,
-      images: [image],
+      ...(image ? { images: [image] } : {}),
     },
   }
 }

--- a/app/blog/post/[slug]/page.tsx
+++ b/app/blog/post/[slug]/page.tsx
@@ -41,7 +41,7 @@ export async function generateMetadata({
     openGraph: {
       title: post.title,
       description: post.summary || '',
-      images: [post.thumbnail || '/img/og-default.jpg'],
+      ...(post.thumbnail ? { images: [post.thumbnail] } : {}),
     },
   }
 }
@@ -80,7 +80,9 @@ export default async function BlogPostPage({
     description: post.summary || '',
     image: isExternalUrl(post.thumbnail || '')
       ? post.thumbnail
-      : `${siteUrl}${post.thumbnail || '/img/og-default.jpg'}`,
+      : post.thumbnail
+        ? `${siteUrl}${post.thumbnail}`
+        : undefined,
     author: {
       '@type': 'Person',
       name: 'Redação M24',
@@ -88,10 +90,6 @@ export default async function BlogPostPage({
     publisher: {
       '@type': 'Organization',
       name: 'M24 Saúde',
-      logo: {
-        '@type': 'ImageObject',
-        url: `${siteUrl}/img/M24.webp`,
-      },
     },
     datePublished: post.date || new Date().toISOString(),
     mainEntityOfPage: {
@@ -141,14 +139,7 @@ export default async function BlogPostPage({
 
         <div className="flex flex-wrap items-center gap-4 text-[0.9375rem] mb-6">
           <div className="flex items-center gap-2 min-w-0">
-            <Image
-              src="/img/avatar_m24.webp"
-              alt="Autor"
-              width={40}
-              height={40}
-              className="flex-shrink-0 w-9 h-9 rounded-full object-cover"
-            />
-            <span>Redação M24</span>
+            <span className="font-semibold">Redação M24</span>
           </div>
 
           <div className="flex items-center gap-1">

--- a/app/iniciar-tour/page.tsx
+++ b/app/iniciar-tour/page.tsx
@@ -10,7 +10,6 @@ export async function generateMetadata(): Promise<Metadata> {
     openGraph: {
       title,
       description,
-      images: ['/img/og-default.jpg'],
     },
   }
 }

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -10,15 +10,7 @@ import { fetchTenantConfig } from '@/lib/fetchTenantConfig'
 import { CartProvider } from '@/lib/context/CartContext'
 
 export const metadata = {
-  icons: {
-    icon: [
-      { url: '/favicon.ico' },
-      { url: '/icon0.png', sizes: '32x32', type: 'image/png' },
-      { url: '/icon1.png', sizes: '16x16', type: 'image/png' },
-    ],
-    apple: '/apple-icon.png',
-  },
-  manifest: '/manifest.json',
+  manifest: '/api/manifest.json',
 }
 
 export default async function RootLayout({

--- a/app/loja/carrinho/metadata.ts
+++ b/app/loja/carrinho/metadata.ts
@@ -9,7 +9,6 @@ export async function generateMetadata(): Promise<Metadata> {
     openGraph: {
       title,
       description,
-      images: ['/img/og-default.jpg'],
     },
   }
 }

--- a/app/loja/categorias/[slug]/metadata.ts
+++ b/app/loja/categorias/[slug]/metadata.ts
@@ -30,7 +30,6 @@ export async function generateMetadata({
     openGraph: {
       title,
       description,
-      images: ['/img/og-default.jpg'],
     },
   }
 }

--- a/app/loja/categorias/metadata.ts
+++ b/app/loja/categorias/metadata.ts
@@ -9,7 +9,6 @@ export async function generateMetadata(): Promise<Metadata> {
     openGraph: {
       title,
       description,
-      images: ['/img/og-default.jpg'],
     },
   }
 }

--- a/app/loja/checkout/metadata.ts
+++ b/app/loja/checkout/metadata.ts
@@ -9,7 +9,6 @@ export async function generateMetadata(): Promise<Metadata> {
     openGraph: {
       title,
       description,
-      images: ['/img/og-default.jpg'],
     },
   }
 }

--- a/app/loja/cliente/metadata.ts
+++ b/app/loja/cliente/metadata.ts
@@ -9,7 +9,6 @@ export async function generateMetadata(): Promise<Metadata> {
     openGraph: {
       title,
       description,
-      images: ['/img/og-default.jpg'],
     },
   }
 }

--- a/app/loja/eventos/[id]/metadata.ts
+++ b/app/loja/eventos/[id]/metadata.ts
@@ -31,14 +31,14 @@ export async function generateMetadata({
   const evento = await getEvento(params.id)
   const title = evento ? evento.titulo : 'Evento'
   const description = evento?.descricao || 'Detalhes do evento.'
-  const image = evento?.imagem || '/img/og-default.jpg'
+  const image = evento?.imagem || undefined
   return {
     title,
     description,
     openGraph: {
       title,
       description,
-      images: [image],
+      ...(image ? { images: [image] } : {}),
     },
   }
 }

--- a/app/loja/eventos/metadata.ts
+++ b/app/loja/eventos/metadata.ts
@@ -9,7 +9,6 @@ export async function generateMetadata(): Promise<Metadata> {
     openGraph: {
       title,
       description,
-      images: ['/img/og-default.jpg'],
     },
   }
 }

--- a/app/loja/inscricoes/confirmacao/metadata.ts
+++ b/app/loja/inscricoes/confirmacao/metadata.ts
@@ -9,7 +9,6 @@ export async function generateMetadata(): Promise<Metadata> {
     openGraph: {
       title,
       description,
-      images: ['/img/og-default.jpg'],
     },
   }
 }

--- a/app/loja/login/metadata.ts
+++ b/app/loja/login/metadata.ts
@@ -9,7 +9,6 @@ export async function generateMetadata(): Promise<Metadata> {
     openGraph: {
       title,
       description,
-      images: ['/img/og-default.jpg'],
     },
   }
 }

--- a/app/loja/metadata.ts
+++ b/app/loja/metadata.ts
@@ -19,7 +19,7 @@ export async function generateMetadata(): Promise<Metadata> {
   const imagem =
     produto.imagens && produto.imagens.length
       ? pb.files.getURL(produto, produto.imagens[0])
-      : '/img/og-default.jpg'
+      : undefined
   const title = `Loja - ${produto.nome}`
   const description = produto.descricao || ''
   return {
@@ -28,7 +28,7 @@ export async function generateMetadata(): Promise<Metadata> {
     openGraph: {
       title,
       description,
-      images: [imagem],
+      ...(imagem ? { images: [imagem] } : {}),
     },
   }
 }

--- a/app/loja/page.tsx
+++ b/app/loja/page.tsx
@@ -59,16 +59,7 @@ export default function Home() {
           </Link>
         </div>
         {/* Direita: Imagem crua */}
-        <div className="relative w-full h-[300px] md:h-auto">
-          <Image
-            src="/img/qg3_tech.webp"
-            alt="Congresso UMADEUS"
-            fill
-            style={{ objectFit: 'cover' }}
-            className="w-full h-full"
-            priority
-          />
-        </div>
+        <div className="relative w-full h-[300px] md:h-auto" />
       </section>
 
       {/* PRODUTOS DESTAQUE */}

--- a/app/loja/perfil/metadata.ts
+++ b/app/loja/perfil/metadata.ts
@@ -9,7 +9,6 @@ export async function generateMetadata(): Promise<Metadata> {
     openGraph: {
       title,
       description,
-      images: ['/img/og-default.jpg'],
     },
   }
 }

--- a/app/loja/produtos/[slug]/metadata.ts
+++ b/app/loja/produtos/[slug]/metadata.ts
@@ -21,14 +21,14 @@ export async function generateMetadata({
     ? produto.imagens[0]
     : typeof produto.imagens === 'object'
       ? Object.values(produto.imagens as Record<string, string[]>)[0]?.[0]
-      : produto.imagem || '/img/og-default.jpg'
+      : produto.imagem || undefined
   return {
     title: produto.nome,
     description: produto.descricao || '',
     openGraph: {
       title: produto.nome,
       description: produto.descricao || '',
-      images: [imagem],
+      ...(imagem ? { images: [imagem] } : {}),
     },
   }
 }

--- a/app/loja/produtos/metadata.ts
+++ b/app/loja/produtos/metadata.ts
@@ -9,7 +9,6 @@ export async function generateMetadata(): Promise<Metadata> {
     openGraph: {
       title,
       description,
-      images: ['/img/og-default.jpg'],
     },
   }
 }

--- a/app/loja/sucesso/metadata.ts
+++ b/app/loja/sucesso/metadata.ts
@@ -9,7 +9,6 @@ export async function generateMetadata(): Promise<Metadata> {
     openGraph: {
       title,
       description,
-      images: ['/img/og-default.jpg'],
     },
   }
 }

--- a/components/templates/Header.tsx
+++ b/components/templates/Header.tsx
@@ -110,13 +110,15 @@ export default function Header() {
             className="flex items-center gap-2 text-xl md:text-2xl font-bold tracking-wide font-bebas"
             aria-label="Página inicial"
           >
-            <Image
-              src={config.logoUrl || '/img/logo_umadeus_branco.png'}
-              alt="UMADEUS"
-              width={36}
-              height={36}
-              className="h-9 w-auto"
-            />
+            {config.logoUrl && (
+              <Image
+                src={config.logoUrl}
+                alt="UMADEUS"
+                width={36}
+                height={36}
+                className="h-9 w-auto"
+              />
+            )}
           </Link>
 
           {/* Navegação Desktop */}

--- a/components/templates/HeaderAdmin.tsx
+++ b/components/templates/HeaderAdmin.tsx
@@ -79,14 +79,16 @@ export default function Header() {
     <header className="bg-animated backdrop-blur-md text-[var(--text-header-primary)] shadow-md sticky top-0 z-50 gradient-x">
       <div className="flex justify-between items-center px-6 py-4 max-w-7xl mx-auto">
         <Link href="/" className="flex items-center">
-          <Image
-            src={config.logoUrl || '/img/logo_umadeus_branco.png'}
-            alt="Logotipo UMADEUS"
-            width={160}
-            height={40}
-            className="h-10 w-auto"
-            priority
-          />
+          {config.logoUrl && (
+            <Image
+              src={config.logoUrl}
+              alt="Logotipo"
+              width={160}
+              height={40}
+              className="h-10 w-auto"
+              priority
+            />
+          )}
         </Link>
 
         {/* Botão hambúrguer */}

--- a/components/templates/LoginForm.tsx
+++ b/components/templates/LoginForm.tsx
@@ -5,6 +5,7 @@ import { motion } from 'framer-motion'
 import { useRouter } from 'next/navigation'
 import { useAuthContext } from '@/lib/context/AuthContext'
 import Image from 'next/image'
+import { useTenant } from '@/lib/context/TenantContext'
 import RedefinirSenhaModal from '@/app/admin/components/RedefinirSenhaModal'
 import { useToast } from '@/lib/context/ToastContext'
 import '@/app/globals.css' // Certifique-se de que o CSS global está importado
@@ -18,6 +19,7 @@ export default function LoginForm({
 }) {
   const router = useRouter()
   const { login, isLoggedIn, isLoading, user } = useAuthContext()
+  const { config } = useTenant()
 
   const [email, setEmail] = useState('')
   const [senha, setSenha] = useState('')
@@ -70,13 +72,15 @@ export default function LoginForm({
     <div className="relative min-h-screen flex items-center justify-center overflow-hidden px-4 sm:px-6">
       <div className="relative z-10 w-full max-w-sm sm:max-w-md p-6 sm:p-8 bg-animated rounded-2xl backdrop-blur-md text-gray-200 shadow-lg">
         <div className="flex flex-col items-center gap-3 mb-6">
-          <Image
-            src="/img/logo_umadeus_branco.png"
-            alt="Logo UMADEUS"
-            width={120}
-            height={120}
-            priority
-          />
+          {config.logoUrl && (
+            <Image
+              src={config.logoUrl}
+              alt="Logo"
+              width={120}
+              height={120}
+              priority
+            />
+          )}
         </div>
 
         <motion.h1

--- a/lib/context/TenantContext.tsx
+++ b/lib/context/TenantContext.tsx
@@ -15,7 +15,7 @@ export type TenantConfig = {
 export const defaultConfig: TenantConfig = {
   font: 'var(--font-geist)',
   primaryColor: '#7c3aed',
-  logoUrl: '/img/logo_umadeus_branco.png',
+  logoUrl: '',
   confirmaInscricoes: false,
 }
 

--- a/lib/posts/getRelatedPosts.ts
+++ b/lib/posts/getRelatedPosts.ts
@@ -51,7 +51,7 @@ export function getRelatedPosts(
         slug,
         title: data.title,
         summary: data.summary,
-        thumbnail: data.thumbnail || '/img/og-default.jpg', // 🔒 fallback garantido
+        thumbnail: data.thumbnail || '',
         category: data.category,
         date: isoDate,
       }

--- a/public/manifest.json
+++ b/public/manifest.json
@@ -1,14 +1,7 @@
 {
   "name": "UMADEUS - Juventude em Missão",
   "short_name": "UMADEUS",
-  "icons": [
-    {
-      "src": "/icon-192x192.png",
-      "sizes": "192x192",
-      "type": "image/png",
-      "purpose": "any maskable"
-    }
-  ],
+  "icons": [],
   "start_url": "/",
   "display": "standalone",
   "theme_color": "#ffffff",

--- a/stories/FormField.stories.tsx
+++ b/stories/FormField.stories.tsx
@@ -33,7 +33,7 @@ export const TemaDinamico: Story = {
         initialConfig={{
           primaryColor: '#2563eb',
           font: 'var(--font-geist)',
-          logoUrl: '/img/logo_umadeus_branco.png',
+          logoUrl: 'https://placehold.co/120x120',
           confirmaInscricoes: false,
         }}
       >
@@ -43,7 +43,7 @@ export const TemaDinamico: Story = {
         initialConfig={{
           primaryColor: '#dc2626',
           font: 'var(--font-geist)',
-          logoUrl: '/img/logo_umadeus_branco.png',
+          logoUrl: 'https://placehold.co/120x120',
           confirmaInscricoes: false,
         }}
       >

--- a/stories/InputWithMask.stories.tsx
+++ b/stories/InputWithMask.stories.tsx
@@ -49,7 +49,7 @@ export const TemaDinamico: Story = {
         initialConfig={{
           primaryColor: '#2563eb',
           font: 'var(--font-geist)',
-          logoUrl: '/img/logo_umadeus_branco.png',
+          logoUrl: 'https://placehold.co/120x120',
           confirmaInscricoes: false,
         }}
       >
@@ -59,7 +59,7 @@ export const TemaDinamico: Story = {
         initialConfig={{
           primaryColor: '#dc2626',
           font: 'var(--font-geist)',
-          logoUrl: '/img/logo_umadeus_branco.png',
+          logoUrl: 'https://placehold.co/120x120',
           confirmaInscricoes: false,
         }}
       >

--- a/stories/TextField.stories.tsx
+++ b/stories/TextField.stories.tsx
@@ -21,7 +21,7 @@ export const TemaDinamico: Story = {
         initialConfig={{
           primaryColor: '#2563eb',
           font: 'var(--font-geist)',
-          logoUrl: '/img/logo_umadeus_branco.png',
+          logoUrl: 'https://placehold.co/120x120',
           confirmaInscricoes: false,
         }}
       >
@@ -31,7 +31,7 @@ export const TemaDinamico: Story = {
         initialConfig={{
           primaryColor: '#dc2626',
           font: 'var(--font-geist)',
-          logoUrl: '/img/logo_umadeus_branco.png',
+          logoUrl: 'https://placehold.co/120x120',
           confirmaInscricoes: false,
         }}
       >

--- a/stories/ToggleSwitch.stories.tsx
+++ b/stories/ToggleSwitch.stories.tsx
@@ -29,7 +29,7 @@ export const TemaDinamico: Story = {
         initialConfig={{
           primaryColor: '#2563eb',
           font: 'var(--font-geist)',
-          logoUrl: '/img/logo_umadeus_branco.png',
+          logoUrl: 'https://placehold.co/120x120',
           confirmaInscricoes: false,
         }}
       >
@@ -39,7 +39,7 @@ export const TemaDinamico: Story = {
         initialConfig={{
           primaryColor: '#dc2626',
           font: 'var(--font-geist)',
-          logoUrl: '/img/logo_umadeus_branco.png',
+          logoUrl: 'https://placehold.co/120x120',
           confirmaInscricoes: false,
         }}
       >


### PR DESCRIPTION
## Summary
- ditch fallback icons referencing `/public` images
- load logos dynamically from backend and update default config
- stop including static icons in layouts
- clean up storybook stories

## Testing
- `npm run lint` *(fails: next not found)*
- `npm run build` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_685ae070e0e4832cbfec8cac14a0079d