### PR TITLE
Add password reset confirmation route

### DIFF
--- a/app/_/auth/confirm-password-reset/[token]/page.tsx
+++ b/app/_/auth/confirm-password-reset/[token]/page.tsx
@@ -1,0 +1,14 @@
+import ConfirmResetForm from '@/components/ConfirmResetForm'
+
+interface Props {
+  params: { token: string }
+}
+
+export default function Page({ params }: Props) {
+  const { token } = params
+  return (
+    <div className="min-h-screen flex items-center justify-center bg-gray-50">
+      <ConfirmResetForm token={token} />
+    </div>
+  )
+}

--- a/components/ConfirmResetForm.tsx
+++ b/components/ConfirmResetForm.tsx
@@ -1,0 +1,109 @@
+'use client'
+import { useState, useMemo } from 'react'
+import { Eye, EyeOff } from 'lucide-react'
+import createPocketBase from '@/lib/pocketbase'
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
+import { Input } from '@/components/ui/input'
+import { Label } from '@/components/ui/label'
+import { Button } from '@/components/ui/button'
+
+interface Props {
+  token: string
+}
+
+export default function ConfirmResetForm({ token }: Props) {
+  const pb = useMemo(() => createPocketBase(false), [])
+
+  const [password, setPassword] = useState('')
+  const [confirm, setConfirm] = useState('')
+  const [show, setShow] = useState(false)
+  const [error, setError] = useState<string>()
+  const [success, setSuccess] = useState(false)
+
+  async function handleSubmit(e: React.FormEvent) {
+    e.preventDefault()
+    setError(undefined)
+
+    if (password.length < 8) {
+      setError('A senha deve ter ao menos 8 caracteres.')
+      return
+    }
+    if (password !== confirm) {
+      setError('As senhas não coincidem.')
+      return
+    }
+
+    try {
+      await pb.collection('users').confirmPasswordReset(token, password, confirm)
+      setSuccess(true)
+    } catch (err) {
+      const message = err instanceof Error ? err.message : 'Erro desconhecido.'
+      setError(message)
+    }
+  }
+
+  if (success) {
+    return (
+      <Card className="w-full max-w-md">
+        <CardHeader>
+          <CardTitle>Senha redefinida!</CardTitle>
+        </CardHeader>
+        <CardContent>
+          <p>
+            Você já pode{' '}
+            <a href="/login" className="text-blue-600 hover:underline">
+              entrar
+            </a>{' '}
+            com sua nova senha.
+          </p>
+        </CardContent>
+      </Card>
+    )
+  }
+
+  return (
+    <Card className="w-full max-w-md">
+      <CardHeader>
+        <CardTitle>Redefinir sua senha</CardTitle>
+      </CardHeader>
+      <CardContent>
+        <form onSubmit={handleSubmit} className="space-y-4">
+          <div>
+            <Label htmlFor="password">Nova senha</Label>
+            <div className="relative">
+              <Input
+                id="password"
+                type={show ? 'text' : 'password'}
+                value={password}
+                onChange={(e) => setPassword(e.target.value)}
+                required
+              />
+              <button
+                type="button"
+                onClick={() => setShow(!show)}
+                className="absolute right-2 top-1/2 -translate-y-1/2"
+                aria-label="Mostrar senha"
+              >
+                {show ? <EyeOff size={16} /> : <Eye size={16} />}
+              </button>
+            </div>
+          </div>
+          <div>
+            <Label htmlFor="confirm">Confirme a senha</Label>
+            <Input
+              id="confirm"
+              type={show ? 'text' : 'password'}
+              value={confirm}
+              onChange={(e) => setConfirm(e.target.value)}
+              required
+            />
+          </div>
+          {error && <p className="text-error-600">{error}</p>}
+          <Button type="submit" className="w-full">
+            Redefinir senha
+          </Button>
+        </form>
+      </CardContent>
+    </Card>
+  )
+}

--- a/components/ui/button.tsx
+++ b/components/ui/button.tsx
@@ -1,0 +1,20 @@
+import * as React from 'react'
+import { cn } from '@/lib/utils'
+
+export interface ButtonProps extends React.ButtonHTMLAttributes<HTMLButtonElement> {
+  variant?: 'primary' | 'secondary' | 'danger'
+}
+
+export const Button = React.forwardRef<HTMLButtonElement, ButtonProps>(
+  ({ className, variant = 'primary', ...props }, ref) => {
+    const variantClass = {
+      primary: 'btn btn-primary',
+      secondary: 'btn btn-secondary',
+      danger: 'btn btn-danger',
+    }[variant]
+    return (
+      <button ref={ref} className={cn(variantClass, className)} {...props} />
+    )
+  }
+)
+Button.displayName = 'Button'

--- a/components/ui/card.tsx
+++ b/components/ui/card.tsx
@@ -1,0 +1,23 @@
+import * as React from 'react'
+import { cn } from '@/lib/utils'
+
+export type CardProps = React.HTMLAttributes<HTMLDivElement>
+
+export const Card = React.forwardRef<HTMLDivElement, CardProps>(
+  ({ className, ...props }, ref) => (
+    <div ref={ref} className={cn('card', className)} {...props} />
+  )
+)
+Card.displayName = 'Card'
+
+export const CardHeader = ({ className, ...props }: React.HTMLAttributes<HTMLDivElement>) => (
+  <div className={cn('space-y-2 mb-4', className)} {...props} />
+)
+
+export const CardTitle = ({ className, ...props }: React.HTMLAttributes<HTMLHeadingElement>) => (
+  <h2 className={cn('text-lg font-bold', className)} {...props} />
+)
+
+export const CardContent = ({ className, ...props }: React.HTMLAttributes<HTMLDivElement>) => (
+  <div className={cn('space-y-4', className)} {...props} />
+)

--- a/components/ui/input.tsx
+++ b/components/ui/input.tsx
@@ -1,0 +1,11 @@
+import * as React from 'react'
+import { cn } from '@/lib/utils'
+
+export type InputProps = React.InputHTMLAttributes<HTMLInputElement>
+
+export const Input = React.forwardRef<HTMLInputElement, InputProps>(
+  ({ className, ...props }, ref) => (
+    <input ref={ref} className={cn('input-base', className)} {...props} />
+  )
+)
+Input.displayName = 'Input'

--- a/components/ui/label.tsx
+++ b/components/ui/label.tsx
@@ -1,0 +1,11 @@
+import * as React from 'react'
+import { cn } from '@/lib/utils'
+
+export type LabelProps = React.LabelHTMLAttributes<HTMLLabelElement>
+
+export const Label = React.forwardRef<HTMLLabelElement, LabelProps>(
+  ({ className, ...props }, ref) => (
+    <label ref={ref} className={cn('block font-medium text-sm', className)} {...props} />
+  )
+)
+Label.displayName = 'Label'

--- a/lib/utils.ts
+++ b/lib/utils.ts
@@ -1,0 +1,3 @@
+export function cn(...classes: Array<string | undefined>) {
+  return classes.filter(Boolean).join(' ')
+}

--- a/stories/DashboardResumo.stories.tsx
+++ b/stories/DashboardResumo.stories.tsx
@@ -99,6 +99,8 @@ export const Default: Story = {
     ],
     filtroStatus: 'pago',
     setFiltroStatus: () => {},
+    totalInscricoes: 2,
+    totalPedidos: 2,
   },
   play: async ({ canvasElement }) => {
     const canvas = within(canvasElement)


### PR DESCRIPTION
## Summary
- add helper `cn` util
- create UI components with design system classes
- implement client-side ConfirmResetForm
- expose page for `_` PocketBase auth reset
- fix DashboardResumo storybook typing to pass build

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6862f973ffcc832c859f3b4111a7c1f1