### PR TITLE
Add tour selectors to Dashboard Analytics filters and export buttons

### DIFF
--- a/app/admin/components/DashboardAnalytics.tsx
+++ b/app/admin/components/DashboardAnalytics.tsx
@@ -154,7 +154,10 @@ export default function DashboardAnalytics({
       <h3 className="text-lg font-semibold mb-4 dark:text-gray-100">
         Análises Temporais{mostrarFinanceiro ? ' e Financeiras' : ''}
       </h3>
-      <div className="flex flex-wrap gap-4 items-center mb-6">
+      <div
+        className="flex flex-wrap gap-4 items-center mb-6"
+        data-tour="dashboard-filter"
+      >
         <div className="flex items-center gap-2">
           <label className="text-sm dark:text-gray-100" htmlFor="inicio">
             Início:
@@ -179,11 +182,16 @@ export default function DashboardAnalytics({
             className="border rounded px-2 py-1"
           />
         </div>
-        <button onClick={handleExportCSV} className="btn btn-primary px-3 py-1">
+        <button
+          onClick={handleExportCSV}
+          data-tour="btn-export-csv"
+          className="btn btn-primary px-3 py-1"
+        >
           Exportar CSV
         </button>
         <button
           onClick={handleExportXLSX}
+          data-tour="btn-export-xlsx"
           className="btn btn-primary px-3 py-1"
         >
           Exportar XLSX

--- a/logs/DOC_LOG.md
+++ b/logs/DOC_LOG.md
@@ -467,3 +467,4 @@ executados.
 ## [2025-06-27] Exportação do tour 'adminFinanceiroSaldoTour' adicionada em docs/Roteiro_admin.md. Impacto: importação simplificada dos roteiros. Lint e build falharam (next not found).
 ## [2025-06-27] Atualizado Roteiro_admin.md para usar seletores `[data-tour]` e mapeados todos os passos em components/tourSteps.
 ## [2025-06-27] Removido tour '/admin/produtos/novo' por nao existir rota dedicada. Documentacao e mapeamento ajustados.
+## [2025-06-27] Inclusão de data-tour em DashboardAnalytics para filtros e botões de exportação. Lint e build falharam (next not found).


### PR DESCRIPTION
## Summary
- add `data-tour` attributes for Dashboard analytics filter and export buttons
- log documentation update

## Testing
- `npm run lint` *(fails: next not found)*
- `npm run build` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_685ef2f5f184832c9e80c19bd107ffbd