### PR TITLE
Fix loja sections rendering

### DIFF
--- a/app/loja/page.tsx
+++ b/app/loja/page.tsx
@@ -9,13 +9,23 @@ interface HomeSection {
   props?: Record<string, unknown>
 }
 
+async function getSections(): Promise<HomeSection[]> {
+  try {
+    const host = (await headers()).get('host') || 'localhost:3000'
+    const protocol = host.includes('localhost') ? 'http' : 'https'
+    const res = await fetch(`${protocol}://${host}/api/home-sections`, {
+      next: { revalidate: 60 },
+    })
+    if (!res.ok) return []
+    const data = await res.json()
+    return Array.isArray(data) ? (data as HomeSection[]) : []
+  } catch {
+    return []
+  }
+}
+
 export default async function LojaPage() {
-  const host = (await headers()).get('host') || 'localhost:3000'
-  const protocol = host.includes('localhost') ? 'http' : 'https'
-  const res = await fetch(`${protocol}://${host}/api/home-sections`, {
-    next: { revalidate: 60 },
-  })
-  const sections: HomeSection[] = await res.json()
+  const sections = await getSections()
 
   return (
     <>

--- a/logs/ERR_LOG.md
+++ b/logs/ERR_LOG.md
@@ -163,3 +163,5 @@
 ## [2025-06-23] Pagamento de inscrição redirecionava ao checkout em vez de usar o link existente. Botão corrigido para reutilizar link_pagamento do pedido. - dev - f095415
 
 ## [2025-06-23] Erro ao gerar link de pagamento Asaas: TypeError: ranges is not iterable - development
+
+## [2025-06-24] sections.map nao era funcao na loja; adicionado getSections com verificacao de array - dev - 164aacff79c6a747b2346877946f764566524bc7


### PR DESCRIPTION
## Summary
- avoid TypeError when rendering `/loja` by validating API response
- document the fix in `ERR_LOG.md`

## Testing
- `npm run lint` *(fails: next not found)*
- `npm run build` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_685aeef401f4832c934866eeb82111b2