### PR TITLE
Fix broadcast page logic and type catches

### DIFF
--- a/app/admin/whatsapp/mensagem-broadcast/page.tsx
+++ b/app/admin/whatsapp/mensagem-broadcast/page.tsx
@@ -78,6 +78,61 @@ export default function MensagemBroadcastPage() {
 
   if (!authChecked) return null
 
+  let bodyContent: React.ReactNode
+  if (!selected.size) {
+    bodyContent = (
+      <div className="flex-1 flex items-center justify-center text-muted">
+        Selecione ao menos um contato
+      </div>
+    )
+  } else {
+    bodyContent = (
+      <form
+        onSubmit={submit}
+        className="mt-auto bg-card border-t border-border"
+      >
+        <div className="flex flex-wrap gap-2 p-4">
+          {Array.from(selected).map((id) => {
+            const c = contacts.find((x) => x.id === id)!
+            return (
+              <span
+                key={id}
+                className="flex items-center gap-1 bg-primary/10 text-primary px-3 py-1 rounded-full"
+              >
+                {c.name}
+                <Button
+                  variant="secondary"
+                  className="p-1"
+                  onClick={() => toggle(id)}
+                >
+                  <X className="w-4 h-4" />
+                </Button>
+              </span>
+            )
+          })}
+        </div>
+
+        <div className="flex items-center p-4">
+          <Textarea
+            placeholder="Digite sua mensagem..."
+            value={message}
+            onChange={(e) => setMessage(e.target.value)}
+            disabled={loading}
+            rows={1}
+            className="flex-1"
+          />
+          <Button
+            type="submit"
+            disabled={loading || !message.trim()}
+            className="ml-2"
+          >
+            {loading ? 'Enviando...' : 'Enviar'}
+          </Button>
+        </div>
+      </form>
+    )
+  }
+
   return (
     <div className="flex h-screen bg-background">
       {/* Lista de contatos */}
@@ -143,55 +198,7 @@ export default function MensagemBroadcastPage() {
           </ul>
         </Card>
 
-        {!selected.size ? (
-          <div className="flex-1 flex items-center justify-center text-muted">
-            Selecione ao menos um contato
-          </div>
-        ) : (
-          <form
-            onSubmit={submit}
-            className="mt-auto bg-card border-t border-border"
-          >
-            <div className="flex flex-wrap gap-2 p-4">
-              {Array.from(selected).map((id) => {
-                const c = contacts.find((x) => x.id === id)!
-                return (
-                  <span
-                    key={id}
-                    className="flex items-center gap-1 bg-primary/10 text-primary px-3 py-1 rounded-full"
-                  >
-                    {c.name}
-                    <Button
-                      variant="secondary"
-                      className="p-1"
-                      onClick={() => toggle(id)}
-                    >
-                      <X className="w-4 h-4" />
-                    </Button>
-                  </span>
-                )
-              })}
-            </div>
-
-            <div className="flex items-center p-4">
-              <Textarea
-                placeholder="Digite sua mensagem..."
-                value={message}
-                onChange={(e) => setMessage(e.target.value)}
-                disabled={loading}
-                rows={1}
-                className="flex-1"
-              />
-              <Button
-                type="submit"
-                disabled={loading || !message.trim()}
-                className="ml-2"
-              >
-                {loading ? 'Enviando...' : 'Enviar'}
-              </Button>
-            </div>
-          </form>
-        )}
+        {bodyContent}
       </main>
     </div>
   )

--- a/app/api/chats/message/broadcast/route.ts
+++ b/app/api/chats/message/broadcast/route.ts
@@ -48,7 +48,7 @@ export async function POST(req: NextRequest) {
 
     // Envia mensagem para cada usuário
     await Promise.all(
-      validos.map(async (u) => {
+        validos.map(async (u) => {
         try {
           const telefone = u.telefone?.replace(/\D/g, '')
           if (!telefone || telefone.length < 10) {
@@ -63,7 +63,7 @@ export async function POST(req: NextRequest) {
             message,
           })
           success++
-        } catch (err) {
+        } catch (err: unknown) {
           failed++
           errors.push(`${u.nome}: ${(err as Error).message}`)
         }
@@ -71,7 +71,7 @@ export async function POST(req: NextRequest) {
     )
 
     return NextResponse.json({ success, failed, errors }, { status: 200 })
-  } catch (err) {
+  } catch (err: unknown) {
     const msg = err instanceof Error ? err.message : 'Erro desconhecido'
     return NextResponse.json({ errors: [msg] }, { status: 500 })
   }


### PR DESCRIPTION
## Summary
- adjust WhatsApp broadcast page to use an explicit `if` block instead of a ternary
- specify error types in broadcast route handler

## Testing
- `npm run lint` *(fails: next not found)*
- `npm run build` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_686098bd3b38832caaeb2117653d8992