### PR TITLE
Fix base url for email notifications

### DIFF
--- a/__tests__/api/inscricoesLojaRoute.test.ts
+++ b/__tests__/api/inscricoesLojaRoute.test.ts
@@ -46,6 +46,7 @@ describe('POST /loja/api/inscricoes', () => {
         evento: 'e1',
       }),
     })
+    ;(req as any).nextUrl = new URL('http://test')
     const res = await POST(req as unknown as NextRequest)
     expect(res.status).toBe(201)
     expect(createUserMock).toHaveBeenCalledWith(
@@ -86,6 +87,7 @@ describe('POST /loja/api/inscricoes', () => {
         evento: 'e1',
       }),
     })
+    ;(req as any).nextUrl = new URL('http://test')
     createUserMock.mockClear()
     const res = await POST(req as unknown as NextRequest)
     expect(res.status).toBe(201)
@@ -119,6 +121,7 @@ describe('POST /loja/api/inscricoes', () => {
         evento: 'e1',
       }),
     })
+    ;(req as any).nextUrl = new URL('http://test')
     const res = await POST(req as unknown as NextRequest)
     expect(res.status).toBe(201)
     expect(fetchMock).toHaveBeenCalledWith(

--- a/app/api/asaas/webhook/route.ts
+++ b/app/api/asaas/webhook/route.ts
@@ -225,7 +225,11 @@ export async function POST(req: NextRequest) {
     }
 
     if (responsavelId) {
-      const base = req.nextUrl.origin
+      const base = req.nextUrl?.origin || req.headers.get('origin')
+      if (!base) {
+        console.error('Base URL não encontrada para envio de notificações')
+        return NextResponse.json({ error: 'Base URL não encontrada' }, { status: 500 })
+      }
 
       try {
         await fetch(`${base}/api/email`, {

--- a/app/loja/api/inscricoes/route.ts
+++ b/app/loja/api/inscricoes/route.ts
@@ -54,7 +54,7 @@ export async function POST(req: NextRequest) {
       })
     }
 
-    const base: InscricaoTemplate = {
+    const baseInscricao: InscricaoTemplate = {
       nome,
       email: data.user_email,
       telefone: String(data.user_phone).replace(/\D/g, ''),
@@ -76,7 +76,7 @@ export async function POST(req: NextRequest) {
       : 'pix'
     const installments = Number(data.installments) || 1
 
-    const { id: _inscricaoId, ...inscricaoSemId } = criarInscricao(base)
+    const { id: _inscricaoId, ...inscricaoSemId } = criarInscricao(baseInscricao)
     void _inscricaoId
 
     const registroParaCriar = {
@@ -110,8 +110,14 @@ export async function POST(req: NextRequest) {
       userId: usuario.id,
     }
 
+    const base = req.nextUrl?.origin || req.headers.get('origin')
+    if (!base) {
+      console.error('Base URL não encontrada para envio de notificações')
+      return
+    }
+
     try {
-      await fetch(`${req.nextUrl.origin}/api/email`, {
+      await fetch(`${base}/api/email`, {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify(payload),
@@ -121,7 +127,7 @@ export async function POST(req: NextRequest) {
     }
 
     try {
-      await fetch(`${req.nextUrl.origin}/api/chats/message/sendWelcome`, {
+      await fetch(`${base}/api/chats/message/sendWelcome`, {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify(payload),


### PR DESCRIPTION
## Summary
- compute base url using request headers in loja inscricoes API
- compute base url using request headers in Asaas webhook
- adjust inscricoesLojaRoute unit tests to provide `nextUrl`

## Testing
- `npm run lint`
- `npm run build`
- `npm test` *(fails: 16 failed, 48 passed)*

------
https://chatgpt.com/codex/tasks/task_e_685d7d3d8ef0832c8996577e3f32cf81