### PR TITLE
Fix auth headers on client fetches

### DIFF
--- a/app/admin/produtos/novo/ModalProduto.tsx
+++ b/app/admin/produtos/novo/ModalProduto.tsx
@@ -7,6 +7,8 @@
  */
 
 import { useEffect, useRef, useState } from 'react'
+import createPocketBase from '@/lib/pocketbase'
+import { getAuthHeaders } from '@/lib/authHeaders'
 import { useAuthContext } from '@/lib/context/AuthContext'
 import { calculateGross } from '@/lib/asaasFees'
 import ModalCategoria from '../categorias/ModalCategoria'
@@ -81,6 +83,7 @@ export function ModalProduto<T extends Record<string, unknown>>({
     initial.requer_inscricao_aprovada ?? false,
   )
   const { isLoggedIn, user: ctxUser } = useAuthContext()
+  const pb = createPocketBase()
   const { showSuccess, showError } = useToast()
   const [exclusivo, setExclusivo] = useState<boolean>(
     initial.exclusivo_user ?? false,
@@ -100,7 +103,8 @@ export function ModalProduto<T extends Record<string, unknown>>({
 
   useEffect(() => {
     if (open) {
-      fetch('/api/eventos')
+      const headers = getAuthHeaders(pb)
+      fetch('/api/eventos', { headers, credentials: 'include' })
         .then((r) => r.json())
         .then((data) => {
           if (Array.isArray(data)) setEventos(data)

--- a/app/completar-cadastro/page.tsx
+++ b/app/completar-cadastro/page.tsx
@@ -1,6 +1,8 @@
 'use client'
 
 import { useEffect, useState } from 'react'
+import createPocketBase from '@/lib/pocketbase'
+import { getAuthHeaders } from '@/lib/authHeaders'
 import { fetchCep } from '@/utils/cep'
 import { useRouter } from 'next/navigation'
 import { TextField, FormField, Button, Spinner } from '@/components'
@@ -16,6 +18,7 @@ export default function CompletarCadastroPage() {
   const { authChecked } = useAuthGuard(['usuario'])
   const { showError, showSuccess } = useToast()
   const router = useRouter()
+  const pb = createPocketBase()
 
   const [dataNasc, setDataNasc] = useState('')
   const [genero, setGenero] = useState('')
@@ -31,7 +34,7 @@ export default function CompletarCadastroPage() {
 
   useEffect(() => {
     if (!authChecked) return
-    fetch('/api/campos')
+    fetch('/api/campos', { headers: getAuthHeaders(pb), credentials: 'include' })
       .then((r) => (r.ok ? r.json() : []))
       .then((d) => {
         if (Array.isArray(d)) setCampos(d)
@@ -61,7 +64,8 @@ export default function CompletarCadastroPage() {
     try {
       const res = await fetch('/api/usuario/atualizar-dados', {
         method: 'PATCH',
-        headers: { 'Content-Type': 'application/json' },
+        headers: { ...getAuthHeaders(pb), 'Content-Type': 'application/json' },
+        credentials: 'include',
         body: JSON.stringify({
           data_nascimento: dataNasc,
           genero,

--- a/app/inscricoes/lider/[liderId]/page.tsx
+++ b/app/inscricoes/lider/[liderId]/page.tsx
@@ -3,6 +3,8 @@
 import Image from 'next/image'
 import Link from 'next/link'
 import { useEffect, useState } from 'react'
+import createPocketBase from '@/lib/pocketbase'
+import { getAuthHeaders } from '@/lib/authHeaders'
 import { useParams } from 'next/navigation'
 import LoadingOverlay from '@/components/organisms/LoadingOverlay'
 import { formatDate } from '@/utils/formatDate'
@@ -11,13 +13,17 @@ import type { Evento } from '@/types'
 export default function EscolherEventoPage() {
   const params = useParams()
   const liderId = params.liderId as string
+  const pb = createPocketBase()
   const [eventos, setEventos] = useState<Evento[]>([])
   const [loading, setLoading] = useState(true)
 
   useEffect(() => {
     async function fetchEventos() {
       try {
-        const res = await fetch('/api/eventos')
+        const res = await fetch('/api/eventos', {
+          headers: getAuthHeaders(pb),
+          credentials: 'include',
+        })
         const data: Evento[] = await res.json()
         setEventos(Array.isArray(data) ? data : [])
       } catch {

--- a/app/loja/page.tsx
+++ b/app/loja/page.tsx
@@ -3,6 +3,8 @@
 import Image from 'next/image'
 import Link from 'next/link'
 import { useEffect, useState } from 'react'
+import createPocketBase from '@/lib/pocketbase'
+import { getAuthHeaders } from '@/lib/authHeaders'
 import { calculateGross } from '@/lib/asaasFees'
 
 interface Produto {
@@ -15,11 +17,15 @@ interface Produto {
 
 export default function Home() {
   const [produtosDestaque, setProdutosDestaque] = useState<Produto[]>([])
+  const pb = createPocketBase()
 
   useEffect(() => {
     async function fetchProdutos() {
       try {
-        const res = await fetch('/api/produtos', { credentials: 'include' })
+        const res = await fetch('/api/produtos', {
+          headers: getAuthHeaders(pb),
+          credentials: 'include',
+        })
         if (res.ok) {
           const list = (await res.json()) as Produto[]
           const prods = list.map((p) => ({

--- a/components/admin/ModalProdutoForm.tsx
+++ b/components/admin/ModalProdutoForm.tsx
@@ -1,6 +1,8 @@
 'use client'
 
 import { useEffect, useRef, useState } from 'react'
+import createPocketBase from '@/lib/pocketbase'
+import { getAuthHeaders } from '@/lib/authHeaders'
 import Image from 'next/image'
 import * as Dialog from '@radix-ui/react-dialog'
 import { AnimatePresence, motion } from 'framer-motion'
@@ -35,6 +37,7 @@ export default function ModalProdutoForm({
   initial = {},
 }: ModalProdutoFormProps) {
   const { showError } = useToast()
+  const pb = createPocketBase()
   const firstFieldRef = useRef<HTMLInputElement>(null)
   const [eventos, setEventos] = useState<Evento[]>([])
   const [preview, setPreview] = useState<string | null>(initial.imagem || null)
@@ -49,7 +52,8 @@ export default function ModalProdutoForm({
   useEffect(() => {
     if (open) {
       firstFieldRef.current?.focus()
-      fetch('/api/eventos')
+      const headers = getAuthHeaders(pb)
+      fetch('/api/eventos', { headers, credentials: 'include' })
         .then((r) => r.json())
         .then((data) => {
           if (Array.isArray(data)) setEventos(data)

--- a/components/admin/OnboardingWizard.tsx
+++ b/components/admin/OnboardingWizard.tsx
@@ -1,5 +1,7 @@
 'use client'
 import { useEffect, useState } from 'react'
+import createPocketBase from '@/lib/pocketbase'
+import { getAuthHeaders } from '@/lib/authHeaders'
 import { useAuthContext } from '@/lib/context/AuthContext'
 import StepSelectClient from '../onboarding/StepSelectClient'
 import StepCreateInstance from '../onboarding/StepCreateInstance'
@@ -32,6 +34,7 @@ function WizardSteps() {
     setLoading,
   } = useOnboarding()
   const { tenantId } = useAuthContext()
+  const pb = createPocketBase()
   const [qrUrl, setQrUrl] = useState('')
   const [qrBase, setQrBase] = useState('')
 
@@ -40,8 +43,13 @@ function WizardSteps() {
     ;(async () => {
       setLoading(true)
       try {
+        const headers = {
+          ...getAuthHeaders(pb),
+          'x-tenant-id': tenantId,
+        }
         const res = await fetch('/api/chats/whatsapp/instance/check', {
-          headers: { 'x-tenant-id': tenantId },
+          headers,
+          credentials: 'include',
         })
         const check = (await res.json()) as CheckResponse
         if (!check) return

--- a/components/onboarding/StepComplete.tsx
+++ b/components/onboarding/StepComplete.tsx
@@ -4,6 +4,8 @@ import { Button } from '@/components/atoms/Button'
 import { useOnboarding } from '@/lib/context/OnboardingContext'
 import { useAuthContext } from '@/lib/context/AuthContext'
 import { useState } from 'react'
+import createPocketBase from '@/lib/pocketbase'
+import { getAuthHeaders } from '@/lib/authHeaders'
 import { maskPhone } from '@/utils/formatPhone'
 
 export default function StepComplete() {
@@ -14,9 +16,15 @@ export default function StepComplete() {
   const handleDisconnect = async () => {
     setLoading(true)
     try {
+      const pb = createPocketBase()
+      const headers = {
+        ...getAuthHeaders(pb),
+        'x-tenant-id': tenantId!,
+      }
       await fetch('/api/chats/whatsapp/instance/delete', {
         method: 'DELETE',
-        headers: { 'x-tenant-id': tenantId! },
+        headers,
+        credentials: 'include',
       })
       setConnection('idle')
       setStep(1)

--- a/components/onboarding/StepCreateInstance.tsx
+++ b/components/onboarding/StepCreateInstance.tsx
@@ -1,5 +1,7 @@
 'use client'
 import { useEffect, useState } from 'react'
+import createPocketBase from '@/lib/pocketbase'
+import { getAuthHeaders } from '@/lib/authHeaders'
 import { useOnboarding } from '@/lib/context/OnboardingContext'
 import { useAuthContext } from '@/lib/context/AuthContext'
 
@@ -20,12 +22,16 @@ export default function StepCreateInstance({
       setLoading(true)
       setError(undefined)
       try {
+        const pb = createPocketBase()
+        const headers = {
+          ...getAuthHeaders(pb),
+          'Content-Type': 'application/json',
+          'x-tenant-id': tenantId!,
+        }
         const res = await fetch('/api/chats/whatsapp/instance', {
           method: 'POST',
-          headers: {
-            'Content-Type': 'application/json',
-            'x-tenant-id': tenantId!,
-          },
+          headers,
+          credentials: 'include',
           body: JSON.stringify({ telefone: `55${telefone}` }),
         })
         if (!res.ok) throw new Error(await res.text())

--- a/components/templates/SignUpForm.tsx
+++ b/components/templates/SignUpForm.tsx
@@ -1,11 +1,13 @@
 'use client'
 
-import { useState, useEffect } from 'react'
+import { useState, useEffect, useMemo } from 'react'
 import { fetchCep } from '@/utils/cep'
 import { useAuthContext } from '@/lib/context/AuthContext'
 import { useToast } from '@/lib/context/ToastContext'
 import type { ClientResponseError } from 'pocketbase'
 import Spinner from '@/components/atoms/Spinner'
+import createPocketBase from '@/lib/pocketbase'
+import { getAuthHeaders } from '@/lib/authHeaders'
 import {
   FormField,
   TextField,
@@ -21,6 +23,7 @@ export default function SignUpForm({
   children?: React.ReactNode
 }) {
   const { signUp } = useAuthContext()
+  const pb = useMemo(() => createPocketBase(), [])
 
   const [campos, setCampos] = useState<{ id: string; nome: string }[]>([])
   const [campo, setCampo] = useState('')
@@ -44,13 +47,19 @@ export default function SignUpForm({
   useEffect(() => {
     async function loadCampos() {
       try {
-        const resTenant = await fetch('/api/tenant')
+        const resTenant = await fetch('/api/tenant', {
+          headers: getAuthHeaders(pb),
+          credentials: 'include',
+        })
         const data = resTenant.ok ? await resTenant.json() : { tenantId: null }
         const tenantId = data.tenantId
 
         if (!tenantId) return
 
-        const res = await fetch('/api/campos')
+        const res = await fetch('/api/campos', {
+          headers: getAuthHeaders(pb),
+          credentials: 'include',
+        })
         if (res.ok) {
           const data = await res.json()
           const lista = Array.isArray(data)

--- a/hooks/useWhatsappApi.ts
+++ b/hooks/useWhatsappApi.ts
@@ -1,14 +1,21 @@
+import createPocketBase from '@/lib/pocketbase'
+import { getAuthHeaders } from '@/lib/authHeaders'
+
 export async function connectInstance(
   instanceName: string,
   apiKey: string,
   tenantId: string,
 ) {
+  const pb = createPocketBase()
+  const headers = {
+    ...getAuthHeaders(pb),
+    'Content-Type': 'application/json',
+    'x-tenant-id': tenantId,
+  }
   const res = await fetch('/api/chats/whatsapp/instance/connect', {
     method: 'POST',
-    headers: {
-      'Content-Type': 'application/json',
-      'x-tenant-id': tenantId,
-    },
+    headers,
+    credentials: 'include',
     body: JSON.stringify({ instanceName, apiKey }),
   })
 
@@ -25,12 +32,16 @@ export async function fetchConnectionState(
   apiKey: string,
   tenantId: string,
 ) {
+  const pb = createPocketBase()
+  const headers = {
+    ...getAuthHeaders(pb),
+    'Content-Type': 'application/json',
+    'x-tenant-id': tenantId,
+  }
   const res = await fetch('/api/chats/whatsapp/instance/connectionState', {
     method: 'POST',
-    headers: {
-      'Content-Type': 'application/json',
-      'x-tenant-id': tenantId,
-    },
+    headers,
+    credentials: 'include',
     body: JSON.stringify({ instanceName, apiKey }),
   })
 

--- a/lib/hooks/useAuth.ts
+++ b/lib/hooks/useAuth.ts
@@ -14,6 +14,7 @@ export function useAuth() {
 
   useEffect(() => {
     const update = () => {
+      pb.authStore.loadFromCookie(document.cookie)
       const isValid = pb.authStore.isValid
       const model = pb.authStore.model as unknown as UserModel | null
       const tokenAtual = pb.authStore.token

--- a/lib/hooks/useInscricoes.ts
+++ b/lib/hooks/useInscricoes.ts
@@ -1,18 +1,22 @@
 'use client'
-import { useEffect, useState } from 'react'
+import { useEffect, useState, useMemo } from 'react'
 
 import { useAuthContext } from '@/lib/context/AuthContext'
+import createPocketBase from '@/lib/pocketbase'
+import { getAuthHeaders } from '@/lib/authHeaders'
 import type { Inscricao } from '@/types'
 
 export default function useInscricoes() {
   const { tenantId } = useAuthContext()
+  const pb = useMemo(() => createPocketBase(), [])
   const [inscricoes, setInscricoes] = useState<Inscricao[]>([])
   const [loading, setLoading] = useState(true)
 
   useEffect(() => {
     if (!tenantId) return
     let active = true
-    fetch('/api/inscricoes', { credentials: 'include' })
+    const headers = getAuthHeaders(pb)
+    fetch('/api/inscricoes', { headers, credentials: 'include' })
       .then((res) => (res.ok ? res.json() : Promise.reject()))
       .then((data) => {
         if (active) setInscricoes(data as Inscricao[])

--- a/lib/hooks/useProdutos.ts
+++ b/lib/hooks/useProdutos.ts
@@ -1,18 +1,22 @@
 'use client'
-import { useEffect, useState } from 'react'
+import { useEffect, useState, useMemo } from 'react'
 
 import { useAuthContext } from '@/lib/context/AuthContext'
+import createPocketBase from '@/lib/pocketbase'
+import { getAuthHeaders } from '@/lib/authHeaders'
 import type { Produto } from '@/types'
 
 export default function useProdutos() {
   const { tenantId } = useAuthContext()
+  const pb = useMemo(() => createPocketBase(), [])
   const [produtos, setProdutos] = useState<Produto[]>([])
   const [loading, setLoading] = useState(true)
 
   useEffect(() => {
     if (!tenantId) return
     let active = true
-    fetch('/api/produtos', { credentials: 'include' })
+    const headers = getAuthHeaders(pb)
+    fetch('/api/produtos', { headers, credentials: 'include' })
       .then((res) => (res.ok ? res.json() : Promise.reject()))
       .then((data) => {
         if (active) setProdutos(data as Produto[])

--- a/lib/hooks/useSyncTenant.ts
+++ b/lib/hooks/useSyncTenant.ts
@@ -1,8 +1,12 @@
 'use client'
-import { useEffect } from 'react'
+import { useEffect, useMemo } from 'react'
+import createPocketBase from '@/lib/pocketbase'
+import { getAuthHeaders } from '@/lib/authHeaders'
 
 export function useSyncTenant() {
+  const pb = useMemo(() => createPocketBase(), [])
   useEffect(() => {
-    fetch('/api/tenant', { credentials: 'include' }).catch(() => {})
-  }, [])
+    const headers = getAuthHeaders(pb)
+    fetch('/api/tenant', { headers, credentials: 'include' }).catch(() => {})
+  }, [pb])
 }

--- a/lib/posts/getPostsClientPB.ts
+++ b/lib/posts/getPostsClientPB.ts
@@ -1,4 +1,5 @@
 import createPocketBase from '@/lib/pocketbase'
+import { getAuthHeaders } from '@/lib/authHeaders'
 
 export interface PostClientRecord {
   id: string
@@ -15,7 +16,8 @@ export interface PostClientRecord {
 
 export async function getPostsClientPB(): Promise<PostClientRecord[]> {
   const pb = createPocketBase()
-  const res = await fetch('/api/tenant')
+  const headers = getAuthHeaders(pb)
+  const res = await fetch('/api/tenant', { headers, credentials: 'include' })
   const data = (await res.json()) as { tenantId: string | null }
   const tenantId = data.tenantId
 

--- a/logs/DOC_LOG.md
+++ b/logs/DOC_LOG.md
@@ -460,3 +460,4 @@ executados.
 ## [2025-06-27] Campo bairro adicionado na edicao de perfil. Lint e build executados.
 ## [2025-06-27] Atualizacao de rotas para /cliente/dashboard e ajuste de docs.
 ## [2025-06-27] ProfileForm atualizado com campos de endereco e rota correta. Lint e build executados.
+## [2025-06-27] Aplicado getAuthHeaders em múltiplas chamadas API e atualizado useAuth para carregar cookie

--- a/logs/ERR_LOG.md
+++ b/logs/ERR_LOG.md
@@ -171,3 +171,4 @@
 ## [2025-07-31] Erro ao criar inscrição com usuário logado: API retornava "validation_not_unique" para o email. Rota /loja/api/inscricoes agora reutiliza o usuário autenticado quando disponível - dev
 
 ## [2025-07-31] Build falhava por "usuario" possivelmente nulo em /loja/api/inscricoes. Adicionada checagem final para garantir usuario antes de prosseguir - dev - 209f481
+## [2025-06-27] Diversos fetch('/api') não enviavam token de autenticação. Adicionada função getAuthHeaders em hooks e páginas - dev


### PR DESCRIPTION
## Summary
- ensure auth cookie is loaded inside `useAuth`
- apply `getAuthHeaders` to various API requests
- log fixes

## Testing
- `npm run lint` *(fails: next not found)*
- `npm run build` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_685eb591e75c832c908c4cbe4893dce6