### PR TITLE
Corrige envio de WhatsApp e e-mail na confirmação de inscrição

### DIFF
--- a/app/admin/inscricoes/page.tsx
+++ b/app/admin/inscricoes/page.tsx
@@ -397,6 +397,21 @@ export default function ListaInscricoesPage() {
         ),
       )
 
+      if (inscricao.criado_por) {
+        const emailRes = await fetch('/api/email', {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({
+            eventType: 'confirmacao_inscricao',
+            userId: inscricao.criado_por,
+            paymentLink: checkout.url,
+          }),
+        })
+        if (!emailRes.ok) {
+          console.warn('Falha ao enviar e-mail', await emailRes.text())
+        }
+      }
+
       // 🔹 6. Enviar link de pagamento via WhatsApp
       const waRes = await fetch('/api/chats/message/sendPayment', {
         method: 'POST',

--- a/lib/server/chats.ts
+++ b/lib/server/chats.ts
@@ -83,7 +83,11 @@ export async function sendTextMessage(params: {
   if (!EVOLUTION_API_URL) throw new Error('EVOLUTION_API_URL not set')
 
   const url = `${EVOLUTION_API_URL}/message/sendText/${params.instanceName}`
-  const body = { number: params.to, text: params.message }
+
+  const digits = params.to.replace(/\D/g, '')
+  const phone = digits.startsWith('55') ? digits : `55${digits}`
+
+  const body = { number: phone, text: params.message }
 
   const res = await fetch(url, {
     method: 'POST',


### PR DESCRIPTION
## Summary
- normaliza telefone antes de chamar a Evolution API
- envia e-mail de confirmação ao confirmar inscrição via painel

## Testing
- `npm run lint` *(falhou: next: not found)*
- `npm run build` *(falhou: next: not found)*

------
https://chatgpt.com/codex/tasks/task_e_685d8ee15af8832ca51757457d1c833f