### PR TITLE
Remove duplicate AdminClientTour from admin layout

### DIFF
--- a/app/admin/layout.tsx
+++ b/app/admin/layout.tsx
@@ -1,9 +1,6 @@
 // app/layout.tsx
 import '@/app/globals.css'
 import LayoutWrapper from '@/components/templates/LayoutWrapperAdmin'
-import dynamic from 'next/dynamic'
-
-const AdminClientTour = dynamic(() => import('@/components/AdminClientTourLoader'))
 
 export const metadata = {
   icons: {
@@ -25,7 +22,6 @@ export default function RootLayout({
   return (
     <div className="antialiased font-sans">
       <LayoutWrapper>
-        <AdminClientTour />
         {children}
       </LayoutWrapper>
     </div>


### PR DESCRIPTION
## Summary
- remove AdminClientTour from `app/admin/layout.tsx`
- use global instance defined in root layout

## Testing
- `npm run lint` *(fails: `next` not found)*
- `npm run build` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_685da43f0a14832c97159d5aeb470dda