### PR TITLE
fix unused hook

### DIFF
--- a/components/AdminClientTour.tsx
+++ b/components/AdminClientTour.tsx
@@ -5,7 +5,6 @@ import { usePathname } from 'next/navigation'
 import { Button } from '@/components/atoms/Button'
 import { HelpCircle } from 'lucide-react'
 import { useAuthContext } from '@/lib/context/AuthContext'
-import { useTenant } from '@/lib/context/TenantContext'
 
 interface AdminClientTourProps {
   stepsByRoute: Record<string, Step[]>
@@ -14,7 +13,6 @@ interface AdminClientTourProps {
 export function AdminClientTour({ stepsByRoute }: AdminClientTourProps) {
   const pathname = usePathname()
   const { tenantId } = useAuthContext()
-  const { config } = useTenant()
   const tourRef = useRef<StoreHelpers | null>(null)
   const steps = useMemo(() => stepsByRoute[pathname] || [], [pathname, stepsByRoute])
   const storageKey = `${tenantId ?? 'public'}-${pathname}-tour-completed`

--- a/logs/DOC_LOG.md
+++ b/logs/DOC_LOG.md
@@ -451,3 +451,4 @@ executados.
 ## [2025-06-26] Implementado tour in-app com React Joyride e passos dinâmicos. Lint e build executados.
 ## [2025-08-10] Expandido steps do tour para cada rota do Admin, importação dinâmica do AdminClientTour no layout e registro de cor primária via TenantProvider. Lint e build falharam (next not found).
 ## [2025-06-26] Atualizado Joyride.md com uso de `var(--accent)` e tour adaptado ao Tenant. Lint e build executados.
+## [2025-06-26] Import useTenant removido do AdminClientTour. Lint executado com sucesso; build não finalizou por limitações do ambiente.


### PR DESCRIPTION
## Summary
- remove unused `useTenant` import from `AdminClientTour`
- log lint/build attempt in DOC_LOG

## Testing
- `npm run lint`
- `npm run build` *(failed: process did not finish)*

------
https://chatgpt.com/codex/tasks/task_e_685dbcf6ab48832c900674c747c3f60e