### PR TITLE
Add email event types and templates

### DIFF
--- a/lib/templates/email/confirmacaoPagamento.html
+++ b/lib/templates/email/confirmacaoPagamento.html
@@ -1,0 +1,35 @@
+<!doctype html>
+<html lang="pt-BR">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Pagamento Confirmado</title>
+  </head>
+  <body style="margin: 0; padding: 0; background: var(--background); font-family: var(--font-body);">
+    <span style="display: none; font-size: 1px; line-height: 1px; max-height: 0; max-width: 0; opacity: 0; overflow: hidden;">Pagamento recebido</span>
+    <table width="100%" cellpadding="0" cellspacing="0" role="presentation">
+      <tr>
+        <td align="center" style="padding: var(--space-md)">
+          <table width="600" cellpadding="0" cellspacing="0" role="presentation" class="card">
+            <tr>
+              <td align="center" style="padding: var(--space-lg)">
+                <img src="{{logoUrl}}" alt="Logo" width="120" />
+              </td>
+            </tr>
+            <tr>
+              <td style="padding: var(--space-md); color: var(--text-primary)">
+                <h2 class="heading" style="color: {{cor_primary}};">Pagamento recebido!</h2>
+                <p>Sua inscrição está confirmada.</p>
+              </td>
+            </tr>
+            <tr>
+              <td style="padding: var(--space-md); font-size: 0.875rem; color: var(--text-secondary); text-align: center;">
+                <p>Se não solicitou este e‑mail, ignore-o.</p>
+              </td>
+            </tr>
+          </table>
+        </td>
+      </tr>
+    </table>
+  </body>
+</html>

--- a/lib/templates/email/novoUsuario.html
+++ b/lib/templates/email/novoUsuario.html
@@ -1,0 +1,35 @@
+<!doctype html>
+<html lang="pt-BR">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Novo Usuário</title>
+  </head>
+  <body style="margin: 0; padding: 0; background: var(--background); font-family: var(--font-body);">
+    <span style="display: none; font-size: 1px; line-height: 1px; max-height: 0; max-width: 0; opacity: 0; overflow: hidden;">Conta criada com sucesso</span>
+    <table width="100%" cellpadding="0" cellspacing="0" role="presentation">
+      <tr>
+        <td align="center" style="padding: var(--space-md)">
+          <table width="600" cellpadding="0" cellspacing="0" role="presentation" class="card">
+            <tr>
+              <td align="center" style="padding: var(--space-lg)">
+                <img src="{{logoUrl}}" alt="Logo" width="120" />
+              </td>
+            </tr>
+            <tr>
+              <td style="padding: var(--space-md); color: var(--text-primary)">
+                <h2 class="heading" style="color: {{cor_primary}};">Olá, {{userName}}!</h2>
+                <p>Sua conta foi criada com sucesso em {{tenantNome}}.</p>
+              </td>
+            </tr>
+            <tr>
+              <td style="padding: var(--space-md); font-size: 0.875rem; color: var(--text-secondary); text-align: center;">
+                <p>Se não solicitou este e‑mail, ignore-o.</p>
+              </td>
+            </tr>
+          </table>
+        </td>
+      </tr>
+    </table>
+  </body>
+</html>


### PR DESCRIPTION
## Summary
- extend `Body.eventType` to accept `novo_usuario` and `confirmacao_pagamento`
- add email templates for new user and payment confirmation
- load new templates in `app/api/email/route.ts`

## Testing
- `npm run lint` *(fails: next not found)*
- `npm run build` *(fails: next not found)*
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_685d4d99e5dc832c96311b260d5d3f25