### PR TITLE
Add produto builder preview page

### DIFF
--- a/app/admin/api/preview-produto/route.ts
+++ b/app/admin/api/preview-produto/route.ts
@@ -1,0 +1,16 @@
+import { NextRequest, NextResponse } from 'next/server'
+import { requireRole } from '@/lib/apiAuth'
+
+export async function POST(req: NextRequest) {
+  const auth = requireRole(req, 'coordenador')
+  if ('error' in auth) {
+    return NextResponse.json({ error: auth.error }, { status: auth.status })
+  }
+
+  try {
+    const data = await req.json()
+    return NextResponse.json(data)
+  } catch {
+    return NextResponse.json({ error: 'Invalid JSON' }, { status: 400 })
+  }
+}

--- a/app/admin/page-builder/produtos/page.tsx
+++ b/app/admin/page-builder/produtos/page.tsx
@@ -1,0 +1,75 @@
+'use client'
+
+import { useState } from 'react'
+import ContentEditable from 'react-contenteditable'
+import { Button, FormField, TextField } from '@/components'
+import { Produto } from '@/types'
+import ProdutoCardPreview from '@/components/admin/ProdutoCardPreview'
+import ProdutoDetailPreview from '@/components/admin/ProdutoDetailPreview'
+
+export default function ProdutoBuilderPage() {
+  const [form, setForm] = useState({ nome: '', preco: '', descricao: '' })
+  const [preview, setPreview] = useState<Produto | null>(null)
+
+  function handleChange(e: React.ChangeEvent<HTMLInputElement>) {
+    const { name, value } = e.target
+    setForm((f) => ({ ...f, [name]: value }))
+  }
+
+  function handleDescChange(e: React.ChangeEvent<HTMLInputElement>) {
+    setForm((f) => ({ ...f, descricao: e.target.value }))
+  }
+
+  async function handleSubmit(e: React.FormEvent) {
+    e.preventDefault()
+    const res = await fetch('/admin/api/preview-produto', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        nome: form.nome,
+        preco: Number(form.preco),
+        descricao: form.descricao,
+      }),
+    })
+    if (res.ok) {
+      const data = await res.json()
+      setPreview(data)
+    } else {
+      setPreview(null)
+    }
+  }
+
+  return (
+    <div className="max-w-xl mx-auto p-6">
+      <h1 className="text-2xl font-bold mb-4">Construtor de Produto</h1>
+      <form onSubmit={handleSubmit} className="space-y-4 mb-6">
+        <FormField label="Nome">
+          <TextField name="nome" value={form.nome} onChange={handleChange} required />
+        </FormField>
+        <FormField label="Preço">
+          <TextField
+            name="preco"
+            type="number"
+            value={form.preco}
+            onChange={handleChange}
+            required
+          />
+        </FormField>
+        <FormField label="Descrição">
+          <ContentEditable
+            html={form.descricao}
+            onChange={handleDescChange as unknown as React.ChangeEventHandler<HTMLInputElement>}
+            className="input-base min-h-[80px]"
+          />
+        </FormField>
+        <Button type="submit">Visualizar</Button>
+      </form>
+      {preview && (
+        <div className="space-y-8">
+          <ProdutoCardPreview produto={preview} />
+          <ProdutoDetailPreview produto={preview} />
+        </div>
+      )}
+    </div>
+  )
+}

--- a/components/admin/ProdutoCardPreview.tsx
+++ b/components/admin/ProdutoCardPreview.tsx
@@ -1,0 +1,24 @@
+'use client'
+import Image from 'next/image'
+import type { Produto } from '@/types'
+
+export default function ProdutoCardPreview({ produto }: { produto: Produto }) {
+  const imgSrc = produto.imagem || (Array.isArray(produto.imagens) ? produto.imagens[0] : '')
+  return (
+    <div className="rounded-2xl bg-white shadow-sm p-4 flex flex-col items-center">
+      {imgSrc && (
+        <Image
+          src={imgSrc}
+          alt={produto.nome}
+          width={300}
+          height={300}
+          className="w-full h-64 object-cover rounded-xl mb-4 border border-[var(--accent-900)]/10"
+        />
+      )}
+      <h3 className="font-medium text-lg mb-2">{produto.nome}</h3>
+      <span className="font-bold text-[var(--accent)] text-lg mb-4">
+        R$ {Number(produto.preco).toFixed(2).replace('.', ',')}
+      </span>
+    </div>
+  )
+}

--- a/components/admin/ProdutoDetailPreview.tsx
+++ b/components/admin/ProdutoDetailPreview.tsx
@@ -1,0 +1,27 @@
+'use client'
+import Image from 'next/image'
+import type { Produto } from '@/types'
+
+export default function ProdutoDetailPreview({ produto }: { produto: Produto }) {
+  const imgSrc = produto.imagem || (Array.isArray(produto.imagens) ? produto.imagens[0] : '')
+  return (
+    <div className="space-y-4">
+      {imgSrc && (
+        <Image
+          src={imgSrc}
+          alt={produto.nome}
+          width={400}
+          height={400}
+          className="rounded-xl mx-auto"
+        />
+      )}
+      <h2 className="text-2xl font-bold">{produto.nome}</h2>
+      <p className="font-semibold">
+        R$ {Number(produto.preco).toFixed(2).replace('.', ',')}
+      </p>
+      {produto.descricao && (
+        <p className="whitespace-pre-line">{produto.descricao}</p>
+      )}
+    </div>
+  )
+}

--- a/components/admin/index.ts
+++ b/components/admin/index.ts
@@ -1,1 +1,3 @@
 export { default as ModalProdutoForm } from './ModalProdutoForm'
+export { default as ProdutoCardPreview } from './ProdutoCardPreview'
+export { default as ProdutoDetailPreview } from './ProdutoDetailPreview'

--- a/docs/page-builder-home.md
+++ b/docs/page-builder-home.md
@@ -16,3 +16,10 @@ reordenadas no painel administrativo.
 O construtor visual está acessível em `/admin/page-builder/home`. Ele utiliza
 `@dnd-kit` para arrastar e soltar os blocos e os componentes do design system
 para os formulários de criação.
+
+## Construtor de Produtos
+
+A página `/admin/page-builder/produtos` permite pré-visualizar cartões e detalhes de produtos.
+Os campos do formulário usam os componentes do design system e edições inline via `react-contenteditable`.
+Ao enviar, os dados são enviados para `/admin/api/preview-produto`,
+retornando o JSON exibido nos componentes `ProdutoCardPreview` e `ProdutoDetailPreview`.

--- a/logs/DOC_LOG.md
+++ b/logs/DOC_LOG.md
@@ -419,3 +419,5 @@
 ## [2025-06-23] Reenvio de pagamento verifica responsavel antes de enviar e-mail. Testes atualizados. Lint e build executados.
 ## [2025-06-24] Implementado Page Builder com blocos dinâmicos e rotas /api/home-sections. Lint e build executados.
 ## [2025-06-24] Rota /api/upload-image criada com conversão WebP e README atualizado. Lint e build executados.
+
+## [2025-06-25] Documentado construtor de produtos e rota de preview.

--- a/package-lock.json
+++ b/package-lock.json
@@ -31,6 +31,7 @@
         "pocketbase": "^0.26.0",
         "react": "^18.2.0",
         "react-chartjs-2": "^5.3.0",
+        "react-contenteditable": "^3.3.7",
         "react-dom": "^18.2.0",
         "sharp": "^0.32.6",
         "tippy.js": "^6.3.7",
@@ -14499,7 +14500,6 @@
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
       "integrity": "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==",
-      "dev": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -15588,7 +15588,6 @@
       "version": "15.8.1",
       "resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.8.1.tgz",
       "integrity": "sha512-oj87CgZICdulUohogVAR7AjlC0327U4el4L6eAvOqCeudMDVU0NThNaV+b9Df4dXgSP1gXMTnPdhfe/2qDH5cg==",
-      "dev": true,
       "dependencies": {
         "loose-envify": "^1.4.0",
         "object-assign": "^4.1.1",
@@ -15945,6 +15944,19 @@
         "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
       }
     },
+    "node_modules/react-contenteditable": {
+      "version": "3.3.7",
+      "resolved": "https://registry.npmjs.org/react-contenteditable/-/react-contenteditable-3.3.7.tgz",
+      "integrity": "sha512-GA9NbC0DkDdpN3iGvib/OMHWTJzDX2cfkgy5Tt98JJAbA3kLnyrNbBIpsSpPpq7T8d3scD39DHP+j8mAM7BIfQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "fast-deep-equal": "^3.1.3",
+        "prop-types": "^15.7.1"
+      },
+      "peerDependencies": {
+        "react": ">=16.3"
+      }
+    },
     "node_modules/react-docgen": {
       "version": "7.1.1",
       "resolved": "https://registry.npmjs.org/react-docgen/-/react-docgen-7.1.1.tgz",
@@ -16005,8 +16017,7 @@
     "node_modules/react-is": {
       "version": "16.13.1",
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
-      "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==",
-      "dev": true
+      "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ=="
     },
     "node_modules/react-refresh": {
       "version": "0.14.2",

--- a/package.json
+++ b/package.json
@@ -41,6 +41,7 @@
     "pocketbase": "^0.26.0",
     "react": "^18.2.0",
     "react-chartjs-2": "^5.3.0",
+    "react-contenteditable": "^3.3.7",
     "react-dom": "^18.2.0",
     "sharp": "^0.32.6",
     "tippy.js": "^6.3.7",


### PR DESCRIPTION
## Summary
- create produto builder page for admins
- show preview via new ProdutoCardPreview and ProdutoDetailPreview components
- add preview-produto API route
- document product builder usage

## Testing
- `npm run lint` *(fails: Parsing error in app/admin/inscricoes/page.tsx)*
- `npm run build` *(fails: Syntax Error in app/admin/inscricoes/page.tsx)*

------
https://chatgpt.com/codex/tasks/task_e_685ae8476eb0832c9fd299c32a2d7c94