### PR TITLE
Add leader confirmation message

### DIFF
--- a/app/api/chats/message/sendWelcome/route.ts
+++ b/app/api/chats/message/sendWelcome/route.ts
@@ -10,16 +10,20 @@ export type Body = {
     | 'novo_usuario'
     | 'confirmacao_pagamento'
     | 'promocao_lider'
+    | 'confirmacao_pendente_lider'
   userId: string
   paymentLink?: string
   campoNome?: string
+  inscritoNome?: string
+  eventoTitulo?: string
 }
 
 export async function POST(req: NextRequest) {
   const pb = createPocketBase()
 
   try {
-    const { eventType, userId, paymentLink, campoNome } = (await req.json()) as Body
+    const { eventType, userId, paymentLink, campoNome, inscritoNome, eventoTitulo } =
+      (await req.json()) as Body
     if (!eventType || !userId) {
       return NextResponse.json(
         { error: 'Parâmetros faltando' },
@@ -82,6 +86,9 @@ export async function POST(req: NextRequest) {
         break
       case 'promocao_lider':
         message = `Parabéns, ${nome}! Agora você lidera o campo ${campoNomeFinal}.`
+        break
+      case 'confirmacao_pendente_lider':
+        message = `Olá ${nome}! Recebemos a inscrição de ${inscritoNome} para o evento ${eventoTitulo}. Por favor, confirme no painel administrativo se está tudo certo ou entre em contato caso haja alguma dúvida.`
         break
       default:
         message = ''

--- a/app/api/inscricoes/route.ts
+++ b/app/api/inscricoes/route.ts
@@ -294,6 +294,21 @@ export async function POST(req: NextRequest) {
       console.error('Erro ao enviar WhatsApp de inscrição:', e)
     }
 
+    try {
+      await fetch(`${req.nextUrl.origin}/api/chats/message/sendWelcome`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          eventType: 'confirmacao_pendente_lider',
+          userId: liderId,
+          inscritoNome: nome,
+          eventoTitulo: evento.titulo,
+        }),
+      })
+    } catch (e) {
+      console.error('Erro ao enviar WhatsApp para o líder:', e)
+    }
+
     return NextResponse.json(responseData)
   } catch (err: unknown) {
     await logConciliacaoErro(`Erro ao criar inscrição: ${String(err)}`)

--- a/logs/DOC_LOG.md
+++ b/logs/DOC_LOG.md
@@ -465,3 +465,4 @@ executados.
 ## [2025-06-27] Atualizado update de usuario para ignorar campos ausentes e preservar dados. Lint e build executados.
 ## [2025-06-27] Evento 'promocao_lider' adicionado e rota PATCH envia notificacoes
 ## [2025-08-10] Seção 'Webhooks Asaas' adicionada ao README explicando prerequisitos e exemplo de cadastro.
+## [2025-06-30] Evento 'confirmacao_pendente_lider' notifica lider via WhatsApp. Lint e build executados.


### PR DESCRIPTION
## Summary
- add `confirmacao_pendente_lider` eventType to WhatsApp route
- notify leader when an inscription is created
- fetch leader and event details in public route
- update test for new leader notification
- document new eventType

## Testing
- `npm run lint`
- `npm run build`
- `npm test` *(fails: Cannot read properties of undefined)*

------
https://chatgpt.com/codex/tasks/task_e_6862ab39295c832cb1916c6a73568f5a