### PR TITLE
Add Evolution API hook and refactor onboarding

### DIFF
--- a/app/api/chats/message/sendText/[instanceName]/route.ts
+++ b/app/api/chats/message/sendText/[instanceName]/route.ts
@@ -21,9 +21,9 @@ export async function POST(
     return NextResponse.json({ error: 'Tenant ausente' }, { status: 400 })
   }
 
-  let body: any
+  let body: { to?: string; message?: string }
   try {
-    body = await req.json()
+    body = (await req.json()) as { to?: string; message?: string }
   } catch {
     return NextResponse.json({ error: 'JSON inválido' }, { status: 400 })
   }
@@ -61,8 +61,9 @@ export async function POST(
       message,
     })
     return NextResponse.json(result, { status: 200 })
-  } catch (err: any) {
+  } catch (err: unknown) {
     console.error('[sendText] sendTextMessage error:', err)
-    return NextResponse.json({ error: err.message }, { status: 500 })
+    const message = err instanceof Error ? err.message : 'Erro desconhecido'
+    return NextResponse.json({ error: message }, { status: 500 })
   }
 }

--- a/app/api/chats/whatsapp/instance/connect/route.ts
+++ b/app/api/chats/whatsapp/instance/connect/route.ts
@@ -71,6 +71,7 @@ export async function POST(req: NextRequest) {
 
   // 4) faz upload do novo QR no PB
   const [, base64Data] = dataUri.split(',')
+  // eslint-disable-next-line @typescript-eslint/ban-ts-comment
   // @ts-ignore Node 18+
   const blob = new Blob([Buffer.from(base64Data, 'base64')], {
     type: 'image/png',

--- a/app/api/chats/whatsapp/instance/route.ts
+++ b/app/api/chats/whatsapp/instance/route.ts
@@ -3,7 +3,6 @@
 import { NextRequest, NextResponse } from 'next/server'
 import createPocketBase from '@/lib/pocketbase'
 import { requireRole } from '@/lib/apiAuth'
-import { Readable } from 'stream'
 
 const PHONE_REGEX = /^\+?[1-9]\d{7,14}$/
 
@@ -102,7 +101,8 @@ export async function POST(req: NextRequest) {
     // 8) converte base64 em Blob (Node18+)
     const [, base64Data] = qrCodeBase64.split(',')
     const buffer = Buffer.from(base64Data, 'base64')
-    // @ts-ignore
+    // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+    // @ts-ignore Node 18+
     const blob = new Blob([buffer], { type: 'image/png' })
 
     // 9) upsert + upload em um só passo

--- a/app/api/chats/whatsapp/message/sendTest/[instanceName]/route.ts
+++ b/app/api/chats/whatsapp/message/sendTest/[instanceName]/route.ts
@@ -73,8 +73,9 @@ export async function POST(
       .update(rec.id, { config_finished: true })
 
     return NextResponse.json({ ok: true, result }, { status: 200 })
-  } catch (err: any) {
+  } catch (err: unknown) {
     console.error('[sendTest] erro ao enviar teste:', err)
-    return NextResponse.json({ error: err.message }, { status: 500 })
+    const message = err instanceof Error ? err.message : 'Erro desconhecido'
+    return NextResponse.json({ error: message }, { status: 500 })
   }
 }

--- a/components/onboarding/StepSelectClient.tsx
+++ b/components/onboarding/StepSelectClient.tsx
@@ -1,6 +1,9 @@
 'use client'
 import { useState } from 'react'
 import { useOnboarding } from '@/lib/context/OnboardingContext'
+import {
+  createInstance,
+} from '@/hooks/useEvolutionApi'
 
 interface StepSelectClientProps {
   onRegistered: (qrUrl: string, qrBase64: string) => void
@@ -46,16 +49,7 @@ export default function StepSelectClient({
     setLoading(true)
     setError(undefined)
     try {
-      const res = await fetch('/api/chats/whatsapp/instance', {
-        method: 'POST',
-        headers: {
-          'Content-Type': 'application/json',
-          'x-tenant-id': localStorage.getItem('tenantId') || '',
-        },
-        body: JSON.stringify({ telefone: `55${raw}` }),
-      })
-      if (!res.ok) throw new Error((await res.json()).error || 'Erro')
-      const d = (await res.json()) as {
+      const d = (await createInstance(`55${raw}`)) as {
         instance: { instanceId: string; instanceName: string }
         apiKey: string
         qrCodeUrl: string
@@ -65,8 +59,8 @@ export default function StepSelectClient({
       setApiKey(d.apiKey)
       onRegistered(d.qrCodeUrl, d.qrBase64)
       setStep(3)
-    } catch (e: any) {
-      setError(e.message)
+    } catch (err: unknown) {
+      setError(err instanceof Error ? err.message : String(err))
       setStep(1)
     } finally {
       setLoading(false)

--- a/hooks/useEvolutionApi.ts
+++ b/hooks/useEvolutionApi.ts
@@ -1,0 +1,73 @@
+const API_URL = (process.env.NEXT_PUBLIC_EVOLUTION_API_URL || process.env.EVOLUTION_API_URL || '').replace(/\/$/, '')
+
+export async function createInstance(telefone: string) {
+  const res = await fetch(`${API_URL}/instance/create`, {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+      apikey: process.env.EVOLUTION_API_KEY as string,
+    },
+    body: JSON.stringify({
+      instanceName: telefone.replace(/\D/g, ''),
+      number: telefone,
+      qrcode: true,
+      integration: 'WHATSAPP-BAILEYS',
+    }),
+  })
+
+  if (!res.ok) {
+    const txt = await res.text()
+    throw new Error(txt)
+  }
+
+  return res.json()
+}
+
+export async function connectInstance(instanceName: string, apiKey: string) {
+  const res = await fetch(`${API_URL}/instance/connect/${instanceName}`, {
+    headers: { apikey: apiKey },
+  })
+
+  if (!res.ok) {
+    const txt = await res.text()
+    throw new Error(txt)
+  }
+
+  return res.json()
+}
+
+export async function fetchInstanceStatus(instanceName: string, apiKey: string) {
+  const res = await fetch(`${API_URL}/instance/connectionState/${instanceName}`, {
+    headers: { apikey: apiKey },
+  })
+
+  if (!res.ok) {
+    const txt = await res.text()
+    throw new Error(txt)
+  }
+
+  return res.json()
+}
+
+export async function sendTestMessage(
+  instanceName: string,
+  apiKey: string,
+  to: string,
+  message = 'Olá! QR autenticado com sucesso!'
+) {
+  const res = await fetch(`${API_URL}/message/sendText/${instanceName}`, {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+      apikey: apiKey,
+    },
+    body: JSON.stringify({ number: to, text: message }),
+  })
+
+  if (!res.ok) {
+    const txt = await res.text()
+    throw new Error(txt)
+  }
+
+  return res.json()
+}


### PR DESCRIPTION
## Summary
- add `hooks/useEvolutionApi` with helper methods
- refactor WhatsApp onboarding steps to use the new helpers
- clean up lint warnings in API routes

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_685c7ddaf368832ca8a90ee3d461219c