### PR TITLE
Implement pagination info in list API

### DIFF
--- a/__tests__/api/inscricoesRoute.test.ts
+++ b/__tests__/api/inscricoesRoute.test.ts
@@ -3,7 +3,13 @@ import { GET } from '../../app/api/inscricoes/route'
 import { NextRequest } from 'next/server'
 import createPocketBaseMock from '../mocks/pocketbase'
 
-const getListMock = vi.fn().mockResolvedValue({ items: [] })
+const getListMock = vi.fn().mockResolvedValue({
+  items: [],
+  page: 1,
+  perPage: 1,
+  totalPages: 1,
+  totalItems: 0,
+})
 const pb = createPocketBaseMock()
 pb.collection.mockReturnValue({ getList: getListMock })
 
@@ -29,6 +35,8 @@ describe('GET /api/inscricoes', () => {
     )
     const res = await GET(req as unknown as NextRequest)
     expect(res.status).toBe(200)
+    const body = await res.json()
+    expect(body).toHaveProperty('totalItems')
     expect(getListMock).toHaveBeenCalledWith(
       1,
       5,
@@ -51,6 +59,8 @@ describe('GET /api/inscricoes', () => {
     ;(req as any).nextUrl = new URL('http://test/api/inscricoes?perPage=20')
     const res = await GET(req as unknown as NextRequest)
     expect(res.status).toBe(200)
+    const body = await res.json()
+    expect(body).toHaveProperty('totalItems')
     expect(getListMock).toHaveBeenLastCalledWith(
       1,
       20,
@@ -76,6 +86,8 @@ describe('GET /api/inscricoes', () => {
     ;(req as any).nextUrl = new URL('http://test/api/inscricoes?status=ativo')
     const res = await GET(req as unknown as NextRequest)
     expect(res.status).toBe(200)
+    const body = await res.json()
+    expect(body).toHaveProperty('totalItems')
     expect(getTenantFromHost).toHaveBeenCalled()
     expect(getListMock).toHaveBeenLastCalledWith(
       1,

--- a/__tests__/api/pedidosRoute.test.ts
+++ b/__tests__/api/pedidosRoute.test.ts
@@ -3,7 +3,13 @@ import { GET, POST } from '../../app/api/pedidos/route'
 import { NextRequest } from 'next/server'
 import createPocketBaseMock from '../mocks/pocketbase'
 
-const getListMock = vi.fn().mockResolvedValue({ items: [] })
+const getListMock = vi.fn().mockResolvedValue({
+  items: [],
+  page: 1,
+  perPage: 1,
+  totalPages: 1,
+  totalItems: 0,
+})
 const createMock = vi
   .fn()
   .mockResolvedValue({ id: 'p1', valor: 10, status: 'pendente' })
@@ -45,6 +51,8 @@ describe('GET /api/pedidos', () => {
     )
     const res = await GET(req as unknown as NextRequest)
     expect(res.status).toBe(200)
+    const body = await res.json()
+    expect(body).toHaveProperty('totalItems')
     expect(getListMock).toHaveBeenCalledWith(
       2,
       5,
@@ -66,6 +74,8 @@ describe('GET /api/pedidos', () => {
     ;(req as any).nextUrl = new URL('http://test/api/pedidos?page=1&perPage=20')
     const res = await GET(req as unknown as NextRequest)
     expect(res.status).toBe(200)
+    const body = await res.json()
+    expect(body).toHaveProperty('totalItems')
     expect(getListMock).toHaveBeenLastCalledWith(
       1,
       20,
@@ -92,6 +102,8 @@ describe('GET /api/pedidos', () => {
     )
     const res = await GET(req as unknown as NextRequest)
     expect(res.status).toBe(200)
+    const body = await res.json()
+    expect(body).toHaveProperty('totalItems')
     expect(getTenantFromHost).toHaveBeenCalled()
     expect(getListMock).toHaveBeenLastCalledWith(
       3,

--- a/app/admin/dashboard/components/DashboardResumo.tsx
+++ b/app/admin/dashboard/components/DashboardResumo.tsx
@@ -21,6 +21,8 @@ interface DashboardResumoProps {
   pedidos: Pedido[]
   filtroStatus: string
   setFiltroStatus: (status: string) => void
+  totalInscricoes: number
+  totalPedidos: number
 }
 
 export default function DashboardResumo({
@@ -28,6 +30,8 @@ export default function DashboardResumo({
   pedidos,
   filtroStatus,
   setFiltroStatus,
+  totalInscricoes,
+  totalPedidos,
 }: DashboardResumoProps) {
   useEffect(() => {
     setupCharts()
@@ -116,7 +120,7 @@ export default function DashboardResumo({
             </Tippy>
           </div>
           <p className="text-3xl font-bold dark:text-gray-100">
-            {inscricoes.length}
+            {totalInscricoes}
           </p>
         </div>
 
@@ -132,7 +136,7 @@ export default function DashboardResumo({
             </Tippy>
           </div>
           <p className="text-3xl font-bold dark:text-gray-100">
-            {pedidos.length}
+            {totalPedidos}
           </p>
         </div>
 

--- a/app/admin/dashboard/page.tsx
+++ b/app/admin/dashboard/page.tsx
@@ -11,6 +11,8 @@ export default function DashboardPage() {
   const { user, authChecked } = useAuthGuard(['coordenador', 'lider'])
   const [inscricoes, setInscricoes] = useState<Inscricao[]>([])
   const [pedidos, setPedidos] = useState<Pedido[]>([])
+  const [totalInscricoes, setTotalInscricoes] = useState(0)
+  const [totalPedidos, setTotalPedidos] = useState(0)
   const [loading, setLoading] = useState(true)
   const [page, setPage] = useState(1)
   const [totalPages, setTotalPages] = useState(1)
@@ -62,6 +64,12 @@ export default function DashboardPage() {
         const rawPedidos = Array.isArray(pedRes.items) ? pedRes.items : pedRes
         if (insRes.totalPages && pedRes.totalPages) {
           setTotalPages(Math.max(insRes.totalPages, pedRes.totalPages))
+        }
+        if (typeof insRes.totalItems === 'number') {
+          setTotalInscricoes(insRes.totalItems)
+        }
+        if (typeof pedRes.totalItems === 'number') {
+          setTotalPedidos(pedRes.totalItems)
         }
 
         if (!isMounted.current) return
@@ -162,6 +170,8 @@ export default function DashboardPage() {
             pedidos={pedidos}
             filtroStatus={filtroStatus}
             setFiltroStatus={setFiltroStatus}
+            totalInscricoes={totalInscricoes}
+            totalPedidos={totalPedidos}
           />
           <DashboardAnalytics inscricoes={inscricoes} pedidos={pedidos} />
           <div className="flex justify-center items-center gap-4 mt-4">

--- a/app/api/inscricoes/route.ts
+++ b/app/api/inscricoes/route.ts
@@ -13,6 +13,7 @@ export async function GET(req: NextRequest) {
     return NextResponse.json({ error: auth.error }, { status: auth.status })
   }
   const { pb, user } = auth
+  const page = Number(req.nextUrl.searchParams.get('page') || '1')
   const perPage = Number(req.nextUrl.searchParams.get('perPage') || '50')
   const status = req.nextUrl.searchParams.get('status') || ''
   try {
@@ -32,12 +33,12 @@ export async function GET(req: NextRequest) {
       baseFilter = `cliente = "${tenantId}"`
     }
     const filtro = status ? `${baseFilter} && status='${status}'` : baseFilter
-    const { items } = await pb.collection('inscricoes').getList(1, perPage, {
+    const result = await pb.collection('inscricoes').getList(page, perPage, {
       filter: filtro,
       expand: 'evento,campo,pedido,produto',
       sort: '-created',
     })
-    return NextResponse.json(items, { status: 200 })
+    return NextResponse.json(result, { status: 200 })
   } catch (err) {
     console.error('Erro ao listar inscricoes:', err)
     return NextResponse.json({ error: 'Erro ao listar' }, { status: 500 })

--- a/app/api/pedidos/route.ts
+++ b/app/api/pedidos/route.ts
@@ -109,11 +109,12 @@ export async function GET(req: NextRequest) {
 
     const filtro = status ? `${baseFilter} && status='${status}'` : baseFilter
     console.log('[PEDIDOS][GET] Filtro final:', filtro)
-    const { items } = await pb.collection('pedidos').getList(page, perPage, {
+    const result = await pb.collection('pedidos').getList(page, perPage, {
       filter: filtro,
       sort: '-created',
       expand: 'campo,id_inscricao,produto',
     })
+    const { items } = result
 
     // Caso a expansão de produto falhe, buscar manualmente
     for (const item of items) {
@@ -136,7 +137,7 @@ export async function GET(req: NextRequest) {
     }
 
     console.log('[PEDIDOS][GET] Retornando pedidos:', items.length)
-    return NextResponse.json(items)
+    return NextResponse.json(result)
   } catch (err) {
     console.error('[PEDIDOS][GET] Erro ao listar:', err)
     return NextResponse.json({ error: 'Erro ao listar' }, { status: 500 })


### PR DESCRIPTION
## Summary
- expose full pagination info in `inscricoes` and `pedidos` APIs
- update dashboard to handle totals from new API response
- show total counts in `DashboardResumo`
- adjust unit tests for new API structure

## Testing
- `npm run lint` *(fails: `next` not found)*
- `npm run build` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6862f6cd3de0832c9d859fe4a8db9d46