### PR TITLE
Implementa notificações após pagamento

### DIFF
--- a/app/api/chats/message/sendWelcome/route.ts
+++ b/app/api/chats/message/sendWelcome/route.ts
@@ -75,7 +75,7 @@ export async function POST(req: NextRequest) {
         message = `Olá ${nome}! Seu cadastro foi realizado com sucesso.`
         break
       case 'confirmacao_pagamento':
-        message = `Pagamento confirmado! Nos vemos em breve.`
+        message = `Olá ${nome}, recebemos seu pagamento. Obrigado!`
         break
       default:
         message = ''


### PR DESCRIPTION
## Summary
- envia mensagem customizada via sendWelcome em confirmações de pagamento
- notifica o responsável por e-mail e WhatsApp após atualizar o pedido

## Testing
- `npm run lint` *(fails: next not found)*
- `npm run build` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_685d4feed480832c8d60232d731e2ecc