### PR TITLE
Remove NEXT_PUBLIC_N8N_WEBHOOK_URL

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -9,7 +9,6 @@ ASAAS_WEBHOOK_SECRET=
 NEXT_PUBLIC_BRASILAPI_URL=https://brasilapi.com.br/api
 ASAAS_API_URL=https://sandbox.asaas.com/api/v3/
 NEXT_PUBLIC_VIA_CEP_URL=https://viacep.com.br/ws
-NEXT_PUBLIC_N8N_WEBHOOK_URL=
 WALLETID_M24=906c2a75-b67a-4263-bee1-6bccca34feb3
 SMTP_HOST=
 SMTP_PORT=

--- a/README.md
+++ b/README.md
@@ -98,7 +98,6 @@ Crie um arquivo `.env.local` na raiz e defina as seguintes variáveis:
 - `PB_ADMIN_PASSWORD` - senha do administrador
 - `ASAAS_API_URL` - URL base da API do Asaas (ex.: `https://api-sandbox.asaas.com/api/v3/`)
 - `NEXT_PUBLIC_BRASILAPI_URL` - base para chamadas à BrasilAPI
-- `NEXT_PUBLIC_N8N_WEBHOOK_URL` - URL do webhook do n8n para receber inscrições
 - `SMTP_HOST`, `SMTP_PORT`, `SMTP_SECURE`, `SMTP_USER`, `SMTP_PASS` e `SMTP_FROM` - credenciais SMTP padrão para envio de e-mails (definidas em `clientes_config`; para `SMTP_USER` e `SMTP_PASS` solicite acesso ao administrador do PocketBase)
 
 Os servidores identificam automaticamente o tenant **priorizando o domínio** de cada requisição por meio da função `getTenantFromHost`, que consulta a coleção `clientes_config` para descobrir o ID do cliente.

--- a/logs/DOC_LOG.md
+++ b/logs/DOC_LOG.md
@@ -426,3 +426,5 @@
 ## [2025-06-25] OnboardingWizard adaptado ao design system: TextField, Button e
 classes card/progress aplicados. TenantId lido do AuthContext. Lint e build
 executados.
+
+## [2025-06-26] Variavel NEXT_PUBLIC_N8N_WEBHOOK_URL removida do README e .env.example. Integracao n8n depreciada.


### PR DESCRIPTION
## Summary
- remove `NEXT_PUBLIC_N8N_WEBHOOK_URL` from `.env.example`
- update README removing reference to the n8n webhook variable
- log variable deprecation in `DOC_LOG.md`

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_685ca063d488832c84738a4fa3ca5ca8