### PR TITLE
Add help button test

### DIFF
--- a/__tests__/AdminClientTour.test.tsx
+++ b/__tests__/AdminClientTour.test.tsx
@@ -1,6 +1,7 @@
 /* @vitest-environment jsdom */
 import React from 'react'
 import { render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
 import { vi } from 'vitest'
 import AdminClientTour from '@/components/AdminClientTour'
 
@@ -45,5 +46,15 @@ describe('AdminClientTour', () => {
     joyrideCallback({ status: 'finished' })
     expect(localStorage.getItem('t1-/admin/dashboard-tour-completed')).toBe('true')
     expect(screen.getByLabelText('Ajuda')).toBeInTheDocument()
+  })
+
+  it('reinicia tour ao clicar em \u201cAjuda\u201d', async () => {
+    localStorage.setItem('t1-/admin/dashboard-tour-completed', 'true')
+    render(<AdminClientTour stepsByRoute={steps} />)
+    expect(resetMock).not.toHaveBeenCalled()
+
+    await userEvent.click(screen.getByLabelText('Ajuda'))
+
+    expect(resetMock).toHaveBeenCalledWith(true)
   })
 })

--- a/package-lock.json
+++ b/package-lock.json
@@ -42,6 +42,7 @@
         "@storybook/nextjs": "^9.0.5",
         "@testing-library/jest-dom": "^6.6.3",
         "@testing-library/react": "^16.3.0",
+        "@testing-library/user-event": "^14.6.1",
         "@types/file-saver": "^2.0.7",
         "@types/node": "^20",
         "@types/nodemailer": "^6.4.17",

--- a/package.json
+++ b/package.json
@@ -52,6 +52,7 @@
     "@storybook/nextjs": "^9.0.5",
     "@testing-library/jest-dom": "^6.6.3",
     "@testing-library/react": "^16.3.0",
+    "@testing-library/user-event": "^14.6.1",
     "@types/file-saver": "^2.0.7",
     "@types/node": "^20",
     "@types/nodemailer": "^6.4.17",


### PR DESCRIPTION
## Summary
- add test for restarting AdminClientTour via the 'Ajuda' button
- include user-event for easier event simulation

## Testing
- `npm run lint`
- `npm run build`
- `npm run test __tests__/AdminClientTour.test.tsx`

------
https://chatgpt.com/codex/tasks/task_e_685dfa2217e8832cb2536d007dc765c3