### PR TITLE
Implement valid step filter for Joyride

### DIFF
--- a/components/AdminClientTour.tsx
+++ b/components/AdminClientTour.tsx
@@ -24,6 +24,13 @@ export function AdminClientTour({ stepsByRoute }: AdminClientTourProps) {
     () => stepsByRoute[pathname] || [],
     [pathname, stepsByRoute],
   )
+  const validSteps = steps.filter((step) => {
+    try {
+      return Boolean(document.querySelector(step.target as string))
+    } catch {
+      return false
+    }
+  })
   const storageKey = `${tenantId ?? 'public'}-${pathname}-tour-completed`
 
   useEffect(() => {
@@ -44,7 +51,7 @@ export function AdminClientTour({ stepsByRoute }: AdminClientTourProps) {
     }
   }
 
-  if (!steps.length) return null
+  if (!validSteps.length) return null
 
   return (
     <>
@@ -52,7 +59,7 @@ export function AdminClientTour({ stepsByRoute }: AdminClientTourProps) {
         getHelpers={(h) => {
           tourRef.current = h
         }}
-        steps={steps}
+        steps={validSteps}
         continuous
         showSkipButton
         scrollToFirstStep

--- a/logs/DOC_LOG.md
+++ b/logs/DOC_LOG.md
@@ -469,3 +469,4 @@ executados.
 ## [2025-06-27] Removido tour '/admin/produtos/novo' por nao existir rota dedicada. Documentacao e mapeamento ajustados.
 ## [2025-06-27] Inclusão de data-tour em DashboardAnalytics para filtros e botões de exportação. Lint e build falharam (next not found).
 ## [2025-06-27] Seletores do tour atualizados para data-tour em dashboard, exportações CSV/XLSX. Lint e build executados.
+## [2025-06-27] AdminClientTour filtra passos cujos seletores não existem no DOM antes de iniciar o tour.


### PR DESCRIPTION
## Summary
- filter Joyride steps based on DOM availability in `AdminClientTour`
- document change in `DOC_LOG`

## Testing
- `npm run lint` *(fails: next not found)*
- `npm run build` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_685ef648e600832cab4c6016eeb8979e