### PR TITLE
Fix sign-up when logged in

### DIFF
--- a/app/loja/api/inscricoes/route.ts
+++ b/app/loja/api/inscricoes/route.ts
@@ -19,39 +19,41 @@ export async function POST(req: NextRequest) {
     }`.trim()
     const senha = data.password || data.passwordConfirm
 
-    let usuario
-    try {
-      usuario = await pb
-        .collection('usuarios')
-        .getFirstListItem(`email='${data.user_email}'`)
-    } catch {
-      if (!tenantId) {
-        return NextResponse.json(
-          { error: 'Tenant não informado' },
-          { status: 400 },
-        )
+    let usuario = pb.authStore.isValid ? pb.authStore.model : null
+    if (!usuario) {
+      try {
+        usuario = await pb
+          .collection('usuarios')
+          .getFirstListItem(`email='${data.user_email}'`)
+      } catch {
+        if (!tenantId) {
+          return NextResponse.json(
+            { error: 'Tenant não informado' },
+            { status: 400 },
+          )
+        }
+        const tempPass = Math.random().toString(36).slice(2, 10)
+        usuario = await pb.collection('usuarios').create({
+          nome,
+          email: data.user_email,
+          cpf: String(data.user_cpf).replace(/\D/g, ''),
+          telefone: String(data.user_phone).replace(/\D/g, ''),
+          data_nascimento: data.user_birth_date,
+          genero: data.user_gender?.toLowerCase(),
+          endereco: data.user_address,
+          bairro: data.user_neighborhood,
+          cep: data.user_cep,
+          cidade: data.user_city,
+          estado: data.user_state,
+          numero: data.user_number,
+          cliente: tenantId,
+          campo: data.campo,
+          perfil: 'usuario',
+          role: 'usuario',
+          password: senha || tempPass,
+          passwordConfirm: senha || tempPass,
+        })
       }
-      const tempPass = Math.random().toString(36).slice(2, 10)
-      usuario = await pb.collection('usuarios').create({
-        nome,
-        email: data.user_email,
-        cpf: String(data.user_cpf).replace(/\D/g, ''),
-        telefone: String(data.user_phone).replace(/\D/g, ''),
-        data_nascimento: data.user_birth_date,
-        genero: data.user_gender?.toLowerCase(),
-        endereco: data.user_address,
-        bairro: data.user_neighborhood,
-        cep: data.user_cep,
-        cidade: data.user_city,
-        estado: data.user_state,
-        numero: data.user_number,
-        cliente: tenantId,
-        campo: data.campo,
-        perfil: 'usuario',
-        role: 'usuario',
-        password: senha || tempPass,
-        passwordConfirm: senha || tempPass,
-      })
     }
 
     const baseInscricao: InscricaoTemplate = {

--- a/logs/ERR_LOG.md
+++ b/logs/ERR_LOG.md
@@ -167,3 +167,5 @@
 ## [2025-06-25] Logout era abortado antes do fetch finalizar; headers agora aguardam logout() antes de redirecionar - dev - b4e0600
 
 ## [2025-06-25] Botão Sair no perfil de usuário não encerrava sessão. Logout agora aguarda fetch e fecha menus antes de redirecionar - dev - 3fec475
+
+## [2025-07-31] Erro ao criar inscrição com usuário logado: API retornava "validation_not_unique" para o email. Rota /loja/api/inscricoes agora reutiliza o usuário autenticado quando disponível - dev


### PR DESCRIPTION
## Summary
- fix route /loja/api/inscricoes to reuse logged user before trying to create a new one
- log error fix in ERR_LOG

## Testing
- `npm run lint` *(fails: next not found)*
- `npm run build` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_685d87799e44832cb34ad97193613ae1