### PR TITLE
Use console.error in server logger

### DIFF
--- a/__tests__/serverLogger.test.ts
+++ b/__tests__/serverLogger.test.ts
@@ -1,34 +1,31 @@
 import { describe, it, expect, vi, afterEach } from 'vitest'
-import path from 'path'
-
-vi.mock('fs/promises', () => ({ appendFile: vi.fn() }))
-
-import { logConciliacaoErro } from '../lib/server/logger'
-import * as fsPromises from 'fs/promises'
+import { logConciliacaoErro, logError } from '../lib/server/logger'
 
 describe('logConciliacaoErro', () => {
   afterEach(() => {
     vi.restoreAllMocks()
   })
 
-  it('escreve mensagem no arquivo de log', async () => {
-    const appendFileSpy = vi.spyOn(fsPromises, 'appendFile')
-    await logConciliacaoErro('teste')
-    const logPath = path.join(process.cwd(), 'logs', 'ERR_LOG.md')
-    expect(appendFileSpy).toHaveBeenCalledWith(
-      logPath,
-      expect.stringContaining('teste'),
-    )
-  })
-
-  it('exibe erro no console quando falha', async () => {
-    const err = new Error('fail')
-    const appendFileSpy = vi
-      .spyOn(fsPromises, 'appendFile')
-      .mockRejectedValue(err)
+  it('envia mensagem para o console', async () => {
     const consoleSpy = vi.spyOn(console, 'error').mockImplementation(() => {})
     await logConciliacaoErro('teste')
-    expect(consoleSpy).toHaveBeenCalledWith('Falha ao registrar ERR_LOG', err)
-    expect(appendFileSpy).toHaveBeenCalled()
+    expect(consoleSpy).toHaveBeenCalledWith(
+      expect.objectContaining({ message: 'teste' }),
+    )
+  })
+})
+
+describe('logError', () => {
+  afterEach(() => {
+    vi.restoreAllMocks()
+  })
+
+  it('registra erro detalhado', async () => {
+    const err = new Error('fail')
+    const consoleSpy = vi.spyOn(console, 'error').mockImplementation(() => {})
+    await logError(err)
+    expect(consoleSpy).toHaveBeenCalledWith(
+      expect.objectContaining({ message: 'fail' }),
+    )
   })
 })

--- a/lib/server/logger.ts
+++ b/lib/server/logger.ts
@@ -1,23 +1,17 @@
-
-async function appendToLog(line: string) {
-  if (process.env.NEXT_RUNTIME === 'edge') {
-    console.error(line.trim())
-    return
-  }
-
-  const { appendFile } = await import('fs/promises')
-  const path = await import('path')
-  const logPath = path.join(process.cwd(), 'logs', 'ERR_LOG.md')
-  await appendFile(logPath, line)
+export async function logError(
+  err: unknown,
+  context: Record<string, unknown> = {},
+) {
+  console.error({
+    message: err instanceof Error ? err.message : String(err),
+    stack: err instanceof Error ? err.stack : undefined,
+    ...context,
+  })
 }
 
-export async function logConciliacaoErro(message: string) {
-  const date = new Date().toISOString().split('T')[0]
-  const env = process.env.NODE_ENV || 'dev'
-  const line = `## [${date}] ${message} - ${env}\n`
-  try {
-    await appendToLog(line)
-  } catch (err) {
-    console.error('Falha ao registrar ERR_LOG', err)
-  }
+export async function logConciliacaoErro(
+  message: string,
+  context: Record<string, unknown> = {},
+) {
+  await logError(new Error(message), context)
 }

--- a/logs/ERR_LOG.md
+++ b/logs/ERR_LOG.md
@@ -1,3 +1,5 @@
+## [2025-06-24] Ajustado logger para usar console.error no Edge - dev - 8e00e3c
+
 ## [2025-06-07] Corrigida tipagem da página de categoria que quebrava build - dev - 450cce4
 
 ## [2025-06-07] Corrigido efeito em ListaInscricoes que não respondia a mudanças de autenticação - dev - 668eeb0


### PR DESCRIPTION
## Summary
- simplify `logConciliacaoErro` by using a new `logError` helper
- adjust unit tests for the new console behavior
- document the fix in `ERR_LOG.md`

## Testing
- `npm run lint`
- `npm run build`
- `npm test` *(fails: 14 failed, 45 passed)*

------
https://chatgpt.com/codex/tasks/task_e_685af22434b8832ca7fe3f3271cf4b7e