### PR TITLE
Add welcome notifications on signup

### DIFF
--- a/app/api/signup/route.ts
+++ b/app/api/signup/route.ts
@@ -22,6 +22,31 @@ export async function POST(req: NextRequest) {
       role: 'usuario',
       ...(tenantId ? { cliente: tenantId } : {}),
     })
+
+    try {
+      await fetch('/api/email', {
+        method: 'POST',
+        body: JSON.stringify({
+          eventType: 'novo_usuario',
+          userId: usuario.id,
+        }),
+      })
+    } catch (err) {
+      console.error('Falha ao enviar email de boas-vindas', err)
+    }
+
+    try {
+      await fetch('/api/chats/message/sendWelcome', {
+        method: 'POST',
+        body: JSON.stringify({
+          eventType: 'novo_usuario',
+          userId: usuario.id,
+        }),
+      })
+    } catch (err) {
+      console.error('Falha ao enviar mensagem de boas-vindas', err)
+    }
+
     return NextResponse.json(usuario, { status: 201 })
   } catch (err: unknown) {
     const e = err as { response?: { data?: unknown } }


### PR DESCRIPTION
## Summary
- trigger welcome email and chat message after signup
- log failures without blocking response

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_685d4fde001c832cbd266ca762e322b0