### PR TITLE
Fix tenant host redirect on password reset

### DIFF
--- a/app/api/usuarios/password-reset/route.ts
+++ b/app/api/usuarios/password-reset/route.ts
@@ -1,13 +1,29 @@
 import { NextRequest, NextResponse } from 'next/server'
 import createPocketBase from '@/lib/pocketbase'
+import { getTenantFromHost } from '@/lib/getTenantFromHost'
+import { getTenantHost } from '@/lib/getTenantHost'
 
 export async function POST(req: NextRequest) {
   try {
     const { email } = await req.json()
     const pb = createPocketBase()
-    const origin = req.nextUrl.origin
-    const confirmUrl = `${origin}/auth/confirm-password-reset`
-    await pb.collection('usuarios').requestPasswordReset(String(email), confirmUrl)
+
+    const tenantId = await getTenantFromHost()
+    if (!tenantId) {
+      return NextResponse.json({ error: 'Tenant não encontrado' }, { status: 400 })
+    }
+
+    const host = await getTenantHost(tenantId)
+    if (!host) {
+      return NextResponse.json({ error: 'Host não configurado' }, { status: 500 })
+    }
+
+    const redirectUrl = `${host}/_/auth/confirm-password-reset`
+    console.log('REDIRECT_URL:', redirectUrl)
+
+    await pb
+      .collection('usuarios')
+      .requestPasswordReset(String(email), redirectUrl)
     return NextResponse.json({ ok: true })
   } catch (err) {
     console.error('Erro ao solicitar reset:', err)

--- a/app/api/usuarios/password-reset/route.ts
+++ b/app/api/usuarios/password-reset/route.ts
@@ -18,7 +18,7 @@ export async function POST(req: NextRequest) {
       return NextResponse.json({ error: 'Host não configurado' }, { status: 500 })
     }
 
-    const redirectUrl = `${host}/_/auth/confirm-password-reset`
+    const redirectUrl = `${host}/auth/confirm-password-reset`
     console.log('REDIRECT_URL:', redirectUrl)
 
     await pb

--- a/lib/getTenantHost.ts
+++ b/lib/getTenantHost.ts
@@ -4,13 +4,20 @@ import createPocketBase from '@/lib/pocketbase'
  * Retorna o host configurado para o tenant informado.
  * Remove barras extras ao final para evitar urls duplicadas.
  */
+interface ClienteConfigRecord {
+  id: string
+  cliente: string
+  host?: string
+  dominio?: string
+}
+
 export async function getTenantHost(tenantId: string): Promise<string | null> {
   try {
     const pb = createPocketBase()
     const cfg = await pb
       .collection('clientes_config')
-      .getFirstListItem(`cliente='${tenantId}'`)
-    const rawHost = (cfg as any).host ?? (cfg as any).dominio ?? ''
+      .getFirstListItem<ClienteConfigRecord>(`cliente='${tenantId}'`)
+    const rawHost = cfg.host ?? cfg.dominio ?? ''
     const host = String(rawHost).replace(/\/+$/, '')
     return host || null
   } catch {

--- a/lib/getTenantHost.ts
+++ b/lib/getTenantHost.ts
@@ -1,0 +1,19 @@
+import createPocketBase from '@/lib/pocketbase'
+
+/**
+ * Retorna o host configurado para o tenant informado.
+ * Remove barras extras ao final para evitar urls duplicadas.
+ */
+export async function getTenantHost(tenantId: string): Promise<string | null> {
+  try {
+    const pb = createPocketBase()
+    const cfg = await pb
+      .collection('clientes_config')
+      .getFirstListItem(`cliente='${tenantId}'`)
+    const rawHost = (cfg as any).host ?? (cfg as any).dominio ?? ''
+    const host = String(rawHost).replace(/\/+$/, '')
+    return host || null
+  } catch {
+    return null
+  }
+}


### PR DESCRIPTION
## Summary
- fetch tenant host from `clientes_config`
- build password reset redirect using the tenant host
- add helper `getTenantHost`

## Testing
- `npm run lint` *(fails: next not found)*
- `npm run build` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_6863107de19c832ca19d630110c30e00