### PR TITLE
Fix logo url in email route

### DIFF
--- a/app/api/email/route.ts
+++ b/app/api/email/route.ts
@@ -70,7 +70,9 @@ export async function POST(req: NextRequest) {
 
     // 5) monta subject + html
     const cor = cfg.cor_primary || '#7c3aed'
-    const logo = cfg.logo_url || ''
+    const logo = cfg.logo
+      ? pb.files.getUrl(cfg, cfg.logo)
+      : cfg.logo_url || ''
     let subject: string, html: string
 
     switch (eventType) {


### PR DESCRIPTION
## Summary
- fetch logo image from PocketBase file field when sending emails

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_685d8350d03c832c96bb711f58f5693f