### PR TITLE
Add nextUrl assignment in inscricoes loja tests

### DIFF
--- a/__tests__/api/inscricoesLojaRoute.test.ts
+++ b/__tests__/api/inscricoesLojaRoute.test.ts
@@ -46,6 +46,7 @@ describe('POST /loja/api/inscricoes', () => {
         evento: 'e1',
       }),
     })
+    ;(req as any).nextUrl = new URL('http://test/loja/api/inscricoes')
     const res = await POST(req as unknown as NextRequest)
     expect(res.status).toBe(201)
     expect(createUserMock).toHaveBeenCalledWith(
@@ -86,6 +87,7 @@ describe('POST /loja/api/inscricoes', () => {
         evento: 'e1',
       }),
     })
+    ;(req as any).nextUrl = new URL('http://test/loja/api/inscricoes')
     createUserMock.mockClear()
     const res = await POST(req as unknown as NextRequest)
     expect(res.status).toBe(201)
@@ -119,6 +121,7 @@ describe('POST /loja/api/inscricoes', () => {
         evento: 'e1',
       }),
     })
+    ;(req as any).nextUrl = new URL('http://test/loja/api/inscricoes')
     const res = await POST(req as unknown as NextRequest)
     expect(res.status).toBe(201)
     expect(fetchMock).toHaveBeenCalledWith(


### PR DESCRIPTION
## Summary
- update the inscricoesLojaRoute tests to assign `nextUrl` on each Request

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_685d7d017324832cafe747dd518fbe2e