### PR TITLE
Add whatsapp api tests and onboarding wizard tests

### DIFF
--- a/__tests__/OnboardingWizard.test.tsx
+++ b/__tests__/OnboardingWizard.test.tsx
@@ -1,0 +1,98 @@
+/* @vitest-environment jsdom */
+import React from 'react'
+import { render, screen, fireEvent } from '@testing-library/react'
+import { vi } from 'vitest'
+import OnboardingWizard from '@/components/admin/OnboardingWizard'
+import { useOnboarding } from '@/lib/context/OnboardingContext'
+
+vi.mock('next/image', () => ({
+  __esModule: true,
+  default: (props: any) => <img {...props} alt={props.alt} />,
+}))
+
+vi.mock('@/lib/context/AuthContext', () => ({
+  useAuthContext: () => ({ tenantId: 't1' }),
+}))
+
+vi.mock('@/components/onboarding/StepSelectClient', () => {
+  return {
+    __esModule: true,
+    default: function Step1() {
+      const { setStep } = useOnboarding()
+      return (
+        <div>
+          Step1<button onClick={() => setStep(2)}>next1</button>
+        </div>
+      )
+    },
+  }
+})
+
+vi.mock('@/components/onboarding/StepCreateInstance', () => {
+  return {
+    __esModule: true,
+    default: function Step2() {
+      const { setStep } = useOnboarding()
+      return (
+        <div>
+          Step2<button onClick={() => setStep(3)}>next2</button>
+        </div>
+      )
+    },
+  }
+})
+
+vi.mock('@/components/onboarding/StepPairing', () => {
+  return {
+    __esModule: true,
+    default: function Step3() {
+      const { setStep } = useOnboarding()
+      return (
+        <div>
+          Step3<button onClick={() => setStep(4)}>next3</button>
+        </div>
+      )
+    },
+  }
+})
+
+vi.mock('@/components/onboarding/StepSendTest', () => {
+  return {
+    __esModule: true,
+    default: function Step4() {
+      const { setStep } = useOnboarding()
+      return (
+        <div>
+          Step4<button onClick={() => setStep(5)}>next4</button>
+        </div>
+      )
+    },
+  }
+})
+
+vi.mock('@/components/onboarding/StepComplete', () => ({
+  __esModule: true,
+  default: () => <div>Step5</div>,
+}))
+
+vi.mock('@/components/onboarding/OnboardingProgress', () => ({
+  __esModule: true,
+  default: () => <div>Progress</div>,
+}))
+
+global.fetch = vi.fn().mockResolvedValue({ ok: true, json: () => Promise.resolve(null) }) as unknown as typeof fetch
+
+describe('OnboardingWizard', () => {
+  it('avanca pelas etapas ao clicar nos botoes', () => {
+    render(<OnboardingWizard />)
+    expect(screen.getByText('Step1')).toBeInTheDocument()
+    fireEvent.click(screen.getByText('next1'))
+    expect(screen.getByText('Step2')).toBeInTheDocument()
+    fireEvent.click(screen.getByText('next2'))
+    expect(screen.getByText('Step3')).toBeInTheDocument()
+    fireEvent.click(screen.getByText('next3'))
+    expect(screen.getByText('Step4')).toBeInTheDocument()
+    fireEvent.click(screen.getByText('next4'))
+    expect(screen.getByText('Step5')).toBeInTheDocument()
+  })
+})

--- a/__tests__/api/whatsappRoutes.test.ts
+++ b/__tests__/api/whatsappRoutes.test.ts
@@ -1,0 +1,89 @@
+import { describe, it, expect, vi } from 'vitest'
+import { POST as POST_INSTANCE } from '../../app/api/chats/whatsapp/instance/route'
+import { POST as POST_STATE } from '../../app/api/chats/whatsapp/instance/connectionState/route'
+import { POST as POST_SEND } from '../../app/api/chats/whatsapp/message/sendTest/[instanceName]/route'
+import { NextRequest } from 'next/server'
+
+vi.mock('../../lib/apiAuth', () => ({ requireRole: vi.fn() }))
+import { requireRole } from '../../lib/apiAuth'
+vi.mock('../../lib/pocketbase', () => ({
+  default: vi.fn(() => ({
+    collection: vi.fn(() => ({
+      getOne: vi.fn(),
+      getFirstListItem: vi.fn(),
+      update: vi.fn(),
+    })),
+    admins: { authWithPassword: vi.fn() },
+    authStore: { isValid: true },
+  })),
+}))
+
+const pbMock = (requireRole as unknown as { mockReturnValue: (v: any) => void })
+
+pbMock.mockReturnValue({ pb: {} as any, user: {} })
+
+describe('POST /api/chats/whatsapp/instance', () => {
+  it('retorna 400 quando tenant ausente', async () => {
+    const req = new Request('http://test', {
+      method: 'POST',
+      body: JSON.stringify({ telefone: '+5511999999999' }),
+    })
+    ;(req as any).nextUrl = new URL('http://test')
+    const res = await POST_INSTANCE(req as unknown as NextRequest)
+    expect(res.status).toBe(400)
+    const body = await res.json()
+    expect(body.error).toBe('Tenant ausente')
+  })
+
+  it('retorna 400 quando telefone invalido', async () => {
+    const req = new Request('http://test', {
+      method: 'POST',
+      headers: { 'x-tenant-id': 't1' },
+      body: JSON.stringify({ telefone: '123' }),
+    })
+    ;(req as any).nextUrl = new URL('http://test')
+    const res = await POST_INSTANCE(req as unknown as NextRequest)
+    expect(res.status).toBe(400)
+    const body = await res.json()
+    expect(body.error).toBe('invalid_phone')
+  })
+})
+
+describe('POST /api/chats/whatsapp/instance/connectionState', () => {
+  it('retorna 400 quando tenant ausente', async () => {
+    const req = new Request('http://test', {
+      method: 'POST',
+      body: JSON.stringify({ instanceName: 'i', apiKey: 'k' }),
+    })
+    ;(req as any).nextUrl = new URL('http://test')
+    const res = await POST_STATE(req as unknown as NextRequest)
+    expect(res.status).toBe(400)
+    const body = await res.json()
+    expect(body.error).toBe('Tenant ausente')
+  })
+})
+
+describe('POST /api/chats/whatsapp/message/sendTest/[instanceName]', () => {
+  it('retorna 400 quando instanceName ausente', async () => {
+    const req = new Request('http://test', {
+      method: 'POST',
+      headers: { 'x-tenant-id': 't1' },
+      body: JSON.stringify({ to: '123' }),
+    })
+    ;(req as any).nextUrl = new URL('http://test')
+    const res = await POST_SEND(req as unknown as NextRequest, { params: Promise.resolve({}) })
+    expect(res.status).toBe(400)
+  })
+
+  it('retorna 400 quando tenant ausente', async () => {
+    const req = new Request('http://test', {
+      method: 'POST',
+      body: JSON.stringify({ to: '123' }),
+    })
+    ;(req as any).nextUrl = new URL('http://test')
+    const res = await POST_SEND(req as unknown as NextRequest, { params: Promise.resolve({ instanceName: 'i' }) })
+    expect(res.status).toBe(400)
+    const body = await res.json()
+    expect(body.error).toBe('Tenant ausente')
+  })
+})


### PR DESCRIPTION
## Summary
- add unit tests for whatsapp-related API routes
- test OnboardingWizard step flow with mocked components
- ensure lint and build pass

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_685c916ac438832caf8c38095a4176ec