### PR TITLE
Fix test message endpoint URL

### DIFF
--- a/components/admin/OnboardingWizard.tsx
+++ b/components/admin/OnboardingWizard.tsx
@@ -238,17 +238,24 @@ export default function OnboardingWizard() {
     setLoading(true)
     setError(undefined)
     try {
-      const res = await fetch(`/api/chats/message/sendText/${instanceName}`, {
-        method: 'POST',
-        headers: {
-          'Content-Type': 'application/json',
-          'x-tenant-id': localStorage.getItem('tenantId') || '',
+      const res = await fetch(
+        `/api/chats/whatsapp/message/sendTest/${instanceName}`,
+        {
+          method: 'POST',
+          headers: {
+            'Content-Type': 'application/json',
+            'x-tenant-id': localStorage.getItem('tenantId') || '',
+          },
+          body: JSON.stringify({
+            to: `55${raw}`,
+            message: 'Olá! QR autenticado com sucesso!',
+          }),
         },
-        body: JSON.stringify({
-          to: `55${raw}`,
-          message: 'Olá! QR autenticado com sucesso!',
-        }),
-      })
+      )
+      if (res.status === 409) {
+        setSentOk(true)
+        return setStep(5)
+      }
       if (!res.ok) throw new Error((await res.json()).error || 'Erro ao enviar')
       setSentOk(true)
       setStep(5)


### PR DESCRIPTION
## Summary
- update endpoint path for sending WhatsApp onboarding test message
- treat 409 responses as successful completion

## Testing
- `npm run lint`
- `npm run build` *(fails: Unexpected any, ts errors)*

------
https://chatgpt.com/codex/tasks/task_e_685c7906aea8832cb1c4f2a6eb44621c