### PR TITLE
Remove unused pagination state

### DIFF
--- a/app/admin/inscricoes/page.tsx
+++ b/app/admin/inscricoes/page.tsx
@@ -64,8 +64,6 @@ export default function ListaInscricoesPage() {
   const [inscricaoEmEdicao, setInscricaoEmEdicao] = useState<Inscricao | null>(
     null,
   )
-  const [pagina, setPagina] = useState(1)
-  const [totalPaginas, setTotalPaginas] = useState(1)
   const { showError, showSuccess } = useToast()
   const placeholderBusca =
     role === 'coordenador'
@@ -810,26 +808,7 @@ export default function ListaInscricoesPage() {
         />
       )}
 
-      {/* Paginação */}
-      <div className="flex justify-between items-center mt-6 text-sm">
-        <button
-          disabled={pagina === 1}
-          onClick={() => setPagina((p) => Math.max(1, p - 1))}
-          className="btn btn-secondary disabled:opacity-50"
-        >
-          Anterior
-        </button>
-        <span>
-          Página {pagina} de {totalPaginas}
-        </span>
-        <button
-          disabled={pagina === totalPaginas}
-          onClick={() => setPagina((p) => Math.min(totalPaginas, p + 1))}
-          className="btn btn-secondary disabled:opacity-50"
-        >
-          Próxima
-        </button>
-      </div>
+      {/* Paginação removida */}
     </main>
   )
 }


### PR DESCRIPTION
## Summary
- clean up unused pagination state in `inscricoes` page

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68630a4aedc4832caa328ae476be2629