### PR TITLE
Add leader promotion notifications

### DIFF
--- a/__tests__/api/adminUsuariosPatchRoute.test.ts
+++ b/__tests__/api/adminUsuariosPatchRoute.test.ts
@@ -17,7 +17,7 @@ describe('PATCH /admin/api/usuarios/[id]', () => {
       pb: { collection: () => ({ update: updateMock }) } as any,
       user: { cliente: 't1' },
     })
-    ;(fetchUsuario as unknown as { mockResolvedValue: (v: any) => void }).mockResolvedValue({})
+    ;(fetchUsuario as unknown as { mockResolvedValue: (v: any) => void }).mockResolvedValue({ role: 'lider' })
 
     const req = new Request('http://test/admin/api/usuarios/u1', {
       method: 'PATCH',
@@ -59,5 +59,32 @@ describe('PATCH /admin/api/usuarios/[id]', () => {
 
     const res = await PATCH(req as unknown as NextRequest)
     expect(res.status).toBe(403)
+  })
+
+  it('envia notificacoes quando papel muda para lider', async () => {
+    const updateMock = vi.fn().mockResolvedValue({})
+    const getOneMock = vi.fn().mockResolvedValue({ expand: { campo: { nome: 'Campo 1' } } })
+    ;(requireRole as unknown as { mockReturnValue: (v: any) => void }).mockReturnValue({
+      pb: { collection: () => ({ update: updateMock, getOne: getOneMock }) } as any,
+      user: { cliente: 't1' },
+    })
+    ;(fetchUsuario as unknown as { mockResolvedValue: (v: any) => void }).mockResolvedValue({ role: 'usuario' })
+
+    const fetchMock = vi.fn().mockResolvedValue({ ok: true })
+    global.fetch = fetchMock as unknown as typeof fetch
+
+    const req = new Request('http://test/admin/api/usuarios/u1', {
+      method: 'PATCH',
+      body: JSON.stringify({ role: 'lider' }),
+    })
+    ;(req as any).nextUrl = new URL('http://test/admin/api/usuarios/u1')
+
+    const res = await PATCH(req as unknown as NextRequest)
+    expect(res.status).toBe(200)
+    expect(fetchMock).toHaveBeenCalledWith('http://test/api/email', expect.any(Object))
+    expect(fetchMock).toHaveBeenCalledWith(
+      'http://test/api/chats/message/sendWelcome',
+      expect.any(Object),
+    )
   })
 })

--- a/docs/Implementacao_Email.md
+++ b/docs/Implementacao_Email.md
@@ -4,6 +4,7 @@ Este guia detalha os passos para criar uma rota unificada no Next.js que dispare
 
 - **nova_inscricao**
 - **confirmacao_inscricao**
+- **promocao_lider**
 
 O fluxo abrange desde a configuração de SMTP por tenant no PocketBase até os testes das chamadas.
 
@@ -76,6 +77,7 @@ Para **multi-tenant**, adicione campos na coleção `clientes_config`:
 
    - `nova_inscricao`
    - `confirmacao_inscricao` (opcionalmente fornecendo `paymentLink`)
+   - `promocao_lider`
 
 4. **Conferência de Logs**: examine o console do servidor Next.js para confirmar a autenticação do Nodemailer e o envio dos e-mails, identificando possíveis erros.
 
@@ -118,7 +120,7 @@ import { getTenantFromHost } from '@/lib/server/tenancy'
 
 ```ts
 type Body = {
-  eventType: 'nova_inscricao' | 'confirmacao_inscricao'
+  eventType: 'nova_inscricao' | 'confirmacao_inscricao' | 'promocao_lider'
   userId: string
   paymentLink?: string
 }
@@ -202,6 +204,19 @@ return NextResponse.json({
     body: JSON.stringify({
       eventType: 'confirmacao_inscricao',
       userId: 'abc123',
+    }),
+  })
+  ```
+
+- **Promoção a Líder**
+
+  ```ts
+  await fetch('/api/email', {
+    method: 'POST',
+    body: JSON.stringify({
+      eventType: 'promocao_lider',
+      userId: 'abc123',
+      campoNome: 'Campo Norte',
     }),
   })
   ```

--- a/lib/templates/email/promocaoLider.html
+++ b/lib/templates/email/promocaoLider.html
@@ -1,0 +1,73 @@
+<!doctype html>
+<html lang="pt-BR">
+
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Promoção a Líder</title>
+</head>
+
+<body
+  style="margin:0; padding:0; background-color:#e9f7fd; font-family:'Helvetica Neue', Helvetica, Arial, sans-serif; color:#333333;">
+  <!-- Container Geral -->
+  <table width="100%" cellpadding="0" cellspacing="0" border="0" style="background-color:#e9f7fd; padding:30px;">
+    <tr>
+      <td align="center">
+        <!-- Card Principal -->
+        <table width="600" cellpadding="0" cellspacing="0" border="0"
+          style="background-color:#ffffff; border-radius:12px; overflow:hidden; box-shadow:0 4px 12px rgba(0,0,0,0.1);">
+          <!-- Preheader -->
+          <tr>
+            <td
+              style="display:none; font-size:1px; line-height:1px; max-height:0; max-width:0; opacity:0; overflow:hidden;">
+              🎉 Agora você é líder no {{tenantNome}}!
+            </td>
+          </tr>
+          <!-- Banner Colorido -->
+          <tr>
+            <td style="background-color:{{cor_primary}}; height:8px;"></td>
+          </tr>
+          <!-- Cabeçalho com Logo -->
+          <tr>
+            <td align="center" style="padding:24px 24px 0;">
+              <img src="{{logoUrl}}" alt="Logo" width="120"
+                style="display:block; border:0; outline:none; text-decoration:none;">
+            </td>
+          </tr>
+          <!-- Conteúdo Principal -->
+          <tr>
+            <td style="padding:24px;">
+              <h2 style="margin:0 0 16px; font-size:26px; line-height:34px; color:{{cor_primary}};">Parabéns, {{userName}}!</h2>
+              <p style="margin:0 0 16px; font-size:16px; line-height:24px;">Você agora lidera o campo <strong>{{campoNome}}</strong> em <strong>{{tenantNome}}</strong>.</p>
+              <p style="margin:0 0 24px; font-size:16px; line-height:24px;">Confira abaixo os principais acessos disponíveis para sua nova função:</p>
+              <ul style="margin:0 0 24px 20px; padding:0; font-size:16px; line-height:24px;">
+                <li>Painel da Liderança (inscrições e pedidos do campo)</li>
+                <li>Páginas de Inscrições e Pedidos</li>
+                <li>Configurações do Perfil</li>
+                <li>Acesso rápido à Loja</li>
+              </ul>
+              <!-- Botão de Acesso -->
+              <table cellpadding="0" cellspacing="0" border="0" style="margin:0 auto;">
+                <tr>
+                  <td align="center" style="background-color:{{cor_primary}}; border-radius:6px;">
+                    <a href="{{loginLink}}"
+                      style="display:inline-block; padding:14px 28px; font-size:16px; color:#ffffff; text-decoration:none; border-radius:6px;">Acessar
+                      Painel</a>
+                  </td>
+                </tr>
+              </table>
+            </td>
+          </tr>
+          <!-- Rodapé Alegre -->
+          <tr>
+            <td style="padding:20px 24px; background-color:#f0f8ff; text-align:center; font-size:14px; color:#555555;">
+              <p style="margin:0;">Se você não solicitou este e-mail, apenas ignore-o 😊</p>
+            </td>
+          </tr>
+        </table>
+      </td>
+    </tr>
+  </table>
+</body>
+
+</html>

--- a/logs/DOC_LOG.md
+++ b/logs/DOC_LOG.md
@@ -463,3 +463,4 @@ executados.
 ## [2025-06-27] Aplicado getAuthHeaders em múltiplas chamadas API e atualizado useAuth para carregar cookie
 ## [2025-06-27] Login retorna token para salvar no contexto e reutilizar em chamadas API. Lint e build executados.
 ## [2025-06-27] Atualizado update de usuario para ignorar campos ausentes e preservar dados. Lint e build executados.
+## [2025-06-27] Evento 'promocao_lider' adicionado e rota PATCH envia notificacoes


### PR DESCRIPTION
## Summary
- add `promocao_lider` event support in email and chat routes
- create email template for new leaders
- trigger notifications when admin promotes user to leader
- document the new event
- update tests for PATCH route

## Testing
- `npm run lint` *(fails: next not found)*
- `npm run build` *(fails: next not found)*


------
https://chatgpt.com/codex/tasks/task_e_685f0730e95c832c965faad43d6c3ca1