### PR TITLE
Fix dynamic metadata base

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -9,20 +9,27 @@ import { generatePrimaryShades } from '@/utils/primaryShades'
 import { fetchTenantConfig } from '@/lib/fetchTenantConfig'
 import { CartProvider } from '@/lib/context/CartContext'
 import dynamic from 'next/dynamic'
+import { headers } from 'next/headers'
 
 const AdminClientTour = dynamic(() => import('@/components/AdminClientTourLoader'))
 
-export const metadata = {
-  metadataBase: new URL('https://umadeus.com.br'),
-  icons: {
-    icon: [
-      { url: '/favicon.ico' },
-      { url: '/icon0.png', sizes: '32x32', type: 'image/png' },
-      { url: '/icon1.png', sizes: '16x16', type: 'image/png' },
-    ],
-    apple: '/apple-icon.png',
-  },
-  manifest: '/manifest.json',
+export async function generateMetadata() {
+  const headersList = await headers()
+  const host = headersList.get('host') || ''
+  const protocol = process.env.NODE_ENV === 'development' ? 'http' : 'https'
+
+  return {
+    metadataBase: new URL(`${protocol}://${host}`),
+    icons: {
+      icon: [
+        { url: '/favicon.ico' },
+        { url: '/icon0.png', sizes: '32x32', type: 'image/png' },
+        { url: '/icon1.png', sizes: '16x16', type: 'image/png' },
+      ],
+      apple: '/apple-icon.png',
+    },
+    manifest: '/manifest.json',
+  }
 }
 
 export default async function RootLayout({

--- a/logs/DOC_LOG.md
+++ b/logs/DOC_LOG.md
@@ -453,3 +453,4 @@ executados.
 ## [2025-06-26] Atualizado Joyride.md com uso de `var(--accent)` e tour adaptado ao Tenant. Lint e build executados.
 ## [2025-06-26] Import useTenant removido do AdminClientTour. Lint executado com sucesso; build não finalizou por limitações do ambiente.
 ## [2025-08-11] Removido passo '/app/home' do Joyride.md. Lint e build executados.
+## [2025-08-12] MetadataBase dinamico no layout com generateMetadata. Impacto: corrige aviso "metadataBase" em cada tenant. Lint e build executados.


### PR DESCRIPTION
## Summary
- use `generateMetadata` in app layout and calculate `metadataBase` from headers
- log the change in DOC_LOG

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_685dc9fdfb3c832cb5ad5dd31f4235e3