### PR TITLE
Fix dashboard pagination aggregation

### DIFF
--- a/app/admin/inscricoes/page.tsx
+++ b/app/admin/inscricoes/page.tsx
@@ -122,6 +122,7 @@ export default function ListaInscricoesPage() {
         })
         const res: { items: InscricaoRecord[]; totalPages: number } =
           await primeiro.json()
+        setTotalPaginas(res.totalPages)
         let todos = res.items
 
         for (let p = 2; p <= res.totalPages; p++) {


### PR DESCRIPTION
## Summary
- gather all pages from `/api/inscricoes` and `/api/pedidos` when loading the admin dashboard
- store total pages in inscricoes page to satisfy lint

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68630a418b38832c8a4baee080efdfde