### PR TITLE
Add test for help button

### DIFF
--- a/__tests__/AdminClientTour.test.tsx
+++ b/__tests__/AdminClientTour.test.tsx
@@ -1,6 +1,7 @@
 /* @vitest-environment jsdom */
 import React from 'react'
 import { render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
 import { vi } from 'vitest'
 import AdminClientTour from '@/components/AdminClientTour'
 
@@ -45,5 +46,13 @@ describe('AdminClientTour', () => {
     joyrideCallback({ status: 'finished' })
     expect(localStorage.getItem('t1-/admin/dashboard-tour-completed')).toBe('true')
     expect(screen.getByLabelText('Ajuda')).toBeInTheDocument()
+  })
+
+  it('reinicia tour ao clicar no botao Ajuda', async () => {
+    render(<AdminClientTour stepsByRoute={steps} />)
+    resetMock.mockClear()
+    const user = userEvent.setup()
+    await user.click(screen.getByLabelText('Ajuda'))
+    expect(resetMock).toHaveBeenCalledWith(true)
   })
 })


### PR DESCRIPTION
## Summary
- add userEvent test for clicking Ajuda button in AdminClientTour

## Testing
- `npm run lint`
- `npm run build`
- `npm run test` *(fails: Tests failed. Watching for file changes...)*
- `npx vitest run __tests__/AdminClientTour.test.tsx`

------
https://chatgpt.com/codex/tasks/task_e_685dcbb94c84832cb96bfe12eff7eadf