### PR TITLE
Add aria label to client tour button

### DIFF
--- a/__tests__/AdminClientTour.test.tsx
+++ b/__tests__/AdminClientTour.test.tsx
@@ -1,6 +1,6 @@
 /* @vitest-environment jsdom */
 import React from 'react'
-import { render } from '@testing-library/react'
+import { render, screen } from '@testing-library/react'
 import { vi } from 'vitest'
 import AdminClientTour from '@/components/AdminClientTour'
 
@@ -44,5 +44,6 @@ describe('AdminClientTour', () => {
     expect(resetMock).toHaveBeenCalledWith(true)
     joyrideCallback({ status: 'finished' })
     expect(localStorage.getItem('t1-/admin/dashboard-tour-completed')).toBe('true')
+    expect(screen.getByLabelText('Ajuda')).toBeInTheDocument()
   })
 })

--- a/components/AdminClientTour.tsx
+++ b/components/AdminClientTour.tsx
@@ -60,7 +60,12 @@ export function AdminClientTour({ stepsByRoute }: AdminClientTourProps) {
         callback={handleJoyrideCallback}
       />
       <div className="fixed bottom-4 right-4 z-50">
-        <Button variant="secondary" className="p-2 rounded-full" onClick={() => tourRef.current?.reset(true)}>
+        <Button
+          variant="secondary"
+          className="p-2 rounded-full"
+          aria-label="Ajuda"
+          onClick={() => tourRef.current?.reset(true)}
+        >
           <HelpCircle size={24} />
         </Button>
       </div>


### PR DESCRIPTION
## Summary
- include `aria-label="Ajuda"` on AdminClientTour help button
- test for button label

## Testing
- `npm run lint`
- `npm run build`
- `npm test` *(fails: 16 failed, 50 passed)*

------
https://chatgpt.com/codex/tasks/task_e_685db5336a70832cb9e3447e03212a18