### PR TITLE
Fix outdated tour doc reference

### DIFF
--- a/logs/DOC_LOG.md
+++ b/logs/DOC_LOG.md
@@ -461,6 +461,7 @@ executados.
 
 ## [2025-08-12] MetadataBase dinamico no layout com generateMetadata. Impacto: corrige aviso "metadataBase" em cada tenant. Lint e build executados.
 
-## [2025-06-27] Criado docs/roteiro-completo.md listando todas as páginas e passos do tour
 ## [2025-06-27] Padronizados data attributes `data-tour` nos componentes do admin e atualizado mapeamento em components/tourSteps. Impacto: seletores do tour mais estáveis.
 ## [2025-06-27] Adicionados data attributes na página de saldo, novo tour '/admin/financeiro/saldo' mapeado e componente DateRangePicker atualizado. Lint e build executados.
+
+## [2025-08-13] Referência a docs/roteiro-completo.md removida do DOC_LOG; documento substituído por docs/Roteiro_admin.md.


### PR DESCRIPTION
## Summary
- remove obsolete docs/roteiro-completo entry from DOC_LOG
- log replacement with docs/Roteiro_admin.md

## Testing
- `npm run lint` *(fails: next not found)*
- `npm run build` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_685eaeda923c832cabd7ccd26b33d9e5