### PR TITLE
Refactor onboarding flow to create instance on step 2

### DIFF
--- a/components/admin/OnboardingWizard.tsx
+++ b/components/admin/OnboardingWizard.tsx
@@ -24,6 +24,7 @@ function WizardSteps() {
   const { tenantId } = useAuthContext()
   const [qrUrl, setQrUrl] = useState('')
   const [qrBase, setQrBase] = useState('')
+  const [phone, setPhone] = useState('')
 
   useEffect(() => {
     if (!tenantId) return
@@ -54,6 +55,10 @@ function WizardSteps() {
     setQrBase(base)
   }
 
+  const handlePhoneSelected = (tel: string) => {
+    setPhone(tel)
+  }
+
   const handleConnected = () => {
     setStep(4)
   }
@@ -61,8 +66,12 @@ function WizardSteps() {
   return (
     <div className="wizard-container max-w-sm mx-auto">
       <OnboardingProgress />
-      {step === 1 && <StepSelectClient onRegistered={handleRegistered} />}
-      {step === 2 && <StepCreateInstance />}
+      {step === 1 && (
+        <StepSelectClient onSelected={handlePhoneSelected} />
+      )}
+      {step === 2 && (
+        <StepCreateInstance phone={phone} onRegistered={handleRegistered} />
+      )}
       {step === 3 && (
         <StepPairing
           qrCodeUrl={qrUrl}

--- a/components/onboarding/StepCreateInstance.tsx
+++ b/components/onboarding/StepCreateInstance.tsx
@@ -1,9 +1,61 @@
 'use client'
-export default function StepCreateInstance() {
+import { useEffect, useState } from 'react'
+import { useOnboarding } from '@/lib/context/OnboardingContext'
+import { useAuthContext } from '@/lib/context/AuthContext'
+
+interface StepCreateInstanceProps {
+  phone: string
+  onRegistered: (url: string, base: string) => void
+}
+
+export default function StepCreateInstance({
+  phone,
+  onRegistered,
+}: StepCreateInstanceProps) {
+  const { setStep, setInstanceName, setApiKey, setLoading } = useOnboarding()
+  const { tenantId } = useAuthContext()
+  const [error, setError] = useState<string>()
+
+  useEffect(() => {
+    const register = async () => {
+      setLoading(true)
+      setError(undefined)
+      try {
+        const res = await fetch('/api/chats/whatsapp/instance', {
+          method: 'POST',
+          headers: {
+            'Content-Type': 'application/json',
+            'x-tenant-id': tenantId!,
+          },
+          body: JSON.stringify({ telefone: `55${phone}` }),
+        })
+        if (!res.ok) throw new Error(await res.text())
+        const d = (await res.json()) as {
+          instance: { instanceId: string; instanceName: string }
+          instanceName?: string
+          apiKey: string
+          qrCodeUrl: string
+          qrBase64: string
+        }
+        setInstanceName(d.instance.instanceName)
+        setApiKey(d.apiKey)
+        onRegistered(d.qrCodeUrl, d.qrBase64)
+        setStep(3)
+      } catch (err: unknown) {
+        setError(err instanceof Error ? err.message : String(err))
+        setStep(1)
+      } finally {
+        setLoading(false)
+      }
+    }
+    if (phone) register()
+  }, [phone, tenantId, onRegistered, setApiKey, setInstanceName, setLoading, setStep])
+
   return (
     <div className="card flex flex-col items-center p-8">
       <span>Configurando sua instância...</span>
       <progress className="progress w-40 mt-4" />
+      {error && <p className="text-red-600 text-sm mt-2">{error}</p>}
     </div>
   )
 }

--- a/components/onboarding/StepSelectClient.tsx
+++ b/components/onboarding/StepSelectClient.tsx
@@ -3,18 +3,15 @@ import { useState } from 'react'
 import { TextField } from '@/components/atoms/TextField'
 import { Button } from '@/components/atoms/Button'
 import { useOnboarding } from '@/lib/context/OnboardingContext'
-import { useAuthContext } from '@/lib/context/AuthContext'
 
 interface StepSelectClientProps {
-  onRegistered: (qrUrl: string, qrBase64: string) => void
+  onSelected: (telefone: string) => void
 }
 
 export default function StepSelectClient({
-  onRegistered,
+  onSelected,
 }: StepSelectClientProps) {
-  const { setStep, setInstanceName, setApiKey, loading, setLoading } =
-    useOnboarding()
-  const { tenantId } = useAuthContext()
+  const { setStep } = useOnboarding()
   const [telefoneLocal, setTelefoneLocal] = useState('')
   const [error, setError] = useState<string>()
 
@@ -40,42 +37,15 @@ export default function StepSelectClient({
     setTelefoneLocal(r)
   }
 
-  const handleRegister = async () => {
+  const handleRegister = () => {
     const raw = telefoneLocal.replace(/\D/g, '')
     if (!/^\d{10,11}$/.test(raw)) {
       setError('Informe DDD + número válido.')
       return
     }
-    setStep(2)
-    setLoading(true)
     setError(undefined)
-    try {
-      const res = await fetch('/api/chats/whatsapp/instance', {
-        method: 'POST',
-        headers: {
-          'Content-Type': 'application/json',
-          'x-tenant-id': tenantId!,
-        },
-        body: JSON.stringify({ telefone: `55${raw}` }),
-      })
-      if (!res.ok) throw new Error(await res.text())
-      const d = (await res.json()) as {
-        instance: { instanceId: string; instanceName: string }
-        instanceName?: string
-        apiKey: string
-        qrCodeUrl: string
-        qrBase64: string
-      }
-      setInstanceName(d.instance.instanceName)
-      setApiKey(d.apiKey)
-      onRegistered(d.qrCodeUrl, d.qrBase64)
-      setStep(3)
-    } catch (err: unknown) {
-      setError(err instanceof Error ? err.message : String(err))
-      setStep(1)
-    } finally {
-      setLoading(false)
-    }
+    onSelected(raw)
+    setStep(2)
   }
 
   return (
@@ -88,8 +58,8 @@ export default function StepSelectClient({
         onChange={handleTelefoneChange}
       />
       {error && <p className="text-red-600 text-sm">{error}</p>}
-      <Button className="mt-2" onClick={handleRegister} disabled={loading}>
-        {loading ? 'Registrando...' : 'Cadastrar'}
+      <Button className="mt-2" onClick={handleRegister}>
+        Cadastrar
       </Button>
     </div>
   )


### PR DESCRIPTION
## Summary
- move instance creation logic from `StepSelectClient` to `StepCreateInstance`
- update `StepSelectClient` to only collect phone number and set step to 2
- call API in `StepCreateInstance` and update onboarding context
- wire new props in `OnboardingWizard`

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_685c9be9147c832cab5d0d8c7aabea40