### PR TITLE
Refactor onboarding wizard

### DIFF
--- a/components/admin/OnboardingWizard.tsx
+++ b/components/admin/OnboardingWizard.tsx
@@ -1,5 +1,6 @@
 'use client'
 import { useEffect, useState } from 'react'
+import { useAuthContext } from '@/lib/context/AuthContext'
 import StepSelectClient from '../onboarding/StepSelectClient'
 import StepCreateInstance from '../onboarding/StepCreateInstance'
 import StepPairing from '../onboarding/StepPairing'
@@ -18,15 +19,16 @@ type CheckResponse = {
 function WizardSteps() {
   const { step, setStep, setInstanceName, setApiKey, setConnection } =
     useOnboarding()
+  const { tenantId } = useAuthContext()
   const [qrUrl, setQrUrl] = useState('')
   const [qrBase, setQrBase] = useState('')
 
   useEffect(() => {
-    const tenant = localStorage.getItem('tenantId') || ''
+    if (!tenantId) return
     ;(async () => {
       try {
         const res = await fetch('/api/chats/whatsapp/instance/check', {
-          headers: { 'x-tenant-id': tenant },
+          headers: { 'x-tenant-id': tenantId },
         })
         const check = (await res.json()) as CheckResponse
         if (!check) return
@@ -43,7 +45,7 @@ function WizardSteps() {
         /* ignore */
       }
     })()
-  }, [setStep, setInstanceName, setApiKey, setConnection])
+  }, [tenantId, setStep, setInstanceName, setApiKey, setConnection])
 
   const handleRegistered = (url: string, base: string) => {
     setQrUrl(url)

--- a/components/onboarding/StepComplete.tsx
+++ b/components/onboarding/StepComplete.tsx
@@ -1,7 +1,7 @@
 'use client'
 export default function StepComplete() {
   return (
-    <div className="p-4 text-center">
+    <div className="card p-4 text-center">
       <p>Conectado com sucesso!</p>
     </div>
   )

--- a/components/onboarding/StepCreateInstance.tsx
+++ b/components/onboarding/StepCreateInstance.tsx
@@ -1,9 +1,9 @@
 'use client'
 export default function StepCreateInstance() {
   return (
-    <div className="flex flex-col items-center p-8">
+    <div className="card flex flex-col items-center p-8">
       <span>Configurando sua instância...</span>
-      <div className="animate-spin h-12 w-12 border-4 border-t-green-600 rounded-full" />
+      <progress className="progress w-40 mt-4" />
     </div>
   )
 }

--- a/components/onboarding/StepPairing.tsx
+++ b/components/onboarding/StepPairing.tsx
@@ -1,5 +1,6 @@
 'use client'
 import { useEffect, useRef, useState } from 'react'
+import { Button } from '@/components/atoms/Button'
 import { useOnboarding } from '@/lib/context/OnboardingContext'
 import {
   connectInstance,
@@ -93,7 +94,7 @@ export default function StepPairing({
   }
 
   return (
-    <div className="p-4 text-center flex flex-col gap-4">
+    <div className="card p-4 text-center flex flex-col gap-4">
       <p>Escaneie o QR Code abaixo para autenticar:</p>
       <img
         src={codeBase ? `data:image/png;base64,${codeBase}` : codeUrl}
@@ -102,13 +103,13 @@ export default function StepPairing({
       />
       {error && <p className="text-red-600">{error}</p>}
       <div className="flex gap-2 justify-center">
-        <button
-          className="btn btn-secondary"
+        <Button
+          variant="secondary"
           onClick={handleRegenerateQr}
           disabled={loading}
         >
           {loading ? 'Gerando...' : 'Regerar QR Code'}
-        </button>
+        </Button>
       </div>
       {countdown > 0 && (
         <p className="text-sm mt-2">

--- a/components/onboarding/StepSelectClient.tsx
+++ b/components/onboarding/StepSelectClient.tsx
@@ -1,5 +1,7 @@
 'use client'
 import { useState } from 'react'
+import { TextField } from '@/components/atoms/TextField'
+import { Button } from '@/components/atoms/Button'
 import { useOnboarding } from '@/lib/context/OnboardingContext'
 import {
   createInstance,
@@ -68,22 +70,18 @@ export default function StepSelectClient({
   }
 
   return (
-    <div className="p-4 flex flex-col gap-2">
+    <div className="card p-4 flex flex-col gap-2">
       <label className="font-medium">Telefone (DDD + número)</label>
-      <input
-        className="input"
+      <TextField
+        className="input-base"
         placeholder="(11) 99999-9999"
         value={maskPhone(telefoneLocal)}
         onChange={handleTelefoneChange}
       />
       {error && <p className="text-red-600 text-sm">{error}</p>}
-      <button
-        className="btn btn-primary mt-2"
-        onClick={handleRegister}
-        disabled={loading}
-      >
+      <Button className="mt-2" onClick={handleRegister} disabled={loading}>
         {loading ? 'Registrando...' : 'Cadastrar'}
-      </button>
+      </Button>
     </div>
   )
 }

--- a/logs/DOC_LOG.md
+++ b/logs/DOC_LOG.md
@@ -423,3 +423,6 @@
 ## [2025-06-25] Variavel PB_URL padronizada no guia de Evolution e .env.example.
 
 ## [2025-06-25] Onboarding de WhatsApp adicionado ao admin e link no header.
+## [2025-06-25] OnboardingWizard adaptado ao design system: TextField, Button e
+classes card/progress aplicados. TenantId lido do AuthContext. Lint e build
+executados.


### PR DESCRIPTION
## Summary
- replace inputs and buttons with TextField and Button atoms
- get tenant id from AuthContext instead of localStorage
- apply card/btn/progress classes
- log documentation update

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_685c81dd3288832ca002de9d987d6d70