### PR TITLE
Add password length checks

### DIFF
--- a/app/signup/page.tsx
+++ b/app/signup/page.tsx
@@ -29,6 +29,10 @@ export default function SignUpPage() {
 
   async function handleSubmit(e: React.FormEvent) {
     e.preventDefault()
+    if (senha.length < 8) {
+      showError('A senha deve ter ao menos 8 caracteres.')
+      return
+    }
 
     if (senha !== senhaConfirm) {
       showError('As senhas não coincidem.')

--- a/components/organisms/EventForm.tsx
+++ b/components/organisms/EventForm.tsx
@@ -215,6 +215,11 @@ export default function EventForm({ eventoId, liderId }: EventFormProps) {
   const handleSubmit = async () => {
     setLoading(true)
     try {
+      if (!liderId && !isLoggedIn && form.password.length < 8) {
+        showError('A senha deve ter ao menos 8 caracteres.')
+        setLoading(false)
+        return
+      }
       if (!liderId && !isLoggedIn && form.password !== form.passwordConfirm) {
         showError('As senhas não coincidem.')
         setLoading(false)

--- a/components/templates/SignUpForm.tsx
+++ b/components/templates/SignUpForm.tsx
@@ -99,6 +99,10 @@ export default function SignUpForm({
 
   async function handleSubmit(e: React.FormEvent) {
     e.preventDefault()
+    if (senha.length < 8) {
+      showError('A senha deve ter ao menos 8 caracteres.')
+      return
+    }
     if (senha !== senhaConfirm) {
       showError('As senhas não coincidem.')
       return


### PR DESCRIPTION
## Summary
- enforce min password length on signup page
- enforce min password length on SignUpForm component
- enforce min password length on EventForm component

## Testing
- `npm run lint` *(fails: Unexpected any in getTenantHost.ts)*
- `npm run build` *(fails: Unexpected any in getTenantHost.ts)*

------
https://chatgpt.com/codex/tasks/task_e_68631a62079c832c9c95b930835187cf