### PR TITLE
Add new placeholders to email service

### DIFF
--- a/app/api/asaas/webhook/route.ts
+++ b/app/api/asaas/webhook/route.ts
@@ -241,6 +241,7 @@ export async function POST(req: NextRequest) {
           body: JSON.stringify({
             eventType: 'confirmacao_pagamento',
             userId: responsavelId,
+            amount: paymentData.value,
           }),
         })
       } catch (err) {

--- a/app/api/email/route.ts
+++ b/app/api/email/route.ts
@@ -16,6 +16,9 @@ export type Body = {
     | 'confirmacao_pagamento'
   userId: string
   paymentLink?: string
+  loginLink?: string
+  amount?: number
+  dueDate?: string
 }
 
 async function loadTemplate(name: string) {
@@ -34,7 +37,8 @@ export async function POST(req: NextRequest) {
 
   try {
     // 1) parse + validação
-    const { eventType, userId, paymentLink } = (await req.json()) as Body
+    const { eventType, userId, paymentLink, loginLink, amount, dueDate } =
+      (await req.json()) as Body
     if (!eventType || !userId) {
       return NextResponse.json(
         { error: 'Parâmetros faltando' },
@@ -100,6 +104,9 @@ export async function POST(req: NextRequest) {
       .replace(/{{logoUrl}}/g, logo)
       .replace(/{{cor_primary}}/g, cor)
       .replace(/{{tenantNome}}/g, cfg.nome || '')
+      .replace(/{{loginLink}}/g, loginLink ?? `${req.nextUrl?.origin}/login`)
+      .replace(/{{amount}}/g, amount ? String(amount) : '')
+      .replace(/{{dueDate}}/g, dueDate ?? '')
 
     // 6) configura o Nodemailer
     const transporter = nodemailer.createTransport({

--- a/app/api/signup/route.ts
+++ b/app/api/signup/route.ts
@@ -38,6 +38,7 @@ export async function POST(req: NextRequest) {
         body: JSON.stringify({
           eventType: 'novo_usuario',
           userId: usuario.id,
+          loginLink: base + '/login',
         }),
       })
     } catch (err) {


### PR DESCRIPTION
## Summary
- extend `Body` in `email/route.ts` with `loginLink`, `amount`, `dueDate`
- replace these placeholders after loading templates
- send a login link on signup
- include payment amount in payment confirmation emails

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_685d8f7ea414832c9fb36b466ee7e78f