### PR TITLE
Corrige endpoint de verificação no OnboardingWizard

### DIFF
--- a/components/admin/OnboardingWizard.tsx
+++ b/components/admin/OnboardingWizard.tsx
@@ -73,20 +73,17 @@ export default function OnboardingWizard() {
   // 1) check initial
   useEffect(() => {
     const tenant = localStorage.getItem('tenantId') || ''
-    console.log('[Onboarding] Iniciando check inicial, tenant:', tenant)
+    console.log('[Onboarding] Iniciando verificacao da instancia, tenant:', tenant)
     ;(async () => {
       try {
-        const res = await fetch(
-          `/api/chats/whatsapp/message/sendTest/${instanceName}`,
-          {
-            headers: { 'x-tenant-id': tenant },
-          },
-        )
-        console.log('[Onboarding] /instance/check status:', res.status)
+        const res = await fetch('/api/chats/whatsapp/instance/check', {
+          headers: { 'x-tenant-id': tenant },
+        })
+        console.log('[Onboarding] check status:', res.status)
 
-        const chk = (await res.json()) as CheckResponse
-        console.log('[Onboarding] check response:', chk)
-        if (!chk) {
+        const check = (await res.json()) as CheckResponse
+        console.log('[Onboarding] check response:', check)
+        if (!check) {
           console.log(
             '[Onboarding] nenhuma instância encontrada — permanece step 1',
           )
@@ -95,14 +92,14 @@ export default function OnboardingWizard() {
 
         console.log(
           '[Onboarding] instância encontrada:',
-          chk.instanceName,
+          check.instanceName,
           'status:',
-          chk.sessionStatus,
+          check.sessionStatus,
         )
-        setInstanceName(chk.instanceName)
-        setApiKey(chk.apiKey)
+        setInstanceName(check.instanceName)
+        setApiKey(check.apiKey)
 
-        if (chk.sessionStatus === 'connected') {
+        if (check.sessionStatus === 'connected') {
           console.log('[Onboarding] status connected — pulando para step 4')
           setStep(4)
         } else {


### PR DESCRIPTION
## Resumo
- ajuste do fetch inicial para usar `/api/chats/whatsapp/instance/check`
- atualização dos logs e variáveis conforme nova verificação

## Testes
- `npm run lint` *(falhou: erros existentes de ESLint)*
- `npm run build` *(falhou: erros de lint no projeto)*


------
https://chatgpt.com/codex/tasks/task_e_685c776ac0a8832cbd76a1fa6141096d