### PR TITLE
Add leader approval message after signup

### DIFF
--- a/app/admin/obrigado/page.tsx
+++ b/app/admin/obrigado/page.tsx
@@ -10,9 +10,9 @@ export default function ObrigadoPage() {
         </h1>
 
         <p className="text-gray-700 text-base leading-relaxed">
-          Sua inscrição foi salva com sucesso e estamos aguardando a confirmação
-          do seu pagamento. Assim que o pagamento for aprovado, você receberá a
-          confirmação final da sua participação.
+          Sua inscrição foi enviada com sucesso e será analisada pela liderança.
+          Após a aprovação, você receberá em seu e-mail as instruções para
+          realizar o pagamento e confirmar sua participação.
         </p>
 
         <div className="text-sm text-gray-500">

--- a/app/inscricoes/obrigado/page.tsx
+++ b/app/inscricoes/obrigado/page.tsx
@@ -9,9 +9,9 @@ export default function ObrigadoPage() {
         </h1>
 
         <p className="text-gray-700 text-base leading-relaxed">
-          Sua inscrição foi salva com sucesso e estamos aguardando a confirmação
-          do seu pagamento. Assim que o pagamento for aprovado, você receberá a
-          confirmação final da sua participação.
+          Sua inscrição foi enviada com sucesso e será analisada pela liderança.
+          Após a aprovação, você receberá em seu e-mail as instruções para
+          realizar o pagamento e confirmar sua participação.
         </p>
 
         <div className="text-sm text-gray-500">


### PR DESCRIPTION
## Summary
- update signup "obrigado" pages with message about leader approval

## Testing
- `npm run lint` *(fails: Unexpected any in getTenantHost.ts)*
- `npm run build` *(fails: Unexpected any in getTenantHost.ts)*

------
https://chatgpt.com/codex/tasks/task_e_686317d2bb5c832ca72c8adaf4a35d0a