### PR TITLE
Fix user lookup in loja inscricoes and add notification tests

### DIFF
--- a/__tests__/api/asaasWebhookRoute.test.ts
+++ b/__tests__/api/asaasWebhookRoute.test.ts
@@ -1,0 +1,72 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { POST } from '../../app/api/asaas/webhook/route'
+import { NextRequest } from 'next/server'
+import createPocketBaseMock from '../mocks/pocketbase'
+
+const pb = createPocketBaseMock()
+const getFirstConfig = vi.fn()
+const getOneConfig = vi.fn()
+const getFirstPedido = vi.fn()
+const updatePedido = vi.fn()
+const updateInscricao = vi.fn()
+
+pb.collection.mockImplementation((name: string) => {
+  if (name === 'clientes_config')
+    return { getFirstListItem: getFirstConfig, getOne: getOneConfig }
+  if (name === 'pedidos')
+    return { getFirstListItem: getFirstPedido, update: updatePedido, getList: vi.fn() }
+  if (name === 'inscricoes')
+    return { update: updateInscricao, getOne: vi.fn() }
+  return {} as any
+})
+
+vi.mock('../../lib/pocketbase', () => ({
+  default: vi.fn(() => pb),
+}))
+
+vi.mock('../../lib/server/logger', () => ({ logConciliacaoErro: vi.fn() }))
+
+beforeEach(() => {
+  vi.clearAllMocks()
+  process.env.ASAAS_API_URL = 'http://asaas'
+  getFirstConfig.mockResolvedValue({ asaas_api_key: '$key', id: 'cli1', nome: 'Cli' })
+  getOneConfig.mockResolvedValue({ asaas_api_key: '$key', id: 'cli1', nome: 'Cli' })
+  getFirstPedido.mockResolvedValue({ id: 'p1', responsavel: 'u1' })
+  updatePedido.mockResolvedValue({})
+  updateInscricao.mockResolvedValue({})
+})
+
+describe('POST /api/asaas/webhook', () => {
+  it('envia notificacoes quando pagamento confirmado', async () => {
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValueOnce({
+        ok: true,
+        json: () => Promise.resolve({
+          status: 'RECEIVED',
+          externalReference: 'cliente_cli1_usuario_u1_inscricao_ins1',
+          customer: 'c1',
+        }),
+      })
+      .mockResolvedValue({ ok: true, json: () => Promise.resolve({}) })
+    global.fetch = fetchMock as unknown as typeof fetch
+
+    const payload = {
+      payment: { id: 'pay1', accountId: 'acc1' },
+      event: 'PAYMENT_RECEIVED',
+    }
+    const req = new Request('http://test/api/asaas/webhook', {
+      method: 'POST',
+      body: JSON.stringify(payload),
+    })
+    ;(req as any).nextUrl = new URL('http://test/api/asaas/webhook')
+
+    const res = await POST(req as unknown as NextRequest)
+    expect(res.status).toBe(200)
+    expect(fetchMock).toHaveBeenCalledWith('http://asaas/payments/pay1', expect.any(Object))
+    expect(fetchMock).toHaveBeenCalledWith('http://test/api/email', expect.any(Object))
+    expect(fetchMock).toHaveBeenCalledWith('http://test/api/chats/message/sendWelcome', expect.any(Object))
+    const body = JSON.parse((fetchMock.mock.calls[1][1] as any).body as string)
+    expect(body.userId).toBe('u1')
+  })
+})

--- a/__tests__/api/inscricoesLojaRoute.test.ts
+++ b/__tests__/api/inscricoesLojaRoute.test.ts
@@ -97,4 +97,39 @@ describe('POST /loja/api/inscricoes', () => {
       }),
     )
   })
+
+  it('envia notificacoes apos inscricao', async () => {
+    getFirstMock.mockRejectedValueOnce(new Error('not found'))
+    createUserMock.mockResolvedValueOnce({ id: 'u3' })
+    createInscricaoMock.mockResolvedValueOnce({ id: 'i3' })
+    const fetchMock = vi.fn().mockResolvedValue({ ok: true })
+    global.fetch = fetchMock as unknown as typeof fetch
+
+    const req = new Request('http://test', {
+      method: 'POST',
+      body: JSON.stringify({
+        user_first_name: 'J',
+        user_last_name: 'D',
+        user_email: 'n@test.com',
+        user_phone: '11999999999',
+        user_cpf: '11111111111',
+        user_birth_date: '2000-01-01',
+        user_gender: 'masculino',
+        campo: 'c1',
+        evento: 'e1',
+      }),
+    })
+    const res = await POST(req as unknown as NextRequest)
+    expect(res.status).toBe(201)
+    expect(fetchMock).toHaveBeenCalledWith(
+      'http://test/api/email',
+      expect.any(Object),
+    )
+    expect(fetchMock).toHaveBeenCalledWith(
+      'http://test/api/chats/message/sendWelcome',
+      expect.any(Object),
+    )
+    const body = JSON.parse((fetchMock.mock.calls[0][1] as any).body as string)
+    expect(body.userId).toBe('u3')
+  })
 })

--- a/app/loja/api/inscricoes/route.ts
+++ b/app/loja/api/inscricoes/route.ts
@@ -20,42 +20,38 @@ export async function POST(req: NextRequest) {
     const senha = data.password || data.passwordConfirm
 
     let usuario
-    if (pb.authStore.isValid && pb.authStore.model) {
-      usuario = pb.authStore.model
-    } else {
-      try {
-        usuario = await pb
-          .collection('usuarios')
-          .getFirstListItem(`email='${data.user_email}'`)
-      } catch {
-        if (!tenantId) {
-          return NextResponse.json(
-            { error: 'Tenant não informado' },
-            { status: 400 },
-          )
-        }
-        const tempPass = Math.random().toString(36).slice(2, 10)
-        usuario = await pb.collection('usuarios').create({
-          nome,
-          email: data.user_email,
-          cpf: String(data.user_cpf).replace(/\D/g, ''),
-          telefone: String(data.user_phone).replace(/\D/g, ''),
-          data_nascimento: data.user_birth_date,
-          genero: data.user_gender?.toLowerCase(),
-          endereco: data.user_address,
-          bairro: data.user_neighborhood,
-          cep: data.user_cep,
-          cidade: data.user_city,
-          estado: data.user_state,
-          numero: data.user_number,
-          cliente: tenantId,
-          campo: data.campo,
-          perfil: 'usuario',
-          role: 'usuario',
-          password: senha || tempPass,
-          passwordConfirm: senha || tempPass,
-        })
+    try {
+      usuario = await pb
+        .collection('usuarios')
+        .getFirstListItem(`email='${data.user_email}'`)
+    } catch {
+      if (!tenantId) {
+        return NextResponse.json(
+          { error: 'Tenant não informado' },
+          { status: 400 },
+        )
       }
+      const tempPass = Math.random().toString(36).slice(2, 10)
+      usuario = await pb.collection('usuarios').create({
+        nome,
+        email: data.user_email,
+        cpf: String(data.user_cpf).replace(/\D/g, ''),
+        telefone: String(data.user_phone).replace(/\D/g, ''),
+        data_nascimento: data.user_birth_date,
+        genero: data.user_gender?.toLowerCase(),
+        endereco: data.user_address,
+        bairro: data.user_neighborhood,
+        cep: data.user_cep,
+        cidade: data.user_city,
+        estado: data.user_state,
+        numero: data.user_number,
+        cliente: tenantId,
+        campo: data.campo,
+        perfil: 'usuario',
+        role: 'usuario',
+        password: senha || tempPass,
+        passwordConfirm: senha || tempPass,
+      })
     }
 
     const base: InscricaoTemplate = {


### PR DESCRIPTION
## Summary
- ensure `POST /loja/api/inscricoes` always fetches or creates user by email
- verify email/chat notifications in loja inscricoes route
- test webhook notification flow on payment confirmation

## Testing
- `npm run lint`
- `npm run build`
- `npx vitest run` *(fails: TypeError: Cannot read properties of undefined (reading 'id') and other failing tests)*

------
https://chatgpt.com/codex/tasks/task_e_685d5f53d4d8832cb4f06c78d93f7cce