### PR TITLE
Implementa barra de progresso e loading centralizado

### DIFF
--- a/components/admin/OnboardingWizard.tsx
+++ b/components/admin/OnboardingWizard.tsx
@@ -5,6 +5,7 @@ import StepSelectClient from '../onboarding/StepSelectClient'
 import StepCreateInstance from '../onboarding/StepCreateInstance'
 import StepPairing from '../onboarding/StepPairing'
 import StepComplete from '../onboarding/StepComplete'
+import OnboardingProgress from '../onboarding/OnboardingProgress'
 import {
   OnboardingProvider,
   useOnboarding,
@@ -58,6 +59,7 @@ function WizardSteps() {
 
   return (
     <div className="wizard-container max-w-sm mx-auto">
+      <OnboardingProgress />
       {step === 1 && <StepSelectClient onRegistered={handleRegistered} />}
       {step === 2 && <StepCreateInstance />}
       {step === 3 && (

--- a/components/onboarding/OnboardingProgress.tsx
+++ b/components/onboarding/OnboardingProgress.tsx
@@ -1,0 +1,20 @@
+'use client'
+import { useOnboarding } from '@/lib/context/OnboardingContext'
+
+export default function OnboardingProgress() {
+  const { step } = useOnboarding()
+  const total = 4
+  return (
+    <div className="mb-4">
+      <div className="w-full bg-neutral-200 rounded-full h-2">
+        <div
+          className="bg-[var(--accent)] h-2 rounded-full transition-all duration-300"
+          style={{ width: `${(step / total) * 100}%` }}
+        />
+      </div>
+      <div className="text-center mt-1 text-sm text-neutral-600">
+        Passo {step} de {total}
+      </div>
+    </div>
+  )
+}

--- a/components/onboarding/StepPairing.tsx
+++ b/components/onboarding/StepPairing.tsx
@@ -28,10 +28,10 @@ export default function StepPairing({
   qrBase64,
   onConnected,
 }: StepPairingProps) {
-  const { instanceName, apiKey, setConnection } = useOnboarding()
+  const { instanceName, apiKey, setConnection, loading, setLoading } =
+    useOnboarding()
   const [codeUrl, setCodeUrl] = useState(qrCodeUrl)
   const [codeBase, setCodeBase] = useState(qrBase64)
-  const [loading, setLoading] = useState(false)
   const [error, setError] = useState<string>()
   const attempts = useRef(0)
   const timeoutRef = useRef<number>()
@@ -101,7 +101,7 @@ export default function StepPairing({
         alt="QR Code"
         className="mx-auto"
       />
-      {error && <p className="text-red-600">{error}</p>}
+      {error && <p className="text-red-600 text-sm">{error}</p>}
       <div className="flex gap-2 justify-center">
         <Button
           variant="secondary"

--- a/components/onboarding/StepSelectClient.tsx
+++ b/components/onboarding/StepSelectClient.tsx
@@ -14,9 +14,9 @@ interface StepSelectClientProps {
 export default function StepSelectClient({
   onRegistered,
 }: StepSelectClientProps) {
-  const { setStep, setInstanceName, setApiKey } = useOnboarding()
+  const { setStep, setInstanceName, setApiKey, loading, setLoading } =
+    useOnboarding()
   const [telefoneLocal, setTelefoneLocal] = useState('')
-  const [loading, setLoading] = useState(false)
   const [error, setError] = useState<string>()
 
   const maskPhone = (digits: string) => {

--- a/lib/context/OnboardingContext.tsx
+++ b/lib/context/OnboardingContext.tsx
@@ -8,6 +8,8 @@ interface OnboardingContextType {
   instanceName: string
   apiKey: string
   connection: ConnectionStatus
+  loading: boolean
+  setLoading: (v: boolean) => void
   setStep: (s: 1 | 2 | 3 | 4) => void
   setInstanceName: (v: string) => void
   setApiKey: (v: string) => void
@@ -19,6 +21,8 @@ const OnboardingContext = createContext<OnboardingContextType>({
   instanceName: '',
   apiKey: '',
   connection: 'idle',
+  loading: false,
+  setLoading: () => {},
   setStep: () => {},
   setInstanceName: () => {},
   setApiKey: () => {},
@@ -34,6 +38,7 @@ export function OnboardingProvider({
   const [instanceName, setInstanceName] = useState('')
   const [apiKey, setApiKey] = useState('')
   const [connection, setConnection] = useState<ConnectionStatus>('idle')
+  const [loading, setLoading] = useState(false)
 
   return (
     <OnboardingContext.Provider
@@ -42,6 +47,8 @@ export function OnboardingProvider({
         instanceName,
         apiKey,
         connection,
+        loading,
+        setLoading,
         setStep,
         setInstanceName,
         setApiKey,


### PR DESCRIPTION
## Resumo
- adiciona estado `loading` ao `OnboardingContext`
- usa o `loading` global nos passos do onboarding
- inclui componente `OnboardingProgress` para exibir passo atual
- exibe erros de API com estilo padrao

## Testes
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_685c8587b148832cb870963568acb8bc