### PR TITLE
Fix password reset paths

### DIFF
--- a/app/_/auth/password-reset/page.tsx
+++ b/app/_/auth/password-reset/page.tsx
@@ -1,9 +1,0 @@
-import RequestResetForm from '@/components/RequestResetForm'
-
-export default function Page() {
-  return (
-    <div className="min-h-screen flex items-center justify-center bg-gray-50">
-      <RequestResetForm />
-    </div>
-  )
-}

--- a/app/api/usuarios/password-reset/route.ts
+++ b/app/api/usuarios/password-reset/route.ts
@@ -6,7 +6,7 @@ export async function POST(req: NextRequest) {
     const { email } = await req.json()
     const pb = createPocketBase()
     const origin = req.nextUrl.origin
-    const confirmUrl = `${origin}/_/auth/confirm-password-reset`
+    const confirmUrl = `${origin}/auth/confirm-password-reset`
     await pb.collection('usuarios').requestPasswordReset(String(email), confirmUrl)
     return NextResponse.json({ ok: true })
   } catch (err) {

--- a/app/auth/confirm-password-reset/[token]/page.tsx
+++ b/app/auth/confirm-password-reset/[token]/page.tsx
@@ -1,11 +1,11 @@
 import ConfirmResetForm from '@/components/ConfirmResetForm'
 
-interface Props {
-  params: { token: string }
-}
-
-export default function Page({ params }: Props) {
-  const { token } = params
+export default async function Page({
+  params,
+}: {
+  params: Promise<{ token: string }>
+}) {
+  const { token } = await params
   return (
     <div className="min-h-screen flex items-center justify-center bg-gray-50">
       <ConfirmResetForm token={token} />

--- a/app/auth/password-reset/page.tsx
+++ b/app/auth/password-reset/page.tsx
@@ -1,5 +1,9 @@
-import { redirect } from 'next/navigation'
+import RequestResetForm from '@/components/RequestResetForm'
 
 export default function Page() {
-  redirect('/_/auth/password-reset')
+  return (
+    <div className="min-h-screen flex items-center justify-center bg-gray-50">
+      <RequestResetForm />
+    </div>
+  )
 }

--- a/arquitetura.md
+++ b/arquitetura.md
@@ -112,7 +112,7 @@ O arquivo `middleware.ts` intercepta cada requisição, consulta a coleção `cl
 - Rotas protegidas com `useAuthGuard` e validação de `role`
 - Algumas rotas de confirmação de inscrição são públicas:
   `/admin/obrigado`, `/admin/pendente`, `/admin/erro`,
-  `/_/auth/password-reset` e `/_/auth/confirm-password-reset/[token]`,
+  `/auth/password-reset` e `/auth/confirm-password-reset/[token]`,
   além de `/admin/inscricoes/recuperar`
 - Layout persistente com navegação clara entre seções (dashboard, pedidos, etc)
 - Paginação, filtros e expand para consultas PocketBase

--- a/components/templates/LoginForm.tsx
+++ b/components/templates/LoginForm.tsx
@@ -122,7 +122,7 @@ export default function LoginForm({
 
           <div className="text-right text-sm">
             <Link
-              href="/_/auth/password-reset"
+              href="/auth/password-reset"
               className="underline text-gray-300 hover:text-white transition"
             >
               Esqueci minha senha

--- a/logs/DOC_LOG.md
+++ b/logs/DOC_LOG.md
@@ -469,3 +469,4 @@ executados.
 ## [2025-06-30] Rota publica de recuperacao de senha movida para `/_/auth/password-reset` e login atualizado para usar esse caminho. Documentacao revisada.
 ## [2025-06-30] Rota /auth/password-reset redireciona para o novo caminho publico e evita erro 404.
 ## [2025-06-30] Rota publica de recuperacao de senha movida para `/_/auth/password-reset` e login atualizado para usar esse caminho. Documentacao revisada.
+## [2025-06-30] Rota de redefinição de senha movida para /auth e confirmUrl atualizado. Lint e build executados.


### PR DESCRIPTION
## Summary
- corrige link de "esqueci minha senha" apontando para `/auth/password-reset`
- remove pastas `_` e move páginas de reset para `/auth`
- ajusta `confirmUrl` na rota de API
- atualiza documentação e log

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_686305c0b7b0832c8b0418a1f7fbc6d8