### PR TITLE
Fix base URL usage in signup route

### DIFF
--- a/__tests__/api/signupRoute.test.ts
+++ b/__tests__/api/signupRoute.test.ts
@@ -17,6 +17,9 @@ vi.mock('../../lib/getTenantFromHost', () => ({
 
 describe('POST /api/signup', () => {
   it('remove caracteres nao numericos de telefone e cpf', async () => {
+    const fetchMock = vi.fn().mockResolvedValue({ ok: true })
+    global.fetch = fetchMock as unknown as typeof fetch
+
     const req = new Request('http://test', {
       method: 'POST',
       body: JSON.stringify({
@@ -27,6 +30,7 @@ describe('POST /api/signup', () => {
         senha: '123',
       }),
     })
+    ;(req as any).nextUrl = new URL('http://test')
 
     const res = await POST(req as unknown as NextRequest)
     expect(res.status).toBe(201)
@@ -35,6 +39,14 @@ describe('POST /api/signup', () => {
         telefone: '11999999999',
         cpf: '52998224725',
       }),
+    )
+    expect(fetchMock).toHaveBeenCalledWith(
+      'http://test/api/email',
+      expect.any(Object),
+    )
+    expect(fetchMock).toHaveBeenCalledWith(
+      'http://test/api/chats/message/sendWelcome',
+      expect.any(Object),
     )
   })
 })

--- a/app/api/signup/route.ts
+++ b/app/api/signup/route.ts
@@ -23,8 +23,14 @@ export async function POST(req: NextRequest) {
       ...(tenantId ? { cliente: tenantId } : {}),
     })
 
+    const base = req.nextUrl?.origin || req.headers.get('origin')
+    if (!base) {
+      console.error('Base URL não encontrada para envio de notificações')
+      return NextResponse.json({ error: 'Base URL não encontrada' }, { status: 500 })
+    }
+
     try {
-      await fetch('/api/email', {
+      await fetch(`${base}/api/email`, {
         method: 'POST',
         body: JSON.stringify({
           eventType: 'novo_usuario',
@@ -36,7 +42,7 @@ export async function POST(req: NextRequest) {
     }
 
     try {
-      await fetch('/api/chats/message/sendWelcome', {
+      await fetch(`${base}/api/chats/message/sendWelcome`, {
         method: 'POST',
         body: JSON.stringify({
           eventType: 'novo_usuario',


### PR DESCRIPTION
## Summary
- include base URL from `req.nextUrl` or `origin` header in `/api/signup`
- ensure tests set `nextUrl` and verify full URLs

## Testing
- `npm run lint`
- `npm run build`
- `npm test` *(fails: 16 failed, 48 passed)*

------
https://chatgpt.com/codex/tasks/task_e_685d821dd310832ca1689367bfc6bee3