### PR TITLE
Fix missing tour route

### DIFF
--- a/components/tourSteps.ts
+++ b/components/tourSteps.ts
@@ -51,8 +51,4 @@ export const stepsByRoute: Record<string, Step[]> = {
   '/admin/whatsapp': [
     { target: '.onboarding-wizard', content: 'Configure a integração com o WhatsApp.', placement: 'top' },
   ],
-  '/app/home': [
-    { target: '.welcome-banner', content: 'Bem‑vindo ao seu painel pessoal!', placement: 'bottom' },
-    { target: '.menu-pedidos', content: 'Confira seus pedidos e status aqui.', placement: 'right' },
-  ],
 }


### PR DESCRIPTION
## Summary
- remove outdated `/app/home` route from `stepsByRoute`

## Testing
- `npm run lint` *(fails: next not found)*
- `npm run build` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_685dbcfc0d08832c83bb0acde617c6fe