### PR TITLE
Fix profile update to preserve fields

### DIFF
--- a/app/api/usuario/atualizar-dados/route.ts
+++ b/app/api/usuario/atualizar-dados/route.ts
@@ -23,22 +23,45 @@ export async function PATCH(req: NextRequest) {
       genero,
     } = await req.json()
 
-    const data: Record<string, unknown> = {
-      nome: String(nome || '').trim(),
-      telefone: String(telefone || '').replace(/\D/g, ''),
-      cpf: String(cpf || '').replace(/\D/g, ''),
-      data_nascimento: String(data_nascimento || ''),
-      cep: String(cep || ''),
-      numero: String(numero || ''),
-      cidade: String(cidade || ''),
-      estado: String(estado || ''),
-      endereco: String(endereco || ''),
-      bairro: String(bairro || ''),
-      genero: String(genero || ''),
-    }
-    if (campo_id) data.campo = String(campo_id)
+    const payload: Record<string, unknown> = {}
 
-    const updated = await pbSafe.collection('usuarios').update(user.id, data)
+    if (nome !== undefined) {
+      payload.nome = String(nome).trim()
+    }
+    if (telefone !== undefined) {
+      payload.telefone = String(telefone).replace(/\D/g, '')
+    }
+    if (cpf !== undefined) {
+      payload.cpf = String(cpf).replace(/\D/g, '')
+    }
+    if (data_nascimento !== undefined) {
+      payload.data_nascimento = String(data_nascimento)
+    }
+    if (cep !== undefined) {
+      payload.cep = String(cep)
+    }
+    if (numero !== undefined) {
+      payload.numero = String(numero)
+    }
+    if (cidade !== undefined) {
+      payload.cidade = String(cidade)
+    }
+    if (estado !== undefined) {
+      payload.estado = String(estado)
+    }
+    if (endereco !== undefined) {
+      payload.endereco = String(endereco)
+    }
+    if (bairro !== undefined) {
+      payload.bairro = String(bairro)
+    }
+    if (genero !== undefined) {
+      payload.genero = String(genero)
+    }
+    if (campo_id !== undefined) {
+      payload.campo = String(campo_id)
+    }
+    const updated = await pbSafe.collection('usuarios').update(user.id, payload)
     pbSafe.authStore.save(pbSafe.authStore.token, updated)
     const cookie = pbSafe.authStore.exportToCookie({
       httpOnly: true,

--- a/app/api/usuarios/[id]/route.ts
+++ b/app/api/usuarios/[id]/route.ts
@@ -40,20 +40,43 @@ export async function PATCH(req: NextRequest) {
   }
   try {
     const data = await req.json()
-    await pb.collection('usuarios').update(id, {
-      nome: String(data.nome || '').trim(),
-      telefone: String(data.telefone || '').replace(/\D/g, ''),
-      cpf: String(data.cpf || '').replace(/\D/g, ''),
-      data_nascimento: String(data.data_nascimento || ''),
-      endereco: String(data.endereco || '').trim(),
-      numero: String(data.numero || '').trim(),
-      bairro: String(data.bairro || '').trim(),
-      cidade: String(data.cidade || '').trim(),
-      estado: String(data.estado || '').trim(),
-      cep: String(data.cep || '').replace(/\D/g, ''),
-      ...(data.tour !== undefined ? { tour: Boolean(data.tour) } : {}),
-      role: user.role,
-    })
+    const payload: Record<string, unknown> = { role: user.role }
+
+    if (data.nome !== undefined) {
+      payload.nome = String(data.nome).trim()
+    }
+    if (data.telefone !== undefined) {
+      payload.telefone = String(data.telefone).replace(/\D/g, '')
+    }
+    if (data.cpf !== undefined) {
+      payload.cpf = String(data.cpf).replace(/\D/g, '')
+    }
+    if (data.data_nascimento !== undefined) {
+      payload.data_nascimento = String(data.data_nascimento)
+    }
+    if (data.endereco !== undefined) {
+      payload.endereco = String(data.endereco).trim()
+    }
+    if (data.numero !== undefined) {
+      payload.numero = String(data.numero).trim()
+    }
+    if (data.bairro !== undefined) {
+      payload.bairro = String(data.bairro).trim()
+    }
+    if (data.cidade !== undefined) {
+      payload.cidade = String(data.cidade).trim()
+    }
+    if (data.estado !== undefined) {
+      payload.estado = String(data.estado).trim()
+    }
+    if (data.cep !== undefined) {
+      payload.cep = String(data.cep).replace(/\D/g, '')
+    }
+    if (data.tour !== undefined) {
+      payload.tour = Boolean(data.tour)
+    }
+
+    await pb.collection('usuarios').update(id, payload)
     return NextResponse.json({ ok: true })
   } catch (err) {
     console.error('Erro ao atualizar perfil:', err)

--- a/logs/DOC_LOG.md
+++ b/logs/DOC_LOG.md
@@ -462,3 +462,4 @@ executados.
 ## [2025-06-27] ProfileForm atualizado com campos de endereco e rota correta. Lint e build executados.
 ## [2025-06-27] Aplicado getAuthHeaders em múltiplas chamadas API e atualizado useAuth para carregar cookie
 ## [2025-06-27] Login retorna token para salvar no contexto e reutilizar em chamadas API. Lint e build executados.
+## [2025-06-27] Atualizado update de usuario para ignorar campos ausentes e preservar dados. Lint e build executados.


### PR DESCRIPTION
## Summary
- avoid overwriting missing fields when updating user data
- keep existing values if request omits some fields
- document lint and build runs

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_685ee4fe9694832c810ff4b8a8f2fccf