### PR TITLE
Add Admin tour tests

### DIFF
--- a/__tests__/AdminClientTour.test.tsx
+++ b/__tests__/AdminClientTour.test.tsx
@@ -1,0 +1,48 @@
+/* @vitest-environment jsdom */
+import React from 'react'
+import { render } from '@testing-library/react'
+import { vi } from 'vitest'
+import AdminClientTour from '@/components/AdminClientTour'
+
+let joyrideCallback: any
+const resetMock = vi.fn()
+
+vi.mock('react-joyride', () => ({
+  __esModule: true,
+  STATUS: { FINISHED: 'finished', SKIPPED: 'skipped' },
+  default: (props: any) => {
+    joyrideCallback = props.callback
+    props.getHelpers({ reset: resetMock })
+    return <div>JoyrideMock</div>
+  },
+}))
+
+vi.mock('next/navigation', () => ({
+  usePathname: () => '/admin/dashboard',
+}))
+
+vi.mock('lucide-react', () => ({ HelpCircle: () => <svg /> }))
+
+vi.mock('@/lib/context/AuthContext', () => ({
+  useAuthContext: () => ({ tenantId: 't1' }),
+}))
+
+vi.mock('@/lib/context/TenantContext', () => ({
+  useTenant: () => ({ config: { primaryColor: '#000' } }),
+}))
+
+const steps = { '/admin/dashboard': [{ target: '.a', content: 'a' }] }
+
+beforeEach(() => {
+  localStorage.clear()
+  vi.clearAllMocks()
+})
+
+describe('AdminClientTour', () => {
+  it('inicia tour na primeira visita e grava flag', () => {
+    render(<AdminClientTour stepsByRoute={steps} />)
+    expect(resetMock).toHaveBeenCalledWith(true)
+    joyrideCallback({ status: 'finished' })
+    expect(localStorage.getItem('t1-/admin/dashboard-tour-completed')).toBe('true')
+  })
+})

--- a/__tests__/AdminClientTourLoader.test.tsx
+++ b/__tests__/AdminClientTourLoader.test.tsx
@@ -1,0 +1,39 @@
+/* @vitest-environment jsdom */
+import React from 'react'
+import { render, screen, waitFor } from '@testing-library/react'
+import { vi } from 'vitest'
+import AdminClientTourLoader from '@/components/AdminClientTourLoader'
+
+let pathname = '/admin/dashboard'
+
+vi.mock('next/navigation', () => ({
+  usePathname: () => pathname,
+}))
+
+const importSpy = vi.fn()
+vi.mock('@/components/AdminClientTour', () => {
+  importSpy()
+  return { __esModule: true, default: () => <div>TourComponent</div> }
+})
+
+beforeEach(() => {
+  vi.clearAllMocks()
+})
+
+describe('AdminClientTourLoader', () => {
+  it('carrega tour quando ha passos para a rota', async () => {
+    pathname = '/admin/dashboard'
+    render(<AdminClientTourLoader />)
+    await screen.findByText('TourComponent')
+    expect(importSpy).toHaveBeenCalled()
+  })
+
+  it('nao carrega tour quando nao ha passos', async () => {
+    pathname = '/sem-roteiro'
+    render(<AdminClientTourLoader />)
+    await waitFor(() => {
+      expect(screen.queryByText('TourComponent')).toBeNull()
+    })
+    expect(importSpy).not.toHaveBeenCalled()
+  })
+})


### PR DESCRIPTION
## Summary
- add tests covering AdminClientTourLoader and AdminClientTour behavior

## Testing
- `npm run lint`
- `npm run build`
- `npm run test` *(fails: 16 failed, 50 passed)*

------
https://chatgpt.com/codex/tasks/task_e_685da444cb7c832c8e7a6960ce5bd301