### PR TITLE
Add minimum password length validation

### DIFF
--- a/app/api/register/route.ts
+++ b/app/api/register/route.ts
@@ -41,6 +41,12 @@ export async function POST(req: NextRequest) {
         { status: 400 },
       )
     }
+    if (String(password).length < 8) {
+      return NextResponse.json(
+        { error: 'A senha deve ter ao menos 8 caracteres.' },
+        { status: 400 },
+      )
+    }
     try {
       await pb
         .collection('clientes_config')

--- a/app/api/signup/route.ts
+++ b/app/api/signup/route.ts
@@ -9,6 +9,12 @@ export async function POST(req: NextRequest) {
     if (!nome || !email || !telefone || !cpf || !senha) {
       return NextResponse.json({ error: 'Dados inválidos' }, { status: 400 })
     }
+    if (String(senha).length < 8) {
+      return NextResponse.json(
+        { error: 'A senha deve ter ao menos 8 caracteres.' },
+        { status: 400 },
+      )
+    }
     const tenantId = await getTenantFromHost()
     const telefoneNumerico = String(telefone).replace(/\D/g, '')
     const cpfNumerico = String(cpf).replace(/\D/g, '')

--- a/app/signup/page.tsx
+++ b/app/signup/page.tsx
@@ -30,6 +30,11 @@ export default function SignUpPage() {
   async function handleSubmit(e: React.FormEvent) {
     e.preventDefault()
 
+    if (senha.length < 8) {
+      showError('A senha deve ter ao menos 8 caracteres.')
+      return
+    }
+
     if (senha !== senhaConfirm) {
       showError('As senhas não coincidem.')
       return

--- a/components/templates/SignUpForm.tsx
+++ b/components/templates/SignUpForm.tsx
@@ -99,6 +99,10 @@ export default function SignUpForm({
 
   async function handleSubmit(e: React.FormEvent) {
     e.preventDefault()
+    if (senha.length < 8) {
+      showError('A senha deve ter ao menos 8 caracteres.')
+      return
+    }
     if (senha !== senhaConfirm) {
       showError('As senhas não coincidem.')
       return


### PR DESCRIPTION
## Summary
- enforce minimum password length when signing up via client page
- update SignUpForm template validation
- validate password length in signup and register API routes

## Testing
- `npm run lint` *(fails: Unexpected any in getTenantHost.ts)*
- `npm run build` *(fails: Unexpected any in getTenantHost.ts)*

------
https://chatgpt.com/codex/tasks/task_e_68631b9a43e4832cabe7925a060e6ac7