### PR TITLE
Refactor StepPairing to use internal WhatsApp API

### DIFF
--- a/components/onboarding/StepPairing.tsx
+++ b/components/onboarding/StepPairing.tsx
@@ -4,8 +4,8 @@ import { Button } from '@/components/atoms/Button'
 import { useOnboarding } from '@/lib/context/OnboardingContext'
 import {
   connectInstance,
-  fetchInstanceStatus,
-} from '@/hooks/useEvolutionApi'
+  fetchConnectionState,
+} from '@/hooks/useWhatsappApi'
 
 interface StepPairingProps {
   qrCodeUrl: string
@@ -50,7 +50,7 @@ export default function StepPairing({
     const poll = async () => {
       attempts.current++
       try {
-        const raw = (await fetchInstanceStatus(
+        const raw = (await fetchConnectionState(
           instanceName,
           apiKey,
         )) as RawStateResponse

--- a/hooks/useWhatsappApi.ts
+++ b/hooks/useWhatsappApi.ts
@@ -1,0 +1,33 @@
+export async function connectInstance(instanceName: string, apiKey: string) {
+  const res = await fetch('/api/chats/whatsapp/instance/connect', {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+    },
+    body: JSON.stringify({ instanceName, apiKey }),
+  })
+
+  if (!res.ok) {
+    const txt = await res.text()
+    throw new Error(txt)
+  }
+
+  return res.json()
+}
+
+export async function fetchConnectionState(instanceName: string, apiKey: string) {
+  const res = await fetch('/api/chats/whatsapp/instance/connectionState', {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+    },
+    body: JSON.stringify({ instanceName, apiKey }),
+  })
+
+  if (!res.ok) {
+    const txt = await res.text()
+    throw new Error(txt)
+  }
+
+  return res.json()
+}


### PR DESCRIPTION
## Summary
- expose connect/connectionState calls in new `useWhatsappApi`
- update `StepPairing` to call the new endpoints

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_685c8b4ec918832ca9ea8f67e48647a9