### PR TITLE
Add onboarding loading overlay

### DIFF
--- a/__tests__/OnboardingWizard.test.tsx
+++ b/__tests__/OnboardingWizard.test.tsx
@@ -1,6 +1,6 @@
 /* @vitest-environment jsdom */
 import React from 'react'
-import { render, screen, fireEvent } from '@testing-library/react'
+import { render, screen, fireEvent, waitFor } from '@testing-library/react'
 import { vi } from 'vitest'
 import OnboardingWizard from '@/components/admin/OnboardingWizard'
 import { useOnboarding } from '@/lib/context/OnboardingContext'
@@ -94,5 +94,23 @@ describe('OnboardingWizard', () => {
     expect(screen.getByText('Step4')).toBeInTheDocument()
     fireEvent.click(screen.getByText('next4'))
     expect(screen.getByText('Step5')).toBeInTheDocument()
+  })
+
+  it('exibe overlay enquanto check pendente', async () => {
+    let resolveFetch: (v: any) => void
+    const fetchPromise = new Promise((resolve) => {
+      resolveFetch = resolve
+    })
+    ;(global.fetch as vi.Mock).mockReturnValueOnce(fetchPromise as any)
+
+    render(<OnboardingWizard />)
+
+    expect(screen.getByText('Carregando...')).toBeInTheDocument()
+
+    resolveFetch({ ok: true, json: () => Promise.resolve(null) })
+
+    await waitFor(() =>
+      expect(screen.queryByText('Carregando...')).not.toBeInTheDocument(),
+    )
   })
 })

--- a/components/admin/OnboardingWizard.tsx
+++ b/components/admin/OnboardingWizard.tsx
@@ -7,6 +7,7 @@ import StepPairing from '../onboarding/StepPairing'
 import StepComplete from '../onboarding/StepComplete'
 import StepSendTest from '../onboarding/StepSendTest'
 import OnboardingProgress from '../onboarding/OnboardingProgress'
+import { LoadingOverlay } from '@/components/organisms'
 import {
   OnboardingProvider,
   useOnboarding,
@@ -27,6 +28,8 @@ function WizardSteps() {
     setApiKey,
     setConnection,
     setTelefone,
+    loading,
+    setLoading,
   } = useOnboarding()
   const { tenantId } = useAuthContext()
   const [qrUrl, setQrUrl] = useState('')
@@ -35,6 +38,7 @@ function WizardSteps() {
   useEffect(() => {
     if (!tenantId) return
     ;(async () => {
+      setLoading(true)
       try {
         const res = await fetch('/api/chats/whatsapp/instance/check', {
           headers: { 'x-tenant-id': tenantId },
@@ -53,9 +57,19 @@ function WizardSteps() {
         }
       } catch {
         /* ignore */
+      } finally {
+        setLoading(false)
       }
     })()
-  }, [tenantId, setStep, setInstanceName, setApiKey, setConnection, setTelefone])
+  }, [
+    tenantId,
+    setStep,
+    setInstanceName,
+    setApiKey,
+    setConnection,
+    setTelefone,
+    setLoading,
+  ])
 
   const handleRegistered = (url: string, base: string) => {
     setQrUrl(url)
@@ -69,6 +83,7 @@ function WizardSteps() {
 
   return (
     <div className="wizard-container max-w-sm mx-auto">
+      <LoadingOverlay show={loading} text="Carregando..." />
       <OnboardingProgress />
       {step === 1 && <StepSelectClient />}
       {step === 2 && (

--- a/logs/DOC_LOG.md
+++ b/logs/DOC_LOG.md
@@ -437,3 +437,4 @@ executados.
 ## [2025-06-26] function-index atualizado: rota /api/n8n removida e adicionada rota Evolution /api/chats/message/sendText. Lint e build executados.
 
 ## [2025-06-26] Variavel NEXT_PUBLIC_N8N_WEBHOOK_URL removida do README e .env.example. Integracao n8n depreciada.
+## [2025-06-26] OnboardingWizard passa a exibir LoadingOverlay enquanto verifica instancia.


### PR DESCRIPTION
## Summary
- add LoadingOverlay to OnboardingWizard and manage state via `useOnboarding`
- show overlay while checking WhatsApp instance
- test overlay visibility during initial check
- log documentation update

## Testing
- `npm run lint` *(fails: `next: not found`)*
- `npm run build` *(fails: `next: not found`)*
- `npm test` *(fails: `vitest: not found`)*

------
https://chatgpt.com/codex/tasks/task_e_685d4367bf18832cb9a09c1bd117cd13