### PR TITLE
Handle logger on Edge runtime

### DIFF
--- a/app/loja/page.tsx
+++ b/app/loja/page.tsx
@@ -9,13 +9,23 @@ interface HomeSection {
   props?: Record<string, unknown>
 }
 
+async function getSections(): Promise<HomeSection[]> {
+  try {
+    const host = (await headers()).get('host') || 'localhost:3000'
+    const protocol = host.includes('localhost') ? 'http' : 'https'
+    const res = await fetch(`${protocol}://${host}/api/home-sections`, {
+      next: { revalidate: 60 },
+    })
+    if (!res.ok) return []
+    const data = await res.json()
+    return Array.isArray(data) ? (data as HomeSection[]) : []
+  } catch {
+    return []
+  }
+}
+
 export default async function LojaPage() {
-  const host = (await headers()).get('host') || 'localhost:3000'
-  const protocol = host.includes('localhost') ? 'http' : 'https'
-  const res = await fetch(`${protocol}://${host}/api/home-sections`, {
-    next: { revalidate: 60 },
-  })
-  const sections: HomeSection[] = await res.json()
+  const sections = await getSections()
 
   return (
     <>

--- a/lib/server/logger.ts
+++ b/lib/server/logger.ts
@@ -1,13 +1,22 @@
-import { appendFile } from 'fs/promises'
-import path from 'path'
+
+async function appendToLog(line: string) {
+  if (process.env.NEXT_RUNTIME === 'edge') {
+    console.error(line.trim())
+    return
+  }
+
+  const { appendFile } = await import('fs/promises')
+  const path = await import('path')
+  const logPath = path.join(process.cwd(), 'logs', 'ERR_LOG.md')
+  await appendFile(logPath, line)
+}
 
 export async function logConciliacaoErro(message: string) {
   const date = new Date().toISOString().split('T')[0]
   const env = process.env.NODE_ENV || 'dev'
   const line = `## [${date}] ${message} - ${env}\n`
   try {
-    const logPath = path.join(process.cwd(), 'logs', 'ERR_LOG.md')
-    await appendFile(logPath, line)
+    await appendToLog(line)
   } catch (err) {
     console.error('Falha ao registrar ERR_LOG', err)
   }

--- a/logs/ERR_LOG.md
+++ b/logs/ERR_LOG.md
@@ -163,3 +163,6 @@
 ## [2025-06-23] Pagamento de inscrição redirecionava ao checkout em vez de usar o link existente. Botão corrigido para reutilizar link_pagamento do pedido. - dev - f095415
 
 ## [2025-06-23] Erro ao gerar link de pagamento Asaas: TypeError: ranges is not iterable - development
+
+## [2025-06-24] sections.map nao era funcao na loja; adicionado getSections com verificacao de array - dev - 164aacff79c6a747b2346877946f764566524bc7
+## [2025-06-24] Logger usava fs/promises no Edge; implementado import dinamico e fallback para console - dev - 3cf4308


### PR DESCRIPTION
## Summary
- avoid Node modules in `logConciliacaoErro` when running on the edge runtime
- document the fix in `ERR_LOG.md`

## Testing
- `npm run lint` *(fails: next not found)*
- `npm run build` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_685aeef401f4832c934866eeb82111b2