### PR TITLE
Implement auth header utility

### DIFF
--- a/app/cliente/components/DashboardHeader.tsx
+++ b/app/cliente/components/DashboardHeader.tsx
@@ -2,6 +2,7 @@
 import { useAuthGuard } from '@/lib/hooks/useAuthGuard'
 import { useEffect, useMemo, useState } from 'react'
 import createPocketBase from '@/lib/pocketbase'
+import { getAuthHeaders } from '@/lib/authHeaders'
 import type { Pedido, Inscricao } from '@/types'
 
 export default function DashboardHeader() {
@@ -12,11 +13,7 @@ export default function DashboardHeader() {
 
   useEffect(() => {
     if (!authChecked || !user) return
-    const token = pb.authStore.token
-    const headers = {
-      Authorization: `Bearer ${token}`,
-      'X-PB-User': JSON.stringify(user),
-    }
+    const headers = getAuthHeaders(pb)
     fetch('/api/inscricoes', { headers, credentials: 'include' })
       .then((res) => res.json())
       .then((data) => setInscricoes(Array.isArray(data) ? data : []))

--- a/app/cliente/components/InscricoesTable.tsx
+++ b/app/cliente/components/InscricoesTable.tsx
@@ -2,6 +2,7 @@
 import { useAuthGuard } from '@/lib/hooks/useAuthGuard'
 import { useEffect, useMemo, useState } from 'react'
 import createPocketBase from '@/lib/pocketbase'
+import { getAuthHeaders } from '@/lib/authHeaders'
 import type { Inscricao } from '@/types'
 import { formatDate } from '@/utils/formatDate'
 
@@ -12,11 +13,7 @@ export default function InscricoesTable({ limit }: { limit?: number }) {
 
   useEffect(() => {
     if (!authChecked || !user) return
-    const token = pb.authStore.token
-    const headers = {
-      Authorization: `Bearer ${token}`,
-      'X-PB-User': JSON.stringify(user),
-    }
+    const headers = getAuthHeaders(pb)
     fetch('/api/inscricoes', { headers, credentials: 'include' })
       .then((res) => res.json())
       .then((data) =>

--- a/app/cliente/components/PedidosTable.tsx
+++ b/app/cliente/components/PedidosTable.tsx
@@ -2,6 +2,7 @@
 import { useAuthGuard } from '@/lib/hooks/useAuthGuard'
 import { useEffect, useMemo, useState } from 'react'
 import createPocketBase from '@/lib/pocketbase'
+import { getAuthHeaders } from '@/lib/authHeaders'
 import type { Pedido } from '@/types'
 
 export default function PedidosTable({ limit }: { limit?: number }) {
@@ -11,11 +12,7 @@ export default function PedidosTable({ limit }: { limit?: number }) {
 
   useEffect(() => {
     if (!authChecked || !user) return
-    const token = pb.authStore.token
-    const headers = {
-      Authorization: `Bearer ${token}`,
-      'X-PB-User': JSON.stringify(user),
-    }
+    const headers = getAuthHeaders(pb)
     fetch('/api/pedidos', { headers, credentials: 'include' })
       .then((res) => res.json())
       .then((data) =>

--- a/app/cliente/components/ProfileForm.tsx
+++ b/app/cliente/components/ProfileForm.tsx
@@ -2,6 +2,7 @@
 import { useAuthGuard } from '@/lib/hooks/useAuthGuard'
 import { useEffect, useMemo, useState } from 'react'
 import createPocketBase from '@/lib/pocketbase'
+import { getAuthHeaders } from '@/lib/authHeaders'
 import { useToast } from '@/lib/context/ToastContext'
 import { FormField, TextField, InputWithMask } from '@/components'
 
@@ -40,11 +41,8 @@ export default function ProfileForm() {
     e.preventDefault()
     if (!user?.id) return
     try {
-      pb.authStore.loadFromCookie(document.cookie)
-      const token = pb.authStore.token
       const headers = {
-        Authorization: `Bearer ${token}`,
-        'X-PB-User': JSON.stringify(user),
+        ...getAuthHeaders(pb),
         'Content-Type': 'application/json',
       }
       const res = await fetch('/api/usuario/atualizar-dados', {

--- a/lib/authHeaders.ts
+++ b/lib/authHeaders.ts
@@ -1,0 +1,9 @@
+import type PocketBase from 'pocketbase'
+
+export function getAuthHeaders(pb: PocketBase) {
+  pb.authStore.loadFromCookie(document.cookie)
+  return {
+    Authorization: `Bearer ${pb.authStore.token}`,
+    'X-PB-User': JSON.stringify(pb.authStore.model),
+  }
+}


### PR DESCRIPTION
## Summary
- add utility function `getAuthHeaders`
- simplify auth header usage in ProfileForm
- use `getAuthHeaders` in DashboardHeader
- update PedidosTable and InscricoesTable to share the same logic

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_685eb3e8068c832c9277b3ad5b4b0d32