### PR TITLE
Add WhatsApp send test step

### DIFF
--- a/components/admin/OnboardingWizard.tsx
+++ b/components/admin/OnboardingWizard.tsx
@@ -5,6 +5,7 @@ import StepSelectClient from '../onboarding/StepSelectClient'
 import StepCreateInstance from '../onboarding/StepCreateInstance'
 import StepPairing from '../onboarding/StepPairing'
 import StepComplete from '../onboarding/StepComplete'
+import StepSendTest from '../onboarding/StepSendTest'
 import OnboardingProgress from '../onboarding/OnboardingProgress'
 import {
   OnboardingProvider,
@@ -37,7 +38,7 @@ function WizardSteps() {
         setApiKey(check.apiKey)
         if (check.sessionStatus === 'connected') {
           setConnection('connected')
-          setStep(4)
+          setStep(5)
         } else {
           setConnection('pending')
           setStep(3)
@@ -69,7 +70,8 @@ function WizardSteps() {
           onConnected={handleConnected}
         />
       )}
-      {step === 4 && <StepComplete />}
+      {step === 4 && <StepSendTest />}
+      {step === 5 && <StepComplete />}
     </div>
   )
 }

--- a/components/onboarding/OnboardingProgress.tsx
+++ b/components/onboarding/OnboardingProgress.tsx
@@ -3,7 +3,7 @@ import { useOnboarding } from '@/lib/context/OnboardingContext'
 
 export default function OnboardingProgress() {
   const { step } = useOnboarding()
-  const total = 4
+  const total = 5
   return (
     <div className="mb-4">
       <div className="w-full bg-neutral-200 rounded-full h-2">

--- a/components/onboarding/StepSendTest.tsx
+++ b/components/onboarding/StepSendTest.tsx
@@ -1,0 +1,80 @@
+'use client'
+import { useState } from 'react'
+import { TextField } from '@/components/atoms/TextField'
+import { Button } from '@/components/atoms/Button'
+import { useOnboarding } from '@/lib/context/OnboardingContext'
+import { useAuthContext } from '@/lib/context/AuthContext'
+
+export default function StepSendTest() {
+  const { instanceName, setStep, loading, setLoading } = useOnboarding()
+  const { tenantId } = useAuthContext()
+  const [telefoneLocal, setTelefoneLocal] = useState('')
+  const [error, setError] = useState<string>()
+
+  const maskPhone = (digits: string) => {
+    const d = digits.slice(0, 2)
+    const n = digits.slice(2)
+    let p1 = ''
+    let p2 = ''
+    if (n.length <= 4) p1 = n
+    else if (n.length <= 8) {
+      p1 = n.slice(0, 4)
+      p2 = n.slice(4)
+    } else {
+      p1 = n.slice(0, 5)
+      p2 = n.slice(5)
+    }
+    return `(${d}) ${p1}${p2 ? '-' + p2 : ''}`
+  }
+
+  const handleTelefoneChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    let r = e.target.value.replace(/\D/g, '')
+    if (r.length > 11) r = r.slice(0, 11)
+    setTelefoneLocal(r)
+  }
+
+  const handleSendTest = async () => {
+    const raw = telefoneLocal.replace(/\D/g, '')
+    if (!/^\d{10,11}$/.test(raw)) {
+      setError('Informe DDD + número válido.')
+      return
+    }
+    setLoading(true)
+    setError(undefined)
+    try {
+      const res = await fetch(
+        `/api/chats/whatsapp/message/sendTest/${instanceName}`,
+        {
+          method: 'POST',
+          headers: {
+            'Content-Type': 'application/json',
+            'x-tenant-id': tenantId!,
+          },
+          body: JSON.stringify({ to: `55${raw}` }),
+        },
+      )
+      if (!res.ok) throw new Error(await res.text())
+      setStep(5)
+    } catch (err: unknown) {
+      setError(err instanceof Error ? err.message : String(err))
+    } finally {
+      setLoading(false)
+    }
+  }
+
+  return (
+    <div className="card p-4 flex flex-col gap-2">
+      <label className="font-medium">Número de teste (DDD + número)</label>
+      <TextField
+        className="input-base"
+        placeholder="(11) 99999-9999"
+        value={maskPhone(telefoneLocal)}
+        onChange={handleTelefoneChange}
+      />
+      {error && <p className="text-red-600 text-sm">{error}</p>}
+      <Button className="mt-2" onClick={handleSendTest} disabled={loading}>
+        {loading ? 'Enviando...' : 'Enviar Mensagem'}
+      </Button>
+    </div>
+  )
+}

--- a/lib/context/OnboardingContext.tsx
+++ b/lib/context/OnboardingContext.tsx
@@ -4,13 +4,13 @@ import { createContext, useContext, useState } from 'react'
 export type ConnectionStatus = 'idle' | 'pending' | 'connected' | 'disconnected'
 
 interface OnboardingContextType {
-  step: 1 | 2 | 3 | 4
+  step: 1 | 2 | 3 | 4 | 5
   instanceName: string
   apiKey: string
   connection: ConnectionStatus
   loading: boolean
   setLoading: (v: boolean) => void
-  setStep: (s: 1 | 2 | 3 | 4) => void
+  setStep: (s: 1 | 2 | 3 | 4 | 5) => void
   setInstanceName: (v: string) => void
   setApiKey: (v: string) => void
   setConnection: (v: ConnectionStatus) => void
@@ -34,7 +34,7 @@ export function OnboardingProvider({
 }: {
   children: React.ReactNode
 }) {
-  const [step, setStep] = useState<1 | 2 | 3 | 4>(1)
+  const [step, setStep] = useState<1 | 2 | 3 | 4 | 5>(1)
   const [instanceName, setInstanceName] = useState('')
   const [apiKey, setApiKey] = useState('')
   const [connection, setConnection] = useState<ConnectionStatus>('idle')


### PR DESCRIPTION
## Summary
- add new onboarding step for sending WhatsApp test message
- wire onboarding wizard to show this step after pairing
- update progress indicator and context

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_685c8d00a6ec832ca9be57f7b5235d9f