### PR TITLE
Fix getAuthHeaders return type

### DIFF
--- a/lib/authHeaders.ts
+++ b/lib/authHeaders.ts
@@ -1,6 +1,6 @@
 import type PocketBase from 'pocketbase'
 
-export function getAuthHeaders(pb: PocketBase) {
+export function getAuthHeaders(pb: PocketBase): HeadersInit {
   if (pb.authStore.isValid && pb.authStore.token && pb.authStore.model) {
     return {
       Authorization: `Bearer ${pb.authStore.token}`,

--- a/logs/ERR_LOG.md
+++ b/logs/ERR_LOG.md
@@ -173,3 +173,4 @@
 ## [2025-07-31] Build falhava por "usuario" possivelmente nulo em /loja/api/inscricoes. Adicionada checagem final para garantir usuario antes de prosseguir - dev - 209f481
 ## [2025-06-27] Diversos fetch('/api') não enviavam token de autenticação. Adicionada função getAuthHeaders em hooks e páginas - dev
 ## [2025-06-27] Erro "Token ou usuário ausente" ao atualizar perfil. Login agora retorna token e contexto salva credenciais.
+## [2025-06-27] Corrigida tipagem de retorno em getAuthHeaders para HeadersInit evitando erro de build em app/admin/inscricoes/page.tsx - dev - 5b28761


### PR DESCRIPTION
## Summary
- specify `HeadersInit` as return type for `getAuthHeaders`
- log error resolution about auth headers build bug

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_685ec4e07ee0832ca2c81604ec3392b5