### PR TITLE
Update blog docs

### DIFF
--- a/arquitetura.md
+++ b/arquitetura.md
@@ -63,7 +63,7 @@ Todas coexistem no mesmo projeto Next.js (App Router) hospedado na **Vercel**.
 ├── layout.tsx             # Layout raiz compartilhado
 ├── page.tsx               # Loja do cliente
 ├── globals.css            # CSS global compartilhado
-/posts/                    # Conteúdo do blog em arquivos .mdx
+posts/                    # (legado) posts agora carregados da coleção `posts` do PocketBase
 /scripts/                  # Scripts auxiliares
 /stories/                  # Storybook de componentes
 components/                # Componentes reutilizáveis compartilhados
@@ -78,6 +78,10 @@ logs/                    # Registros de documentação e erros
 ```
 
 ---
+## 🔌 Middleware de Tenant
+
+O arquivo `middleware.ts` intercepta cada requisição, consulta a coleção `clientes_config` do PocketBase para descobrir o tenant associado ao domínio e injeta o cabeçalho `x-tenant-id`. Também grava o cookie `tenantId` para que páginas e APIs identifiquem o cliente ativo sem depender de parâmetros na URL.
+
 
 ## 🌐 Site – Boas Práticas
 
@@ -97,9 +101,9 @@ logs/                    # Registros de documentação e erros
 
 ## ✍️ Blog – Boas Práticas
 
-- Conteúdo em `/posts` no formato MDX
-- Componentes em `app/blog/components`
-- Utilize `BlogClient.tsx` para carregar posts no cliente
+ - Postagens carregadas da coleção `posts` do PocketBase
+ - Componentes em `app/blog/components`
+ - Utilize `BlogClient.tsx` para exibir os posts no cliente
 
 ---
 

--- a/logs/DOC_LOG.md
+++ b/logs/DOC_LOG.md
@@ -440,3 +440,5 @@ executados.
 ## [2025-08-09] Botão de logout adicionado à página de perfil do usuário. Lint e build executados.
 
 ## [2025-06-25] Headers e página de perfil atualizados para aguardar o logout antes de redirecionar. Lint e build executados.
+
+## [2025-06-26] Atualizado arquitetura.md removendo referencia a /posts, descrevendo carregamento via PocketBase e adicionada secao do middleware. Impacto: documentacao alinhada ao README e entendimento claro sobre tenant.


### PR DESCRIPTION
## Summary
- clarify that posts come from PocketBase instead of the `/posts` folder
- mention the tenant middleware
- log the update

## Testing
- `npm run lint` *(fails: next not found)*
- `npm run build` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_685d4bf731c8832cb6a4b76daf52ade8