### PR TITLE
Fix auth headers without document.cookie

### DIFF
--- a/lib/authHeaders.ts
+++ b/lib/authHeaders.ts
@@ -1,9 +1,11 @@
 import type PocketBase from 'pocketbase'
 
 export function getAuthHeaders(pb: PocketBase) {
-  pb.authStore.loadFromCookie(document.cookie)
-  return {
-    Authorization: `Bearer ${pb.authStore.token}`,
-    'X-PB-User': JSON.stringify(pb.authStore.model),
+  if (pb.authStore.isValid && pb.authStore.token && pb.authStore.model) {
+    return {
+      Authorization: `Bearer ${pb.authStore.token}`,
+      'X-PB-User': JSON.stringify(pb.authStore.model),
+    }
   }
+  return {}
 }

--- a/lib/context/AuthContext.tsx
+++ b/lib/context/AuthContext.tsx
@@ -1,10 +1,7 @@
 'use client'
 
 import { createContext, useContext, useEffect, useMemo, useState } from 'react'
-import createPocketBase, {
-  clearBaseAuth,
-  updateBaseAuth,
-} from '@/lib/pocketbase'
+import createPocketBase, { clearBaseAuth } from '@/lib/pocketbase'
 import { getAuthHeaders } from '@/lib/authHeaders'
 import type { UserModel } from '@/types/UserModel'
 
@@ -59,8 +56,6 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
         })
         if (meRes.ok) {
           const data = await meRes.json()
-          pb.authStore.loadFromCookie(document.cookie)
-          updateBaseAuth(pb.authStore.token, pb.authStore.model)
           setUser(data.user as UserModel)
           setIsLoggedIn(true)
         }
@@ -103,8 +98,6 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
     })
     if (!res.ok) throw new Error('Login failed')
     const data = await res.json()
-    pb.authStore.loadFromCookie(document.cookie)
-    updateBaseAuth(pb.authStore.token, pb.authStore.model)
     setUser(data.user as UserModel)
     setIsLoggedIn(true)
     if (typeof window !== 'undefined') {

--- a/lib/hooks/useAuth.ts
+++ b/lib/hooks/useAuth.ts
@@ -2,37 +2,36 @@
 
 'use client'
 
-import { useState, useEffect, useMemo } from 'react'
-import createPocketBase from '@/lib/pocketbase'
+import { useState, useEffect } from 'react'
 import type { UserModel } from '@/types/UserModel'
 
 export function useAuth() {
-  const pb = useMemo(() => createPocketBase(), [])
   const [user, setUser] = useState<UserModel | null>(null)
-  const [token, setToken] = useState<string | null>(null)
   const [isLoggedIn, setIsLoggedIn] = useState(false)
 
   useEffect(() => {
-    const update = () => {
-      pb.authStore.loadFromCookie(document.cookie)
-      const isValid = pb.authStore.isValid
-      const model = pb.authStore.model as unknown as UserModel | null
-      const tokenAtual = pb.authStore.token
-
-      setUser(model)
-      setToken(tokenAtual)
-      setIsLoggedIn(isValid && !!model)
+    async function load() {
+      try {
+        const res = await fetch('/api/auth/me', { credentials: 'include' })
+        if (res.ok) {
+          const data = await res.json()
+          setUser(data.user as UserModel)
+          setIsLoggedIn(true)
+        } else {
+          setUser(null)
+          setIsLoggedIn(false)
+        }
+      } catch {
+        setUser(null)
+        setIsLoggedIn(false)
+      }
     }
 
-    update()
-
-    const unsubscribe = pb.authStore.onChange(update)
-    return () => unsubscribe()
-  }, [pb])
+    load()
+  }, [])
 
   return {
     user,
-    token,
     isLoggedIn,
   }
 }


### PR DESCRIPTION
## Summary
- derive auth headers only from PocketBase authStore
- update AuthContext and hooks to stop reading HttpOnly cookie

## Testing
- `npm run lint` *(fails: next not found)*
- `npm run build` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_685ebf8c7dcc832cbb1b85485f266cb1