### PR TITLE
Add WhatsApp contacts endpoint

### DIFF
--- a/app/api/chats/contacts/route.ts
+++ b/app/api/chats/contacts/route.ts
@@ -1,0 +1,37 @@
+import { NextRequest, NextResponse } from 'next/server'
+import { requireRole } from '@/lib/apiAuth'
+import type { UserModel } from '@/types/UserModel'
+
+export async function GET(req: NextRequest) {
+  const auth = requireRole(req, 'coordenador')
+  if ('error' in auth) {
+    return NextResponse.json({ error: auth.error }, { status: auth.status })
+  }
+  const { pb, user } = auth
+
+  const role = req.nextUrl.searchParams.get('role') || 'todos'
+  let filter = `cliente='${user.cliente}'`
+  if (role && role !== 'todos') {
+    filter += ` && role='${role}'`
+  }
+
+  try {
+    const list = await pb.collection('usuarios').getFullList<UserModel>({
+      filter,
+      sort: 'nome',
+    })
+    const result = list.map((u) => {
+      const avatar = (u as Record<string, unknown>).avatar as string | undefined
+      return {
+        id: u.id,
+        name: u.nome,
+        phone: u.telefone ?? undefined,
+        avatarUrl: avatar ? pb.files.getUrl(u, avatar) : undefined,
+      }
+    })
+    return NextResponse.json(result, { status: 200 })
+  } catch (err) {
+    const message = err instanceof Error ? err.message : 'Erro ao listar contato'
+    return NextResponse.json({ error: message }, { status: 500 })
+  }
+}

--- a/app/api/chats/message/broadcast/route.ts
+++ b/app/api/chats/message/broadcast/route.ts
@@ -30,7 +30,8 @@ export async function POST(req: NextRequest) {
       ),
     )
     const validos = usuarios.filter(
-      (u): u is UserModel => !!u && u.cliente === user.cliente && u.telefone,
+      (u): u is UserModel =>
+        !!u && u.cliente === user.cliente && !!u.telefone,
     )
 
     // Busca instanceId/apiKey do cliente

--- a/docs/Implementacao_WhatsApp.md
+++ b/docs/Implementacao_WhatsApp.md
@@ -25,3 +25,23 @@ Permite envio de mensagens manuais via WhatsApp para contatos selecionados.
 - Apenas coordenadores podem acessar esta rota.
 - O envio é feito apenas para os usuários selecionados com telefone válido.
 - O campo `errors` lista falhas individuais de envio. 
+
+## [GET] /api/chats/contacts?role=lider|usuario|todos
+
+Retorna a lista de usuários do tenant filtrando pelo papel desejado.
+
+- Query `role`: `lider`, `usuario` ou `todos` (padrão).
+- Requer autenticação de coordenador.
+- Responde com um array de contatos contendo `id`, `name`, `phone` e `avatarUrl`.
+
+### Exemplo de resposta
+```json
+[
+  {
+    "id": "abc123",
+    "name": "João",
+    "phone": "5511999999999",
+    "avatarUrl": "https://.../avatar.png"
+  }
+]
+```

--- a/logs/DOC_LOG.md
+++ b/logs/DOC_LOG.md
@@ -457,3 +457,5 @@ executados.
 
 ## [2025-06-26] InscricaoForm preenche campo via searchParams e valor do usuario. Campo permanece selecionado ao navegar entre etapas. Lint e build executados apos instalar dependencias.
 ## [2025-06-28] Atualizada documentação da rota de broadcast para aceitar lista de recipients.
+
+## [2025-08-10] Rota /api/chats/contacts criada e documentada. Lint e build executados.


### PR DESCRIPTION
## Summary
- create `/api/chats/contacts` endpoint
- filter users by role for broadcast feature
- clarify WhatsApp contacts API usage in docs
- note new docs entry in DOC_LOG

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6860955cb23c832c8aa5f7cd23b43657