### PR TITLE
Add preco_bruto to products

### DIFF
--- a/__tests__/CarrinhoPreco.test.tsx
+++ b/__tests__/CarrinhoPreco.test.tsx
@@ -5,7 +5,6 @@ import { vi, describe, it, expect } from 'vitest'
 import CarrinhoPage from '@/app/loja/carrinho/page'
 import CartPreview from '@/components/molecules/CartPreview'
 import { CartProvider } from '@/lib/context/CartContext'
-import { calculateGross } from '@/lib/asaasFees'
 
 vi.mock('next/image', () => ({
   __esModule: true,
@@ -26,18 +25,20 @@ vi.mock('@/lib/context/AuthContext', () => ({
 }))
 
 function renderWithItem() {
+  const preco_bruto = 50
   const preco = 50
   const item = {
     id: '1',
     nome: 'Prod',
     preco,
+    preco_bruto,
     imagens: ['/img.jpg'],
     slug: 'prod',
     quantidade: 1,
     variationId: '1',
   }
   window.localStorage.setItem('carrinho', JSON.stringify([item]))
-  return { preco }
+  return { preco_bruto }
 }
 
 function renderWithItems() {
@@ -45,6 +46,7 @@ function renderWithItems() {
     id: '1',
     nome: 'Prod1',
     preco: 10,
+    preco_bruto: 10,
     imagens: ['/img1.jpg'],
     slug: 'prod1',
     quantidade: 1,
@@ -54,6 +56,7 @@ function renderWithItems() {
     id: '2',
     nome: 'Prod2',
     preco: 20,
+    preco_bruto: 20,
     imagens: ['/img2.jpg'],
     slug: 'prod2',
     quantidade: 2,
@@ -65,8 +68,8 @@ function renderWithItems() {
 
 describe('CarrinhoPage', () => {
   it('mostra valor bruto do item', async () => {
-    const { preco } = renderWithItem()
-    const gross = calculateGross(preco, 'pix', 1).gross
+    const { preco_bruto } = renderWithItem()
+    const gross = preco_bruto
     render(
       <CartProvider>
         <CarrinhoPage />
@@ -81,8 +84,8 @@ describe('CarrinhoPage', () => {
 
 describe('CartPreview', () => {
   it('mostra total bruto calculado', () => {
-    const { preco } = renderWithItem()
-    const gross = calculateGross(preco, 'pix', 1).gross
+    const { preco_bruto } = renderWithItem()
+    const gross = preco_bruto
     render(
       <CartProvider>
         <CartPreview />
@@ -95,10 +98,8 @@ describe('CartPreview', () => {
 
   it('mostra valor bruto de cada item', () => {
     const { item1, item2 } = renderWithItems()
-    const gross1 =
-      calculateGross(item1.preco, 'pix', 1).gross * item1.quantidade
-    const gross2 =
-      calculateGross(item2.preco, 'pix', 1).gross * item2.quantidade
+    const gross1 = item1.preco_bruto * item1.quantidade
+    const gross2 = item2.preco_bruto * item2.quantidade
     render(
       <CartProvider>
         <CartPreview />

--- a/__tests__/ProdutosFiltradosPreco.test.tsx
+++ b/__tests__/ProdutosFiltradosPreco.test.tsx
@@ -3,7 +3,6 @@ import React from 'react'
 import { render, screen } from '@testing-library/react'
 import { describe, it, expect, vi } from 'vitest'
 import ProdutosFiltrados from '@/components/organisms/ProdutosFiltrados'
-import { calculateGross } from '@/lib/asaasFees'
 
 vi.mock('next/image', () => ({
   __esModule: true,
@@ -19,15 +18,15 @@ vi.mock('next/link', () => ({
 
 describe('ProdutosFiltrados', () => {
   it('exibe valor bruto calculado', () => {
-    const precoBase = 100
-    const { gross } = calculateGross(precoBase, 'pix', 1)
+    const precoBruto = 100
     render(
       <ProdutosFiltrados
         produtos={[
           {
             id: '1',
             nome: 'Prod',
-            preco: precoBase,
+            preco: 80,
+            preco_bruto: precoBruto,
             imagens: ['/img.jpg'],
             slug: 'prod',
           },
@@ -35,7 +34,7 @@ describe('ProdutosFiltrados', () => {
       />,
     )
     expect(
-      screen.getByText(`R$ ${gross.toFixed(2).replace('.', ',')}`),
+      screen.getByText(`R$ ${precoBruto.toFixed(2).replace('.', ',')}`),
     ).toBeInTheDocument()
   })
 })

--- a/__tests__/orderFlow.test.ts
+++ b/__tests__/orderFlow.test.ts
@@ -16,8 +16,8 @@ const dadosValidos = {
   tamanho: 'M',
 }
 
-const pulseira = { id: 'p1', nome: 'Somente Pulseira', preco: 10 }
-const kit = { id: 'p2', nome: 'Kit Camisa + Pulseira', preco: 50 }
+const pulseira = { id: 'p1', nome: 'Somente Pulseira', preco: 10, preco_bruto: 10 }
+const kit = { id: 'p2', nome: 'Kit Camisa + Pulseira', preco: 50, preco_bruto: 50 }
 
 describe('Fluxo de inscrição e pedido', () => {
   it('cria inscrição válida com status pendente', () => {

--- a/app/admin/api/produtos/[id]/route.ts
+++ b/app/admin/api/produtos/[id]/route.ts
@@ -2,6 +2,7 @@ import { NextRequest, NextResponse } from 'next/server'
 import { requireRole } from '@/lib/apiAuth'
 import { logInfo } from '@/lib/logger'
 import { logConciliacaoErro } from '@/lib/server/logger'
+import { calculateGross } from '@/lib/asaasFees'
 
 export async function GET(req: NextRequest) {
   const { pathname } = req.nextUrl
@@ -44,6 +45,9 @@ export async function PUT(req: NextRequest) {
     const formData = await req.formData()
 
     formData.set('user_org', user.id)
+    const preco = Number(formData.get('preco') || 0)
+    const bruto = calculateGross(preco, 'pix', 1).gross
+    formData.set('preco_bruto', String(bruto))
 
     logInfo('Atualizando produto', {
       pbHost: pb.baseUrl,

--- a/app/admin/api/produtos/route.ts
+++ b/app/admin/api/produtos/route.ts
@@ -2,6 +2,7 @@ import { NextRequest, NextResponse } from 'next/server'
 import { requireRole } from '@/lib/apiAuth'
 import { logInfo } from '@/lib/logger'
 import { logConciliacaoErro } from '@/lib/server/logger'
+import { calculateGross } from '@/lib/asaasFees'
 
 export async function GET(req: NextRequest) {
   const auth = requireRole(req, 'coordenador')
@@ -33,6 +34,9 @@ export async function POST(req: NextRequest) {
     const formData = await req.formData()
     formData.set('user_org', user.id)
     formData.set('cliente', user.cliente as string)
+    const preco = Number(formData.get('preco') || 0)
+    const bruto = calculateGross(preco, 'pix', 1).gross
+    formData.set('preco_bruto', String(bruto))
     const keys = Array.from(formData.keys())
     logInfo('Criando produto', {
       pbHost: pb.baseUrl,

--- a/app/admin/produtos/editar/[id]/page.tsx
+++ b/app/admin/produtos/editar/[id]/page.tsx
@@ -3,11 +3,11 @@
 import { useEffect, useState, useRef } from 'react'
 import { useParams, useRouter } from 'next/navigation'
 import { useAuthContext } from '@/lib/context/AuthContext'
-import { calculateGross } from '@/lib/asaasFees'
 import LoadingOverlay from '@/components/organisms/LoadingOverlay'
 import { useToast } from '@/lib/context/ToastContext'
 import { useAuthGuard } from '@/lib/hooks/useAuthGuard'
 import ToggleSwitch from '@/components/atoms/ToggleSwitch'
+import { calculateGross } from '@/lib/asaasFees'
 
 interface Categoria {
   id: string
@@ -51,12 +51,12 @@ export default function EditarProdutoPage() {
   const [exclusivo, setExclusivo] = useState(false)
   const inputHex = useRef<HTMLInputElement | null>(null)
   const [valorCliente, setValorCliente] = useState(
-    calculateGross(Number(initial?.preco ?? 0), 'pix', 1).gross,
+    Number(initial?.preco_bruto ?? 0),
   )
 
   useEffect(() => {
-    setValorCliente(calculateGross(Number(initial?.preco ?? 0), 'pix', 1).gross)
-  }, [initial?.preco])
+    setValorCliente(Number(initial?.preco_bruto ?? 0))
+  }, [initial?.preco_bruto])
 
   useEffect(() => {
     if (!authChecked) return

--- a/app/admin/produtos/novo/ModalProduto.tsx
+++ b/app/admin/produtos/novo/ModalProduto.tsx
@@ -88,7 +88,7 @@ export function ModalProduto<T extends Record<string, unknown>>({
   const [cores, setCores] = useState<string[]>([])
   const inputHex = useRef<HTMLInputElement | null>(null)
   const [valorCliente, setValorCliente] = useState(
-    calculateGross(Number(initial.preco ?? 0), 'pix', 1).gross,
+    Number(initial.preco_bruto ?? 0),
   )
 
   useEffect(() => {

--- a/app/api/pedidos/route.ts
+++ b/app/api/pedidos/route.ts
@@ -307,7 +307,7 @@ export async function POST(req: NextRequest) {
       }
     }
 
-    const valor = produtoRecord?.preco ?? 0
+    const valor = produtoRecord?.preco_bruto ?? 0
     console.log('[PEDIDOS][POST] Valor final do pedido:', valor)
 
     const payload = {

--- a/app/loja/carrinho/page.tsx
+++ b/app/loja/carrinho/page.tsx
@@ -6,7 +6,6 @@ import { useRouter } from 'next/navigation'
 import { useAuthContext } from '@/lib/context/AuthContext'
 import { useState } from 'react'
 import { hexToPtName } from '@/utils/colorNamePt'
-import { calculateGross } from '@/lib/asaasFees'
 
 function formatCurrency(n: number) {
   return `R$ ${n.toFixed(2).replace('.', ',')}`
@@ -18,7 +17,7 @@ export default function CarrinhoPage() {
   const router = useRouter()
   const [showPrompt, setShowPrompt] = useState(false)
   const totalBruto = itens.reduce(
-    (sum, i) => sum + calculateGross(i.preco, 'pix', 1).gross * i.quantidade,
+    (sum, i) => sum + (i.preco_bruto || 0) * i.quantidade,
     0,
   )
 
@@ -84,9 +83,7 @@ export default function CarrinhoPage() {
                 <p className="text-xs text-gray-400">Qtd: {item.quantidade}</p>
               </div>
               <div className="font-semibold text-accent">
-                {formatCurrency(
-                  calculateGross(item.preco, 'pix', 1).gross * item.quantidade,
-                )}
+                {formatCurrency(item.preco_bruto * item.quantidade)}
               </div>
               <button
                 onClick={() => removeItem(item.variationId)}

--- a/app/loja/checkout/page.tsx
+++ b/app/loja/checkout/page.tsx
@@ -8,7 +8,7 @@ import { useAuthContext } from '@/lib/context/AuthContext'
 import { useToast } from '@/lib/context/ToastContext'
 import { CheckCircle } from 'lucide-react'
 import { hexToPtName } from '@/utils/colorNamePt'
-import { calculateGross, calculateNet, PaymentMethod } from '@/lib/asaasFees'
+import { calculateNet, PaymentMethod } from '@/lib/asaasFees'
 import {
   MAX_ITEM_DESCRIPTION_LENGTH,
   MAX_ITEM_NAME_LENGTH,
@@ -53,20 +53,12 @@ function CheckoutContent() {
 
   // 2. calcula total bruto
   const totalGross = useMemo(
-    () => calculateGross(total, paymentMethod, installments).gross,
-    [total, paymentMethod, installments],
+    () => itens.reduce((sum, i) => sum + i.preco_bruto * i.quantidade, 0),
+    [itens],
   )
 
-  // 3️⃣ calcula o subtotal bruto somando o bruto de cada item
-  const displayTotalGross = useMemo(() => {
-    return itens.reduce(
-      (sum, i) =>
-        sum +
-        calculateGross(i.preco, paymentMethod, installments).gross *
-          i.quantidade,
-      0,
-    )
-  }, [itens, paymentMethod, installments])
+  // 3️⃣ subtotal bruto (igual ao total para este fluxo)
+  const displayTotalGross = totalGross
 
   useEffect(() => {
     if (user) {
@@ -152,11 +144,7 @@ function CheckoutContent() {
               /* ignore */
             }
           }
-          const grossUnit = calculateGross(
-            i.preco,
-            paymentMethod,
-            installments,
-          ).gross
+          const grossUnit = i.preco_bruto
           return {
             name: i.nome.slice(0, MAX_ITEM_NAME_LENGTH),
             description: i.descricao?.slice(0, MAX_ITEM_DESCRIPTION_LENGTH),
@@ -433,10 +421,7 @@ function CheckoutContent() {
                     </div>
                   </div>
                   <div className="font-semibold">
-                    {formatCurrency(
-                      calculateGross(item.preco, paymentMethod, installments)
-                        .gross * item.quantidade,
-                    )}
+                    {formatCurrency(item.preco_bruto * item.quantidade)}
                   </div>
                 </li>
               ))}

--- a/app/loja/produtos/[slug]/page.tsx
+++ b/app/loja/produtos/[slug]/page.tsx
@@ -72,9 +72,6 @@ export default function ProdutoDetalhe() {
       ? produto.tamanhos.split(',').map((t) => t.trim())
       : ['P', 'M', 'G', 'GG']
 
-  // Make sure parsedValor is declared before it is used
-  // Example:
-  const parsedValor = Number(produto.preco)
 
   return (
     <main className="text-platinum font-sans px-4 md:px-16 py-10">
@@ -90,7 +87,6 @@ export default function ProdutoDetalhe() {
           generos={generos}
           tamanhos={tamanhos}
           nome={produto.nome}
-          preco={parsedValor}
           descricao={produto.descricao}
           produto={produto}
         />

--- a/components/molecules/CartPreview.tsx
+++ b/components/molecules/CartPreview.tsx
@@ -3,12 +3,11 @@
 import Link from 'next/link'
 import Image from 'next/image'
 import { useCart } from '@/lib/context/CartContext'
-import { calculateGross } from '@/lib/asaasFees'
 
 export default function CartPreview() {
   const { itens } = useCart()
   const total = itens.reduce(
-    (sum, i) => sum + calculateGross(i.preco, 'pix', 1).gross * i.quantidade,
+    (sum, i) => sum + (i.preco_bruto || 0) * i.quantidade,
     0,
   )
 
@@ -42,7 +41,7 @@ export default function CartPreview() {
             </div>
             <span className="text-xs text-neutral-900 font-semibold">
               R$
-              {(calculateGross(item.preco, 'pix', 1).gross * item.quantidade)
+              {(item.preco_bruto * item.quantidade)
                 .toFixed(2)
                 .replace('.', ',')}
             </span>

--- a/components/organisms/ProdutoInterativo.tsx
+++ b/components/organisms/ProdutoInterativo.tsx
@@ -2,7 +2,6 @@
 import { useState, useRef, useEffect, useMemo } from 'react'
 import Image from 'next/image'
 import type { Produto } from '@/types'
-import { calculateGross } from '@/lib/asaasFees'
 
 import AddToCartButton from '@/components/molecules/AddToCartButton'
 
@@ -101,7 +100,6 @@ export default function ProdutoInterativo({
   generos,
   tamanhos,
   nome,
-  preco,
   descricao,
   produto,
 }: {
@@ -109,7 +107,6 @@ export default function ProdutoInterativo({
   generos: string[]
   tamanhos: string[]
   nome: string
-  preco: number
   descricao?: string
   produto: Produto
 }) {
@@ -136,10 +133,7 @@ export default function ProdutoInterativo({
   const [indexImg, setIndexImg] = useState(0)
   const pauseRef = useRef(false)
 
-  const precoBruto = useMemo(
-    () => calculateGross(preco, 'pix', 1).gross,
-    [preco],
-  )
+  const precoBruto = produto.preco_bruto
 
   const firstImgKey = Object.keys(imagens)[0]
   const imgs = imagens[genero] || imagens['default'] || imagens[firstImgKey]

--- a/components/organisms/ProdutosFiltrados.tsx
+++ b/components/organisms/ProdutosFiltrados.tsx
@@ -4,7 +4,6 @@ import Image from 'next/image'
 import Link from 'next/link'
 import { useMemo, useState } from 'react'
 import useInscricoes from '@/lib/hooks/useInscricoes'
-import { calculateGross } from '@/lib/asaasFees'
 
 const faixasPreco = [
   { label: 'Até R$ 50', min: 0, max: 50 },
@@ -118,7 +117,7 @@ export default function ProdutosFiltrados({
         </div>
         <div className="grid grid-cols-2 sm:grid-cols-3 lg:grid-cols-4 gap-6">
           {filtrados.map((p) => {
-            const precoBruto = calculateGross(p.preco, 'pix', 1).gross
+            const precoBruto = p.preco_bruto
             const precisaAprov =
               p.requer_inscricao_aprovada && !possuiAprovacao(p)
             return (

--- a/docs/Documentacao_M24.md
+++ b/docs/Documentacao_M24.md
@@ -106,7 +106,8 @@ Para cada coleção, utilize a seguinte estrutura:
 | `nome`                      | String                    | Sim         | Nome do produto                                  |
 | `user_org`                  | Relation → `usuarios`     | Sim         | Organizador ou dono do produto                   |
 | `quantidade`                | Number                    | Sim         | Estoque disponível (unidades)                    |
-| `preco`                     | Number                    | Sim         | Preço unitário (em centavos ou decimal)          |
+| `preco`                     | Number                    | Sim         | Preço líquido (base)                             |
+| `preco_bruto`               | Number                    | Sim         | Valor final ao cliente (Pix à vista)            |
 | `ativo`                     | Boolean                   | Sim         | Se o produto está ativo/visível no front         |
 | `tamanhos`                  | Array                     | Não         | Tamanhos disponíveis: `PP`, `P`, `M`, `G`, `GG`  |
 | `imagens`                   | Array                     | Não         | Galeria de imagens                               |
@@ -159,6 +160,7 @@ Para cada coleção, utilize a seguinte estrutura:
   "user_org": "abc123usuario",
   "quantidade": 50,
   "preco": 4990,
+  "preco_bruto": 5350,
   "ativo": true,
   "tamanhos": ["P", "M", "G"],
   "slug": "camiseta-basica-preta",

--- a/docs/manual-aprovacao-inscricao.md
+++ b/docs/manual-aprovacao-inscricao.md
@@ -32,7 +32,7 @@ const pedidoPayload = {
     inscricao.genero ??
     (Array.isArray(produto.generos) ? produto.generos[0] : 'feminino'),
   email: inscricao.email,
-  valor: produto.preco,
+  valor: produto.preco_bruto,
   status: 'pendente',
   campo: campo?.id,
   responsavel: inscricao.criado_por,

--- a/lib/flows/orderFlow.ts
+++ b/lib/flows/orderFlow.ts
@@ -14,12 +14,13 @@ export function criarPedido(
     id: string
     nome?: string
     preco: number
+    preco_bruto: number
     tamanhos?: string[] | string
     generos?: string[] | string
   },
 ): Pedido {
   const first = (v?: string[] | string) => (Array.isArray(v) ? v[0] : v)
-  const valor = produto.preco
+  const valor = produto.preco_bruto
 
   return {
     id: `ped_${inscricao.id}`,

--- a/lib/products.ts
+++ b/lib/products.ts
@@ -2,6 +2,7 @@ export interface ProdutoRecord {
   id: string
   nome: string
   preco: number
+  preco_bruto: number
   imagens?: string[]
   checkout_url?: string
   categoria?: string

--- a/logs/DOC_LOG.md
+++ b/logs/DOC_LOG.md
@@ -444,3 +444,4 @@ executados.
 ## [2025-08-09] Botão de logout adicionado à página de perfil do usuário. Lint e build executados.
 
 ## [2025-06-26] Atualizado arquitetura.md removendo referencia a /posts, descrevendo carregamento via PocketBase e adicionada secao do middleware. Impacto: documentacao alinhada ao README e entendimento claro sobre tenant.
+## [2025-06-26] Campo preco_bruto adicionado na colecao produtos e documentacao atualizada.

--- a/types/index.ts
+++ b/types/index.ts
@@ -90,6 +90,7 @@ export type Produto = {
   id: string
   nome: string
   preco: number
+  preco_bruto: number
   imagem?: string
   imagens?: string[]
   tamanhos?: string[] | string


### PR DESCRIPTION
## Summary
- add `preco_bruto` in types and ProdutoRecord
- include bruto price when creating/updating products
- read `preco_bruto` in cart, product lists and product pages
- update order flow and API to use bruto price
- document new field and update examples
- adjust unit tests
- log documentation update

## Testing
- `npm run lint` *(fails: next not found)*
- `npm run build` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_685d5f132e0c832cb1b7bb664c4b65f9