### PR TITLE
fix: envia genero e corrige data no perfil

### DIFF
--- a/app/api/usuario/atualizar-dados/route.ts
+++ b/app/api/usuario/atualizar-dados/route.ts
@@ -39,7 +39,15 @@ export async function PATCH(req: NextRequest) {
     if (campo_id) data.campo = String(campo_id)
 
     const updated = await pbSafe.collection('usuarios').update(user.id, data)
-    return NextResponse.json(updated, { status: 200 })
+    pbSafe.authStore.save(pbSafe.authStore.token, updated)
+    const cookie = pbSafe.authStore.exportToCookie({
+      httpOnly: true,
+      secure: process.env.NODE_ENV === 'production',
+      path: '/',
+    })
+    const res = NextResponse.json(updated, { status: 200 })
+    res.headers.append('Set-Cookie', cookie)
+    return res
   } catch (err) {
     console.error('Erro ao atualizar dados:', err)
     return NextResponse.json(

--- a/app/cliente/components/ProfileForm.tsx
+++ b/app/cliente/components/ProfileForm.tsx
@@ -15,6 +15,7 @@ export default function ProfileForm() {
   const [telefone, setTelefone] = useState('')
   const [cpf, setCpf] = useState('')
   const [dataNascimento, setDataNascimento] = useState('')
+  const [genero, setGenero] = useState('')
   const [cep, setCep] = useState('')
   const [endereco, setEndereco] = useState('')
   const [bairro, setBairro] = useState('')
@@ -27,9 +28,11 @@ export default function ProfileForm() {
       setNome(String(user.nome ?? ''))
       setTelefone(String(user.telefone ?? ''))
       setCpf(String(user.cpf ?? ''))
-      setDataNascimento(String(user.data_nascimento ?? ''))
+      const nasc = String(user.data_nascimento ?? '')
+      setDataNascimento(nasc ? nasc.split(' ')[0] : '')
       setCep(String(user.cep ?? ''))
       setEndereco(String(user.endereco ?? ''))
+      setGenero(String(user.genero ?? ''))
       setBairro(String(user.bairro ?? ''))
       setCidade(String(user.cidade ?? ''))
       setNumero(String(user.numero ?? ''))
@@ -54,6 +57,7 @@ export default function ProfileForm() {
           telefone: telefone.trim(),
           cpf: cpf.trim(),
           data_nascimento: dataNascimento,
+          genero,
           cep,
           endereco,
           bairro,
@@ -63,6 +67,8 @@ export default function ProfileForm() {
         }),
       })
       if (res.ok) {
+        const updated = await res.json()
+        pb.authStore.save(pb.authStore.token, updated)
         showSuccess('Dados atualizados!')
       } else {
         showError('Erro ao salvar.')
@@ -117,6 +123,18 @@ export default function ProfileForm() {
           value={dataNascimento}
           onChange={(e) => setDataNascimento(e.target.value)}
         />
+      </FormField>
+      <FormField label="Gênero" htmlFor="perfil-genero">
+        <select
+          id="perfil-genero"
+          className={inputStyle}
+          value={genero}
+          onChange={(e) => setGenero(e.target.value)}
+        >
+          <option value="">Selecione</option>
+          <option value="masculino">Masculino</option>
+          <option value="feminino">Feminino</option>
+        </select>
       </FormField>
       <FormField label="CEP" htmlFor="perfil-cep">
         <TextField

--- a/logs/ERR_LOG.md
+++ b/logs/ERR_LOG.md
@@ -175,3 +175,4 @@
 ## [2025-06-27] Erro "Token ou usuário ausente" ao atualizar perfil. Login agora retorna token e contexto salva credenciais.
 ## [2025-06-27] Corrigida tipagem de retorno em getAuthHeaders para HeadersInit evitando erro de build em app/admin/inscricoes/page.tsx - dev - 5b28761
 ## [2025-06-27] Correção de dependências de pb em diversos useEffect - dev
+## [2025-06-27] Perfil do cliente não enviava gênero e data_nascimento retornava formato inválido. Rota de atualização agora ajusta cookie - dev

--- a/types/UserModel.ts
+++ b/types/UserModel.ts
@@ -11,6 +11,7 @@ export type UserModel = {
   estado?: string
   cep?: string
   cidade?: string
+  genero?: string
   campo?: string
   role: 'coordenador' | 'lider' | 'usuario'
   cliente?: string


### PR DESCRIPTION
## Summary
- enviar campo `genero` ao atualizar perfil do cliente
- normalizar `data_nascimento` para `YYYY-MM-DD`
- atualizar cookie de autenticação na rota PATCH
- tipagem do usuário inclui `genero`
- registrar correção em `ERR_LOG.md`

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_685ecb1bc96c832ca5ccf813cacc535f