### PR TITLE
Fix broadcast page avatar

### DIFF
--- a/app/admin/whatsapp/mensagem-broadcast/page.tsx
+++ b/app/admin/whatsapp/mensagem-broadcast/page.tsx
@@ -1,6 +1,7 @@
 'use client'
 
 import React, { useState, useEffect } from 'react'
+import Image from 'next/image'
 import { ArrowLeft, CheckCircle, X, Clock, Send, StopCircle } from 'lucide-react'
 import { useAuthGuard } from '@/lib/hooks/useAuthGuard'
 import { useToast } from '@/lib/hooks/useToast'
@@ -249,10 +250,11 @@ export default function MensagemBroadcastPage() {
                   ${broadcastProgress?.isProcessing ? 'opacity-50 cursor-not-allowed' : ''}`}
               >
                 <div className="flex items-center gap-3">
-                  {/* eslint-disable-next-line @next/next/no-img-element */}
-                  <img
+                  <Image
                     src={c.avatarUrl || '/avatar-placeholder.png'}
                     alt={c.name}
+                    width={32}
+                    height={32}
                     className="w-8 h-8 rounded-full"
                   />
                   <div>


### PR DESCRIPTION
## Summary
- use `Image` on broadcast contacts page

## Testing
- `npm run lint` *(fails: 'Send' defined but never used and other errors)*

------
https://chatgpt.com/codex/tasks/task_e_68609fe319bc832ca1da355246f1a4a5