### PR TITLE
Update password reset flow

### DIFF
--- a/app/_/auth/confirm-password-reset/[token]/page.tsx
+++ b/app/_/auth/confirm-password-reset/[token]/page.tsx
@@ -1,0 +1,14 @@
+import ConfirmResetForm from '@/components/ConfirmResetForm'
+
+interface Props {
+  params: { token: string }
+}
+
+export default function Page({ params }: Props) {
+  const { token } = params
+  return (
+    <div className="min-h-screen flex items-center justify-center bg-gray-50">
+      <ConfirmResetForm token={token} />
+    </div>
+  )
+}

--- a/app/_/auth/password-reset/page.tsx
+++ b/app/_/auth/password-reset/page.tsx
@@ -1,0 +1,9 @@
+import RequestResetForm from '@/components/RequestResetForm'
+
+export default function Page() {
+  return (
+    <div className="min-h-screen flex items-center justify-center bg-gray-50">
+      <RequestResetForm />
+    </div>
+  )
+}

--- a/app/api/usuarios/password-reset/route.ts
+++ b/app/api/usuarios/password-reset/route.ts
@@ -5,7 +5,9 @@ export async function POST(req: NextRequest) {
   try {
     const { email } = await req.json()
     const pb = createPocketBase()
-    await pb.collection('usuarios').requestPasswordReset(String(email))
+    const origin = req.nextUrl.origin
+    const confirmUrl = `${origin}/_/auth/confirm-password-reset`
+    await pb.collection('usuarios').requestPasswordReset(String(email), confirmUrl)
     return NextResponse.json({ ok: true })
   } catch (err) {
     console.error('Erro ao solicitar reset:', err)

--- a/app/auth/password-reset/page.tsx
+++ b/app/auth/password-reset/page.tsx
@@ -1,0 +1,5 @@
+import { redirect } from 'next/navigation'
+
+export default function Page() {
+  redirect('/_/auth/password-reset')
+}

--- a/arquitetura.md
+++ b/arquitetura.md
@@ -112,7 +112,8 @@ O arquivo `middleware.ts` intercepta cada requisição, consulta a coleção `cl
 - Rotas protegidas com `useAuthGuard` e validação de `role`
 - Algumas rotas de confirmação de inscrição são públicas:
   `/admin/obrigado`, `/admin/pendente`, `/admin/erro`,
-  `/admin/redefinir-senha` e `/admin/inscricoes/recuperar`
+  `/_/auth/password-reset` e `/_/auth/confirm-password-reset/[token]`,
+  além de `/admin/inscricoes/recuperar`
 - Layout persistente com navegação clara entre seções (dashboard, pedidos, etc)
 - Paginação, filtros e expand para consultas PocketBase
 - Armazenamento de token com `pb.authStore` e persistência no localStorage

--- a/components/ConfirmResetForm.tsx
+++ b/components/ConfirmResetForm.tsx
@@ -1,0 +1,109 @@
+'use client'
+import { useState, useMemo } from 'react'
+import { Eye, EyeOff } from 'lucide-react'
+import createPocketBase from '@/lib/pocketbase'
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
+import { Input } from '@/components/ui/input'
+import { Label } from '@/components/ui/label'
+import { Button } from '@/components/ui/button'
+
+interface Props {
+  token: string
+}
+
+export default function ConfirmResetForm({ token }: Props) {
+  const pb = useMemo(() => createPocketBase(false), [])
+
+  const [password, setPassword] = useState('')
+  const [confirm, setConfirm] = useState('')
+  const [show, setShow] = useState(false)
+  const [error, setError] = useState<string>()
+  const [success, setSuccess] = useState(false)
+
+  async function handleSubmit(e: React.FormEvent) {
+    e.preventDefault()
+    setError(undefined)
+
+    if (password.length < 8) {
+      setError('A senha deve ter ao menos 8 caracteres.')
+      return
+    }
+    if (password !== confirm) {
+      setError('As senhas não coincidem.')
+      return
+    }
+
+    try {
+      await pb.collection('users').confirmPasswordReset(token, password, confirm)
+      setSuccess(true)
+    } catch (err) {
+      const message = err instanceof Error ? err.message : 'Erro desconhecido.'
+      setError(message)
+    }
+  }
+
+  if (success) {
+    return (
+      <Card className="w-full max-w-md">
+        <CardHeader>
+          <CardTitle>Senha redefinida!</CardTitle>
+        </CardHeader>
+        <CardContent>
+          <p>
+            Você já pode{' '}
+            <a href="/login" className="text-blue-600 hover:underline">
+              entrar
+            </a>{' '}
+            com sua nova senha.
+          </p>
+        </CardContent>
+      </Card>
+    )
+  }
+
+  return (
+    <Card className="w-full max-w-md">
+      <CardHeader>
+        <CardTitle>Redefinir sua senha</CardTitle>
+      </CardHeader>
+      <CardContent>
+        <form onSubmit={handleSubmit} className="space-y-4">
+          <div>
+            <Label htmlFor="password">Nova senha</Label>
+            <div className="relative">
+              <Input
+                id="password"
+                type={show ? 'text' : 'password'}
+                value={password}
+                onChange={(e) => setPassword(e.target.value)}
+                required
+              />
+              <button
+                type="button"
+                onClick={() => setShow(!show)}
+                className="absolute right-2 top-1/2 -translate-y-1/2"
+                aria-label="Mostrar senha"
+              >
+                {show ? <EyeOff size={16} /> : <Eye size={16} />}
+              </button>
+            </div>
+          </div>
+          <div>
+            <Label htmlFor="confirm">Confirme a senha</Label>
+            <Input
+              id="confirm"
+              type={show ? 'text' : 'password'}
+              value={confirm}
+              onChange={(e) => setConfirm(e.target.value)}
+              required
+            />
+          </div>
+          {error && <p className="text-error-600">{error}</p>}
+          <Button type="submit" className="w-full">
+            Redefinir senha
+          </Button>
+        </form>
+      </CardContent>
+    </Card>
+  )
+}

--- a/components/RequestResetForm.tsx
+++ b/components/RequestResetForm.tsx
@@ -1,0 +1,50 @@
+'use client'
+import { useState } from 'react'
+import { useToast } from '@/lib/context/ToastContext'
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
+import { Input } from '@/components/ui/input'
+import { Button } from '@/components/ui/button'
+
+export default function RequestResetForm() {
+  const [email, setEmail] = useState('')
+  const { showSuccess, showError } = useToast()
+
+  async function handleSubmit(e: React.FormEvent) {
+    e.preventDefault()
+    try {
+      const res = await fetch('/api/usuarios/password-reset', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ email }),
+      })
+      if (!res.ok) throw new Error('Erro')
+      showSuccess('Enviamos um link para redefinir sua senha.')
+      setEmail('')
+    } catch (err) {
+      console.error(err)
+      showError('Não foi possível enviar o link. Verifique o e-mail.')
+    }
+  }
+
+  return (
+    <Card className="w-full max-w-md">
+      <CardHeader>
+        <CardTitle>Recuperar acesso</CardTitle>
+      </CardHeader>
+      <CardContent>
+        <form onSubmit={handleSubmit} className="space-y-4">
+          <Input
+            type="email"
+            placeholder="Digite seu e-mail"
+            value={email}
+            onChange={(e) => setEmail(e.target.value)}
+            required
+          />
+          <Button type="submit" className="w-full">
+            Enviar
+          </Button>
+        </form>
+      </CardContent>
+    </Card>
+  )
+}

--- a/components/templates/LoginForm.tsx
+++ b/components/templates/LoginForm.tsx
@@ -5,7 +5,7 @@ import { motion } from 'framer-motion'
 import { useRouter } from 'next/navigation'
 import { useAuthContext } from '@/lib/context/AuthContext'
 import Image from 'next/image'
-import RedefinirSenhaModal from '@/app/admin/components/RedefinirSenhaModal'
+import Link from 'next/link'
 import { useToast } from '@/lib/context/ToastContext'
 import '@/app/globals.css' // Certifique-se de que o CSS global está importado
 import { PasswordField } from '@/components'
@@ -23,7 +23,6 @@ export default function LoginForm({
   const [email, setEmail] = useState('')
   const [senha, setSenha] = useState('')
   const [isSubmitting, setIsSubmitting] = useState(false)
-  const [mostrarModal, setMostrarModal] = useState(false)
   const { showError } = useToast()
 
   // Redirecionamento pós-login
@@ -122,13 +121,12 @@ export default function LoginForm({
           />
 
           <div className="text-right text-sm">
-            <button
-              type="button"
-              onClick={() => setMostrarModal(true)}
+            <Link
+              href="/_/auth/password-reset"
               className="underline text-gray-300 hover:text-white transition"
             >
               Esqueci minha senha
-            </button>
+            </Link>
           </div>
 
           {children && (
@@ -147,10 +145,6 @@ export default function LoginForm({
             {isSubmitting ? 'Entrando...' : 'Entrar'}
           </button>
         </form>
-
-        {mostrarModal && (
-          <RedefinirSenhaModal onClose={() => setMostrarModal(false)} />
-        )}
       </div>
     </div>
   )

--- a/components/ui/button.tsx
+++ b/components/ui/button.tsx
@@ -1,0 +1,20 @@
+import * as React from 'react'
+import { cn } from '@/lib/utils'
+
+export interface ButtonProps extends React.ButtonHTMLAttributes<HTMLButtonElement> {
+  variant?: 'primary' | 'secondary' | 'danger'
+}
+
+export const Button = React.forwardRef<HTMLButtonElement, ButtonProps>(
+  ({ className, variant = 'primary', ...props }, ref) => {
+    const variantClass = {
+      primary: 'btn btn-primary',
+      secondary: 'btn btn-secondary',
+      danger: 'btn btn-danger',
+    }[variant]
+    return (
+      <button ref={ref} className={cn(variantClass, className)} {...props} />
+    )
+  }
+)
+Button.displayName = 'Button'

--- a/components/ui/card.tsx
+++ b/components/ui/card.tsx
@@ -1,0 +1,23 @@
+import * as React from 'react'
+import { cn } from '@/lib/utils'
+
+export type CardProps = React.HTMLAttributes<HTMLDivElement>
+
+export const Card = React.forwardRef<HTMLDivElement, CardProps>(
+  ({ className, ...props }, ref) => (
+    <div ref={ref} className={cn('card', className)} {...props} />
+  )
+)
+Card.displayName = 'Card'
+
+export const CardHeader = ({ className, ...props }: React.HTMLAttributes<HTMLDivElement>) => (
+  <div className={cn('space-y-2 mb-4', className)} {...props} />
+)
+
+export const CardTitle = ({ className, ...props }: React.HTMLAttributes<HTMLHeadingElement>) => (
+  <h2 className={cn('text-lg font-bold', className)} {...props} />
+)
+
+export const CardContent = ({ className, ...props }: React.HTMLAttributes<HTMLDivElement>) => (
+  <div className={cn('space-y-4', className)} {...props} />
+)

--- a/components/ui/input.tsx
+++ b/components/ui/input.tsx
@@ -1,0 +1,11 @@
+import * as React from 'react'
+import { cn } from '@/lib/utils'
+
+export type InputProps = React.InputHTMLAttributes<HTMLInputElement>
+
+export const Input = React.forwardRef<HTMLInputElement, InputProps>(
+  ({ className, ...props }, ref) => (
+    <input ref={ref} className={cn('input-base', className)} {...props} />
+  )
+)
+Input.displayName = 'Input'

--- a/components/ui/label.tsx
+++ b/components/ui/label.tsx
@@ -1,0 +1,11 @@
+import * as React from 'react'
+import { cn } from '@/lib/utils'
+
+export type LabelProps = React.LabelHTMLAttributes<HTMLLabelElement>
+
+export const Label = React.forwardRef<HTMLLabelElement, LabelProps>(
+  ({ className, ...props }, ref) => (
+    <label ref={ref} className={cn('block font-medium text-sm', className)} {...props} />
+  )
+)
+Label.displayName = 'Label'

--- a/lib/utils.ts
+++ b/lib/utils.ts
@@ -1,0 +1,3 @@
+export function cn(...classes: Array<string | undefined>) {
+  return classes.filter(Boolean).join(' ')
+}

--- a/logs/DOC_LOG.md
+++ b/logs/DOC_LOG.md
@@ -466,3 +466,5 @@ executados.
 ## [2025-06-27] Evento 'promocao_lider' adicionado e rota PATCH envia notificacoes
 ## [2025-08-10] Seção 'Webhooks Asaas' adicionada ao README explicando prerequisitos e exemplo de cadastro.
 ## [2025-06-30] Evento 'confirmacao_pendente_lider' notifica lider via WhatsApp. Lint e build executados.
+## [2025-06-30] Rota publica de recuperacao de senha movida para `/_/auth/password-reset` e login atualizado para usar esse caminho. Documentacao revisada.
+## [2025-06-30] Rota /auth/password-reset redireciona para o novo caminho publico e evita erro 404.

--- a/stories/DashboardResumo.stories.tsx
+++ b/stories/DashboardResumo.stories.tsx
@@ -99,6 +99,8 @@ export const Default: Story = {
     ],
     filtroStatus: 'pago',
     setFiltroStatus: () => {},
+    totalInscricoes: 2,
+    totalPedidos: 2,
   },
   play: async ({ canvasElement }) => {
     const canvas = within(canvasElement)


### PR DESCRIPTION
## Summary
- add dedicated password reset request page
- link to the new route from the login form
- document public routes for password reset
- redirect legacy `/auth/password-reset` to the new route

## Testing
- `npm run lint` *(fails: `next` not found)*
- `npm run build` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6862f973ffcc832c859f3b4111a7c1f1