### PR TITLE
Handle duplicate test sending

### DIFF
--- a/components/onboarding/StepSendTest.tsx
+++ b/components/onboarding/StepSendTest.tsx
@@ -53,6 +53,10 @@ export default function StepSendTest() {
           body: JSON.stringify({ to: `55${raw}` }),
         },
       )
+      if (res.status === 409) {
+        setError('Teste já executado')
+        return
+      }
       if (!res.ok) throw new Error(await res.text())
       setStep(5)
     } catch (err: unknown) {


### PR DESCRIPTION
## Summary
- check for HTTP 409 when sending onboarding test message

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_685c952d7c4c832c9239a79815e787d9