### PR TITLE
Show connected number in onboarding

### DIFF
--- a/app/api/chats/whatsapp/instance/check/route.ts
+++ b/app/api/chats/whatsapp/instance/check/route.ts
@@ -51,6 +51,7 @@ export async function GET(req: NextRequest) {
     {
       instanceName: rec.instanceName,
       apiKey: rec.apiKey,
+      telefone: rec.telefone,
       sessionStatus: rec.sessionStatus,
     },
     { status: 200 },

--- a/app/api/chats/whatsapp/instance/delete/route.ts
+++ b/app/api/chats/whatsapp/instance/delete/route.ts
@@ -1,0 +1,54 @@
+import { NextRequest, NextResponse } from 'next/server'
+import createPocketBase from '@/lib/pocketbase'
+import { requireRole } from '@/lib/apiAuth'
+
+export async function DELETE(req: NextRequest) {
+  const tenant = req.headers.get('x-tenant-id')
+  if (!tenant) {
+    return NextResponse.json({ error: 'Tenant ausente' }, { status: 400 })
+  }
+
+  const auth = requireRole(req, ['coordenador', 'admin'])
+  if ('error' in auth) {
+    return NextResponse.json({ error: auth.error }, { status: auth.status })
+  }
+
+  const pb = createPocketBase()
+  if (!pb.authStore.isValid) {
+    await pb.admins.authWithPassword(
+      process.env.PB_ADMIN_EMAIL!,
+      process.env.PB_ADMIN_PASSWORD!,
+    )
+  }
+
+  const list = await pb
+    .collection('whatsapp_clientes')
+    .getFullList({ filter: `cliente="${tenant}"`, limit: 1 })
+
+  if (list.length === 0) {
+    return NextResponse.json({ error: 'registro_nao_encontrado' }, { status: 404 })
+  }
+
+  const rec = list[0]
+  const instanceName = rec.instanceName
+  const apiKey = rec.apiKey
+
+  // tenta deslogar e remover na Evolution (ignora erros)
+  try {
+    await fetch(`${process.env.EVOLUTION_API_URL}/instance/logout/${instanceName}`, {
+      method: 'DELETE',
+      headers: { apikey: apiKey },
+    })
+  } catch {}
+
+  try {
+    await fetch(`${process.env.EVOLUTION_API_URL}/instance/delete/${instanceName}`, {
+      method: 'DELETE',
+      headers: { apikey: apiKey },
+    })
+  } catch {}
+
+  await pb.collection('whatsapp_clientes').delete(rec.id)
+
+  return NextResponse.json({ ok: true }, { status: 200 })
+}

--- a/components/admin/OnboardingWizard.tsx
+++ b/components/admin/OnboardingWizard.tsx
@@ -15,16 +15,22 @@ import {
 type CheckResponse = {
   instanceName: string
   apiKey: string
+  telefone: string
   sessionStatus: 'pending' | 'connected' | 'disconnected'
 } | null
 
 function WizardSteps() {
-  const { step, setStep, setInstanceName, setApiKey, setConnection } =
-    useOnboarding()
+  const {
+    step,
+    setStep,
+    setInstanceName,
+    setApiKey,
+    setConnection,
+    setTelefone,
+  } = useOnboarding()
   const { tenantId } = useAuthContext()
   const [qrUrl, setQrUrl] = useState('')
   const [qrBase, setQrBase] = useState('')
-  const [phone, setPhone] = useState('')
 
   useEffect(() => {
     if (!tenantId) return
@@ -37,6 +43,7 @@ function WizardSteps() {
         if (!check) return
         setInstanceName(check.instanceName)
         setApiKey(check.apiKey)
+        setTelefone(check.telefone)
         if (check.sessionStatus === 'connected') {
           setConnection('connected')
           setStep(5)
@@ -48,16 +55,13 @@ function WizardSteps() {
         /* ignore */
       }
     })()
-  }, [tenantId, setStep, setInstanceName, setApiKey, setConnection])
+  }, [tenantId, setStep, setInstanceName, setApiKey, setConnection, setTelefone])
 
   const handleRegistered = (url: string, base: string) => {
     setQrUrl(url)
     setQrBase(base)
   }
 
-  const handlePhoneSelected = (tel: string) => {
-    setPhone(tel)
-  }
 
   const handleConnected = () => {
     setStep(4)
@@ -66,11 +70,9 @@ function WizardSteps() {
   return (
     <div className="wizard-container max-w-sm mx-auto">
       <OnboardingProgress />
-      {step === 1 && (
-        <StepSelectClient onSelected={handlePhoneSelected} />
-      )}
+      {step === 1 && <StepSelectClient />}
       {step === 2 && (
-        <StepCreateInstance phone={phone} onRegistered={handleRegistered} />
+        <StepCreateInstance onRegistered={handleRegistered} />
       )}
       {step === 3 && (
         <StepPairing

--- a/components/onboarding/StepComplete.tsx
+++ b/components/onboarding/StepComplete.tsx
@@ -1,8 +1,57 @@
 'use client'
+import { CheckCircle } from 'lucide-react'
+import { Button } from '@/components/atoms/Button'
+import { useOnboarding } from '@/lib/context/OnboardingContext'
+import { useAuthContext } from '@/lib/context/AuthContext'
+import { useState } from 'react'
+
 export default function StepComplete() {
+  const { telefone, setStep, setConnection } = useOnboarding()
+  const { tenantId } = useAuthContext()
+  const [loading, setLoading] = useState(false)
+
+  const maskPhone = (digits: string) => {
+    const d = digits.slice(0, 2)
+    const n = digits.slice(2)
+    let p1 = ''
+    let p2 = ''
+    if (n.length <= 4) p1 = n
+    else if (n.length <= 8) {
+      p1 = n.slice(0, 4)
+      p2 = n.slice(4)
+    } else {
+      p1 = n.slice(0, 5)
+      p2 = n.slice(5)
+    }
+    return `(${d}) ${p1}${p2 ? '-' + p2 : ''}`
+  }
+
+  const handleDisconnect = async () => {
+    setLoading(true)
+    try {
+      await fetch('/api/chats/whatsapp/instance/delete', {
+        method: 'DELETE',
+        headers: { 'x-tenant-id': tenantId! },
+      })
+      setConnection('idle')
+      setStep(1)
+    } finally {
+      setLoading(false)
+    }
+  }
+
   return (
-    <div className="card p-4 text-center">
-      <p>Conectado com sucesso!</p>
+    <div className="card p-4 text-center flex flex-col items-center gap-2">
+      <CheckCircle className="text-green-600 w-8 h-8" />
+      <p className="font-medium">Número conectado:</p>
+      <p>{maskPhone(telefone)}</p>
+      <Button variant="secondary" onClick={handleDisconnect} disabled={loading}>
+        {loading ? 'Desconectando...' : 'Desconectar'}
+      </Button>
+      <p className="text-xs text-neutral-600 mt-1 text-center">
+        Apenas um número por cliente. Para usar outro número, desconecte e
+        reinicie o processo.
+      </p>
     </div>
   )
 }

--- a/components/onboarding/StepCreateInstance.tsx
+++ b/components/onboarding/StepCreateInstance.tsx
@@ -4,15 +4,11 @@ import { useOnboarding } from '@/lib/context/OnboardingContext'
 import { useAuthContext } from '@/lib/context/AuthContext'
 
 interface StepCreateInstanceProps {
-  phone: string
   onRegistered: (url: string, base: string) => void
 }
 
-export default function StepCreateInstance({
-  phone,
-  onRegistered,
-}: StepCreateInstanceProps) {
-  const { setStep, setInstanceName, setApiKey, setLoading } = useOnboarding()
+export default function StepCreateInstance({ onRegistered }: StepCreateInstanceProps) {
+  const { telefone, setStep, setInstanceName, setApiKey, setLoading } = useOnboarding()
   const { tenantId } = useAuthContext()
   const [error, setError] = useState<string>()
 
@@ -27,7 +23,7 @@ export default function StepCreateInstance({
             'Content-Type': 'application/json',
             'x-tenant-id': tenantId!,
           },
-          body: JSON.stringify({ telefone: `55${phone}` }),
+          body: JSON.stringify({ telefone: `55${telefone}` }),
         })
         if (!res.ok) throw new Error(await res.text())
         const d = (await res.json()) as {
@@ -48,8 +44,8 @@ export default function StepCreateInstance({
         setLoading(false)
       }
     }
-    if (phone) register()
-  }, [phone, tenantId, onRegistered, setApiKey, setInstanceName, setLoading, setStep])
+    if (telefone) register()
+  }, [telefone, tenantId, onRegistered, setApiKey, setInstanceName, setLoading, setStep])
 
   return (
     <div className="card flex flex-col items-center p-8">

--- a/components/onboarding/StepSelectClient.tsx
+++ b/components/onboarding/StepSelectClient.tsx
@@ -4,14 +4,8 @@ import { TextField } from '@/components/atoms/TextField'
 import { Button } from '@/components/atoms/Button'
 import { useOnboarding } from '@/lib/context/OnboardingContext'
 
-interface StepSelectClientProps {
-  onSelected: (telefone: string) => void
-}
-
-export default function StepSelectClient({
-  onSelected,
-}: StepSelectClientProps) {
-  const { setStep } = useOnboarding()
+export default function StepSelectClient() {
+  const { setStep, setTelefone } = useOnboarding()
   const [telefoneLocal, setTelefoneLocal] = useState('')
   const [error, setError] = useState<string>()
 
@@ -44,7 +38,7 @@ export default function StepSelectClient({
       return
     }
     setError(undefined)
-    onSelected(raw)
+    setTelefone(raw)
     setStep(2)
   }
 

--- a/docs/Evolution/whatsapp_onboarding.md
+++ b/docs/Evolution/whatsapp_onboarding.md
@@ -11,9 +11,10 @@
 2. [Check de Existência](#2-check-de-existência)
 3. [Polling de Conexão](#3-polling-de-conexão)
 4. [Envio de Mensagem de Teste](#4-envio-de-mensagem-de-teste)
-5. [Envio de Mensagem (Produção)](#5-envio-de-mensagem-produção)
-6. [Fluxo Front-end (React)](#6-fluxo-front-end-react)
-7. [Boas Práticas](#7-boas-práticas)
+5. [Exclusão de Instância](#5-exclusao-de-instancia)
+6. [Envio de Mensagem (Produção)](#6-envio-de-mensagem-produção)
+7. [Fluxo Front-end (React)](#7-fluxo-front-end-react)
+8. [Boas Práticas](#8-boas-práticas)
 
 ---
 
@@ -80,6 +81,7 @@ Editar
 {
 "instanceName": "nome-do-cliente",
 "apiKey": "…",
+"telefone": "5511999999999",
 "sessionStatus": "pending" | "connected" | "disconnected"
 } 3. Polling de Conexão
 POST /api/chats/whatsapp/instance/connectionState
@@ -147,7 +149,24 @@ Erros
 
 500 se falha na API externa
 
-5. Envio de Mensagem (Produção)
+5. Exclusão de Instância
+   DELETE /api/chats/whatsapp/instance/delete
+
+Headers
+
+x-tenant-id: <tenantId>
+
+Resposta 200
+
+json
+Copiar
+Editar
+{
+"ok": true
+}
+
+---
+6. Envio de Mensagem (Produção)
    POST /api/chats/whatsapp/message/sendText/{instanceName}
 
 Headers
@@ -170,7 +189,7 @@ Resposta 200
 
 Erros: 400 / 404 / 500 conforme validações
 
-6. Fluxo Front-end (React)
+7. Fluxo Front-end (React)
    Step 1: usuário insere DDD+número → chama /cadastrar.
 
 Step 2: mostra spinner até resposta.
@@ -181,7 +200,7 @@ Step 4: ao detectar state === open, exibe campo de destino e chama /sendTest/{in
 
 Step 5: exibe mensagem de sucesso e bloqueia reenvio (config_finished = true).
 
-7. Boas Práticas
+8. Boas Práticas
    Utilize middleware para validar pb_auth e x-tenant-id.
 
 Trate erros com try/catch e retorne códigos HTTP adequados.

--- a/lib/context/OnboardingContext.tsx
+++ b/lib/context/OnboardingContext.tsx
@@ -7,12 +7,14 @@ interface OnboardingContextType {
   step: 1 | 2 | 3 | 4 | 5
   instanceName: string
   apiKey: string
+  telefone: string
   connection: ConnectionStatus
   loading: boolean
   setLoading: (v: boolean) => void
   setStep: (s: 1 | 2 | 3 | 4 | 5) => void
   setInstanceName: (v: string) => void
   setApiKey: (v: string) => void
+  setTelefone: (v: string) => void
   setConnection: (v: ConnectionStatus) => void
 }
 
@@ -20,12 +22,14 @@ const OnboardingContext = createContext<OnboardingContextType>({
   step: 1,
   instanceName: '',
   apiKey: '',
+  telefone: '',
   connection: 'idle',
   loading: false,
   setLoading: () => {},
   setStep: () => {},
   setInstanceName: () => {},
   setApiKey: () => {},
+  setTelefone: () => {},
   setConnection: () => {},
 })
 
@@ -37,6 +41,7 @@ export function OnboardingProvider({
   const [step, setStep] = useState<1 | 2 | 3 | 4 | 5>(1)
   const [instanceName, setInstanceName] = useState('')
   const [apiKey, setApiKey] = useState('')
+  const [telefone, setTelefone] = useState('')
   const [connection, setConnection] = useState<ConnectionStatus>('idle')
   const [loading, setLoading] = useState(false)
 
@@ -46,12 +51,14 @@ export function OnboardingProvider({
         step,
         instanceName,
         apiKey,
+        telefone,
         connection,
         loading,
         setLoading,
         setStep,
         setInstanceName,
         setApiKey,
+        setTelefone,
         setConnection,
       }}
     >

--- a/logs/DOC_LOG.md
+++ b/logs/DOC_LOG.md
@@ -426,3 +426,5 @@
 ## [2025-06-25] OnboardingWizard adaptado ao design system: TextField, Button e
 classes card/progress aplicados. TenantId lido do AuthContext. Lint e build
 executados.
+
+## [2025-06-26] Check de instância inclui telefone e criado endpoint DELETE /instance/delete. Documentação atualizada e StepComplete mostra número conectado com opção de desconectar. Lint e build executados.


### PR DESCRIPTION
## Summary
- include phone in instance check response
- allow deleting whatsapp instance
- manage phone via OnboardingContext
- update wizard steps to use context
- show connected number and disconnect option after pairing
- document new `DELETE /instance/delete` endpoint and updated check response

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_685c75ae5318832cb8c06c03796508e4