### PR TITLE
Add onboarding polling tests

### DIFF
--- a/__tests__/StepPairing.test.tsx
+++ b/__tests__/StepPairing.test.tsx
@@ -1,0 +1,62 @@
+/* @vitest-environment jsdom */
+import React from 'react'
+import { render } from '@testing-library/react'
+import { vi, describe, it, expect, beforeEach, afterEach } from 'vitest'
+import StepPairing from '@/components/onboarding/StepPairing'
+import { fetchConnectionState } from '@/hooks/useWhatsappApi'
+import { useOnboarding } from '@/lib/context/OnboardingContext'
+import { useAuthContext } from '@/lib/context/AuthContext'
+
+vi.mock('@/hooks/useWhatsappApi', () => ({
+  fetchConnectionState: vi.fn(),
+  connectInstance: vi.fn(),
+}))
+
+vi.mock('@/lib/context/AuthContext', () => ({
+  useAuthContext: () => ({ tenantId: 't1' }),
+}))
+
+const setConnection = vi.fn()
+vi.mock('@/lib/context/OnboardingContext', () => ({
+  useOnboarding: () => ({
+    instanceName: 'inst',
+    apiKey: 'key',
+    setConnection,
+    loading: false,
+    setLoading: vi.fn(),
+  }),
+}))
+
+
+beforeEach(() => {
+  vi.useFakeTimers()
+  vi.clearAllMocks()
+})
+
+afterEach(() => {
+  vi.useRealTimers()
+})
+
+describe('StepPairing polling', () => {
+  it('tenta novamente ate conectar', async () => {
+    ;(fetchConnectionState as unknown as vi.Mock).mockResolvedValueOnce({
+      instance: { state: 'connecting' },
+    }).mockResolvedValueOnce({
+      instance: { state: 'open' },
+    })
+
+    const onConnected = vi.fn()
+    render(<StepPairing qrCodeUrl="u" qrBase64="b" onConnected={onConnected} />)
+
+    await vi.advanceTimersByTimeAsync(10000)
+    expect(fetchConnectionState).toHaveBeenCalledTimes(1)
+    expect(onConnected).not.toHaveBeenCalled()
+
+    await vi.advanceTimersByTimeAsync(10000)
+    expect(fetchConnectionState).toHaveBeenCalledTimes(2)
+    expect(onConnected).toHaveBeenCalled()
+    expect(setConnection).toHaveBeenCalledWith('connected')
+  })
+})
+
+

--- a/__tests__/StepSendTest.test.tsx
+++ b/__tests__/StepSendTest.test.tsx
@@ -1,0 +1,39 @@
+/* @vitest-environment jsdom */
+import React from 'react'
+import { render, screen, fireEvent } from '@testing-library/react'
+import { vi, describe, it, expect, beforeEach } from 'vitest'
+import StepSendTest from '@/components/onboarding/StepSendTest'
+
+vi.mock('@/lib/context/AuthContext', () => ({
+  useAuthContext: () => ({ tenantId: 't1' }),
+}))
+
+const setStep = vi.fn()
+vi.mock('@/lib/context/OnboardingContext', () => ({
+  useOnboarding: () => ({
+    instanceName: 'inst',
+    setStep,
+    loading: false,
+    setLoading: vi.fn(),
+  }),
+}))
+
+beforeEach(() => {
+  vi.clearAllMocks()
+})
+
+describe('StepSendTest', () => {
+  it('exibe erro quando recebe status 409', async () => {
+    global.fetch = vi.fn().mockResolvedValue({ status: 409, ok: false }) as unknown as typeof fetch
+
+    render(<StepSendTest />)
+    const input = screen.getByPlaceholderText('(11) 99999-9999')
+    fireEvent.change(input, { target: { value: '11999999999' } })
+    fireEvent.click(screen.getByText('Enviar Mensagem'))
+
+    await screen.findByText('Teste já executado')
+    expect(setStep).not.toHaveBeenCalled()
+  })
+})
+
+

--- a/__tests__/api/whatsappRoutes.test.ts
+++ b/__tests__/api/whatsappRoutes.test.ts
@@ -1,26 +1,20 @@
 import { describe, it, expect, vi } from 'vitest'
 import { POST as POST_INSTANCE } from '../../app/api/chats/whatsapp/instance/route'
 import { POST as POST_STATE } from '../../app/api/chats/whatsapp/instance/connectionState/route'
+import { POST as POST_CONNECT } from '../../app/api/chats/whatsapp/instance/connect/route'
 import { POST as POST_SEND } from '../../app/api/chats/whatsapp/message/sendTest/[instanceName]/route'
 import { NextRequest } from 'next/server'
+import createPocketBaseMock from '../mocks/pocketbase'
 
 vi.mock('../../lib/apiAuth', () => ({ requireRole: vi.fn() }))
 import { requireRole } from '../../lib/apiAuth'
+
+const pb = createPocketBaseMock()
 vi.mock('../../lib/pocketbase', () => ({
-  default: vi.fn(() => ({
-    collection: vi.fn(() => ({
-      getOne: vi.fn(),
-      getFirstListItem: vi.fn(),
-      update: vi.fn(),
-    })),
-    admins: { authWithPassword: vi.fn() },
-    authStore: { isValid: true },
-  })),
+  default: vi.fn(() => pb),
 }))
 
-const pbMock = (requireRole as unknown as { mockReturnValue: (v: any) => void })
-
-pbMock.mockReturnValue({ pb: {} as any, user: {} })
+(requireRole as unknown as { mockReturnValue: (v: any) => void }).mockReturnValue({ pb, user: {} })
 
 describe('POST /api/chats/whatsapp/instance', () => {
   it('retorna 400 quando tenant ausente', async () => {
@@ -87,3 +81,62 @@ describe('POST /api/chats/whatsapp/message/sendTest/[instanceName]', () => {
     expect(body.error).toBe('Tenant ausente')
   })
 })
+
+describe('POST /api/chats/whatsapp/instance/connect', () => {
+  it('retorna 404 quando instancia inexistente', async () => {
+    pb.collection.mockReturnValueOnce({ getFullList: vi.fn().mockResolvedValue([]) })
+    const req = new Request('http://test', {
+      method: 'POST',
+      headers: { 'x-tenant-id': 't1' },
+      body: JSON.stringify({ instanceName: 'i', apiKey: 'k' }),
+    })
+    ;(req as any).nextUrl = new URL('http://test')
+    const res = await POST_CONNECT(req as unknown as NextRequest)
+    expect(res.status).toBe(404)
+  })
+
+  it('retorna dados de QR quando sucesso', async () => {
+    const getFullList = vi.fn().mockResolvedValue([{ id: '1' }])
+    const update = vi.fn().mockResolvedValue({ qrCode: 'url.png' })
+    pb.collection.mockReturnValue({ getFullList, update })
+    global.fetch = vi.fn().mockResolvedValue({
+      ok: true,
+      json: () => Promise.resolve({ pairingCode: 'p', base64: 'abc' }),
+    }) as unknown as typeof fetch
+    const req = new Request('http://test', {
+      method: 'POST',
+      headers: { 'x-tenant-id': 't1' },
+      body: JSON.stringify({ instanceName: 'i', apiKey: 'k' }),
+    })
+    ;(req as any).nextUrl = new URL('http://test')
+    const res = await POST_CONNECT(req as unknown as NextRequest)
+    expect(res.status).toBe(200)
+    const body = await res.json()
+    expect(body.pairingCode).toBe('p')
+    expect(body.qrCodeUrl).toBe('url.png')
+    expect(body.qrBase64).toBe('abc')
+  })
+})
+
+describe('POST /api/chats/whatsapp/instance/connectionState sucesso', () => {
+  it('atualiza status para connected quando aberto', async () => {
+    const getFullList = vi.fn().mockResolvedValue([{ id: '1' }])
+    const update = vi.fn()
+    pb.collection.mockReturnValue({ getFullList, update })
+    global.fetch = vi.fn().mockResolvedValue({
+      ok: true,
+      json: () => Promise.resolve({ instance: { state: 'open' } }),
+    }) as unknown as typeof fetch
+    const req = new Request('http://test', {
+      method: 'POST',
+      headers: { 'x-tenant-id': 't1' },
+      body: JSON.stringify({ instanceName: 'i', apiKey: 'k' }),
+    })
+    ;(req as any).nextUrl = new URL('http://test')
+    const res = await POST_STATE(req as unknown as NextRequest)
+    expect(res.status).toBe(200)
+    expect(update).toHaveBeenCalledWith('1', { sessionStatus: 'connected' })
+  })
+})
+
+


### PR DESCRIPTION
## Summary
- add polling test for StepPairing
- test StepSendTest error 409 handling
- cover whatsapp connect and connection state routes
- run lint and build

## Testing
- `npm run lint`
- `npm run build`
- `npm test` *(fails: 15 failed, 48 passed)*

------
https://chatgpt.com/codex/tasks/task_e_685c9c0711d0832cadedaef6e016f160