### PR TITLE
Fix request loops via pocketbase memoization

### DIFF
--- a/app/admin/inscricoes/page.tsx
+++ b/app/admin/inscricoes/page.tsx
@@ -1,6 +1,6 @@
 'use client'
 
-import { useEffect, useState } from 'react'
+import { useEffect, useState, useMemo } from 'react'
 import createPocketBase from '@/lib/pocketbase'
 import { getAuthHeaders } from '@/lib/authHeaders'
 import { Copy } from 'lucide-react'
@@ -50,7 +50,7 @@ type Inscricao = {
 
 export default function ListaInscricoesPage() {
   const { user, authChecked } = useAuthGuard(['coordenador', 'lider'])
-  const pb = createPocketBase()
+  const pb = useMemo(() => createPocketBase(), [])
   const tenantId = user?.cliente || ''
   const [inscricoes, setInscricoes] = useState<Inscricao[]>([])
   const [role, setRole] = useState('')

--- a/app/admin/produtos/editar/[id]/page.tsx
+++ b/app/admin/produtos/editar/[id]/page.tsx
@@ -1,6 +1,6 @@
 'use client'
 
-import { useEffect, useState, useRef } from 'react'
+import { useEffect, useState, useRef, useMemo } from 'react'
 import createPocketBase from '@/lib/pocketbase'
 import { getAuthHeaders } from '@/lib/authHeaders'
 import { useParams, useRouter } from 'next/navigation'
@@ -36,7 +36,7 @@ function slugify(str: string) {
 export default function EditarProdutoPage() {
   const { id } = useParams<{ id: string }>()
   const { user: ctxUser, isLoggedIn } = useAuthContext()
-  const pb = createPocketBase()
+  const pb = useMemo(() => createPocketBase(), [])
   const router = useRouter()
   const { showSuccess, showError } = useToast()
   const { authChecked } = useAuthGuard(['coordenador'])

--- a/app/admin/produtos/novo/ModalProduto.tsx
+++ b/app/admin/produtos/novo/ModalProduto.tsx
@@ -6,7 +6,7 @@
  * "Requer inscrição aprovada" e o botão de compra permanece desativado.
  */
 
-import { useEffect, useRef, useState } from 'react'
+import { useEffect, useRef, useState, useMemo } from 'react'
 import createPocketBase from '@/lib/pocketbase'
 import { getAuthHeaders } from '@/lib/authHeaders'
 import { useAuthContext } from '@/lib/context/AuthContext'
@@ -83,7 +83,7 @@ export function ModalProduto<T extends Record<string, unknown>>({
     initial.requer_inscricao_aprovada ?? false,
   )
   const { isLoggedIn, user: ctxUser } = useAuthContext()
-  const pb = createPocketBase()
+  const pb = useMemo(() => createPocketBase(), [])
   const { showSuccess, showError } = useToast()
   const [exclusivo, setExclusivo] = useState<boolean>(
     initial.exclusivo_user ?? false,

--- a/app/completar-cadastro/page.tsx
+++ b/app/completar-cadastro/page.tsx
@@ -1,6 +1,6 @@
 'use client'
 
-import { useEffect, useState } from 'react'
+import { useEffect, useState, useMemo } from 'react'
 import createPocketBase from '@/lib/pocketbase'
 import { getAuthHeaders } from '@/lib/authHeaders'
 import { fetchCep } from '@/utils/cep'
@@ -18,7 +18,7 @@ export default function CompletarCadastroPage() {
   const { authChecked } = useAuthGuard(['usuario'])
   const { showError, showSuccess } = useToast()
   const router = useRouter()
-  const pb = createPocketBase()
+  const pb = useMemo(() => createPocketBase(), [])
 
   const [dataNasc, setDataNasc] = useState('')
   const [genero, setGenero] = useState('')

--- a/app/inscricoes/lider/[liderId]/page.tsx
+++ b/app/inscricoes/lider/[liderId]/page.tsx
@@ -2,7 +2,7 @@
 
 import Image from 'next/image'
 import Link from 'next/link'
-import { useEffect, useState } from 'react'
+import { useEffect, useState, useMemo } from 'react'
 import createPocketBase from '@/lib/pocketbase'
 import { getAuthHeaders } from '@/lib/authHeaders'
 import { useParams } from 'next/navigation'
@@ -13,7 +13,7 @@ import type { Evento } from '@/types'
 export default function EscolherEventoPage() {
   const params = useParams()
   const liderId = params.liderId as string
-  const pb = createPocketBase()
+  const pb = useMemo(() => createPocketBase(), [])
   const [eventos, setEventos] = useState<Evento[]>([])
   const [loading, setLoading] = useState(true)
 

--- a/app/loja/checkout/page.tsx
+++ b/app/loja/checkout/page.tsx
@@ -2,7 +2,7 @@
 
 import { useCart } from '@/lib/context/CartContext'
 import { useRouter } from 'next/navigation'
-import { Suspense, useState, useEffect } from 'react'
+import { Suspense, useState, useEffect, useMemo } from 'react'
 import createPocketBase from '@/lib/pocketbase'
 import { getAuthHeaders } from '@/lib/authHeaders'
 import LoadingOverlay from '@/components/organisms/LoadingOverlay'
@@ -15,7 +15,6 @@ import {
   MAX_ITEM_DESCRIPTION_LENGTH,
   MAX_ITEM_NAME_LENGTH,
 } from '@/lib/constants'
-import { useMemo } from 'react'
 import type { Produto } from '@/types'
 import { useSyncTenant } from '@/lib/hooks/useSyncTenant'
 
@@ -28,7 +27,7 @@ function CheckoutContent() {
 
   const router = useRouter()
   const { isLoggedIn, user, tenantId } = useAuthContext()
-  const pb = createPocketBase()
+  const pb = useMemo(() => createPocketBase(), [])
   useSyncTenant()
   const { showSuccess, showError } = useToast()
 

--- a/app/loja/page.tsx
+++ b/app/loja/page.tsx
@@ -2,7 +2,7 @@
 
 import Image from 'next/image'
 import Link from 'next/link'
-import { useEffect, useState } from 'react'
+import { useEffect, useState, useMemo } from 'react'
 import createPocketBase from '@/lib/pocketbase'
 import { getAuthHeaders } from '@/lib/authHeaders'
 import { calculateGross } from '@/lib/asaasFees'
@@ -17,7 +17,7 @@ interface Produto {
 
 export default function Home() {
   const [produtosDestaque, setProdutosDestaque] = useState<Produto[]>([])
-  const pb = createPocketBase()
+  const pb = useMemo(() => createPocketBase(), [])
 
   useEffect(() => {
     async function fetchProdutos() {

--- a/logs/ERR_LOG.md
+++ b/logs/ERR_LOG.md
@@ -184,3 +184,4 @@
 
 ## [2025-06-27] EventForm nao normalizava data_nascimento ao preencher usuario; campo ficava vazio. Valor agora cortado para YYYY-MM-DD - dev
 ## [2025-08-10] Webhook agora registra accountId e externalReference quando cliente ausente - dev - dbfc979
+## [2025-06-30] Correção de loop infinito ao memoizar PocketBase nas páginas de inscrições e loja - dev - b51998f1


### PR DESCRIPTION
## Summary
- memoize createPocketBase in several client pages to avoid re-render loops
- document bug fix in `ERR_LOG.md`

## Testing
- `npm run lint` *(fails: next not found)*
- `npm run build` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_6862ed493814832c9d8f655bdab05d3f