### PR TITLE
Implement reset password modal in customer area

### DIFF
--- a/__tests__/AreaClienteModal.test.tsx
+++ b/__tests__/AreaClienteModal.test.tsx
@@ -1,0 +1,30 @@
+/* @vitest-environment jsdom */
+import React from 'react'
+import { render, screen, fireEvent } from '@testing-library/react'
+import { vi } from 'vitest'
+import AreaCliente from '@/app/loja/cliente/page'
+
+vi.mock('@/lib/hooks/useAuthGuard', () => ({
+  useAuthGuard: () => ({
+    user: { nome: 'User', email: 'user@example.com', telefone: '123', role: 'usuario' },
+    authChecked: true,
+  }),
+}))
+
+vi.mock('@/lib/pocketbase', () => ({
+  __esModule: true,
+  default: vi.fn(() => ({ authStore: { token: 't' } })),
+}))
+
+// silence fetch for useEffect
+beforeEach(() => {
+  global.fetch = vi.fn().mockResolvedValue({ json: () => Promise.resolve([]) }) as any
+})
+
+test('abre modal ao clicar em Alterar senha', async () => {
+  render(<AreaCliente />)
+  fireEvent.click(screen.getByRole('button', { name: /alterar senha/i }))
+  expect(
+    await screen.findByRole('heading', { name: /redefinir senha/i })
+  ).toBeInTheDocument()
+})

--- a/app/loja/cliente/page.tsx
+++ b/app/loja/cliente/page.tsx
@@ -5,12 +5,14 @@ import { useAuthGuard } from '@/lib/hooks/useAuthGuard'
 import createPocketBase from '@/lib/pocketbase'
 import type { Inscricao, Pedido } from '@/types'
 import { formatDate } from '@/utils/formatDate'
+import RedefinirSenhaModal from '@/app/admin/components/RedefinirSenhaModal'
 
 export default function AreaCliente() {
   const { user, authChecked } = useAuthGuard(['usuario'])
   const pb = useMemo(() => createPocketBase(), [])
   const [inscricoes, setInscricoes] = useState<Inscricao[]>([])
   const [pedidos, setPedidos] = useState<Pedido[]>([])
+  const [mostrarModalSenha, setMostrarModalSenha] = useState(false)
 
   useEffect(() => {
     if (!authChecked || !user) return
@@ -40,6 +42,7 @@ export default function AreaCliente() {
   if (!authChecked) return null
 
   return (
+    <>
     <main className="p-8 text-platinum font-sans space-y-10">
       <section className="card">
         <h2 className="text-xl font-bold">Resumo do Cliente</h2>
@@ -57,9 +60,13 @@ export default function AreaCliente() {
           <a href="/loja/perfil" className="btn btn-secondary">
             Alterar dados pessoais
           </a>
-          <a href="/admin/redefinir-senha" className="btn btn-secondary">
+          <button
+            type="button"
+            onClick={() => setMostrarModalSenha(true)}
+            className="btn btn-secondary"
+          >
             Alterar senha
-          </a>
+          </button>
           <button type="button" className="btn btn-secondary" disabled>
             Gerenciar endereços
           </button>
@@ -114,5 +121,9 @@ export default function AreaCliente() {
         </table>
       </section>
     </main>
+    {mostrarModalSenha && (
+      <RedefinirSenhaModal onClose={() => setMostrarModalSenha(false)} />
+    )}
+    </>
   )
 }

--- a/logs/DOC_LOG.md
+++ b/logs/DOC_LOG.md
@@ -453,3 +453,4 @@ executados.
 ## [2025-06-26] Campo preco_bruto adicionado na colecao produtos e documentacao atualizada.
 
 ## [2025-06-26] InscricaoForm preenche campo via searchParams e valor do usuario. Campo permanece selecionado ao navegar entre etapas. Lint e build executados apos instalar dependencias.
+## [2025-08-09] Area do cliente usa modal para redefinir senha ao clicar em "Alterar senha". Lint e build falharam (next not found).


### PR DESCRIPTION
## Summary
- show `RedefinirSenhaModal` in `AreaCliente`
- test modal visibility on button click
- document changes

## Testing
- `npm test` *(fails: vitest not found)*
- `npm run lint` *(fails: next not found)*
- `npm run build` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_685e9e4f9038832cb465fe77389929b6