### PR TITLE
fix: adjust inscrições chart aggregation

### DIFF
--- a/app/admin/dashboard/components/DashboardResumo.tsx
+++ b/app/admin/dashboard/components/DashboardResumo.tsx
@@ -61,12 +61,18 @@ export default function DashboardResumo({
     return acc
   }, {})
 
+  const contagemInscricoes = inscricoes.reduce<Record<string, number>>((acc, i) => {
+    const campo = i.expand?.campo?.nome || 'Sem campo'
+    acc[campo] = (acc[campo] || 0) + 1
+    return acc
+  }, {})
+
   const inscricoesChart = {
-    labels: inscricoes.map((i) => i.expand?.campo?.nome || 'Sem campo'),
+    labels: Object.keys(contagemInscricoes),
     datasets: [
       {
         label: 'Inscrições',
-        data: inscricoes.map(() => 1),
+        data: Object.values(contagemInscricoes),
         backgroundColor: twColors.primary600,
       },
     ],


### PR DESCRIPTION
## Summary
- aggregate inscrição counts by field when building chart data

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6862a1180d14832cac6b465cded4f2ed