### PR TITLE
Corrige filtro de produtos por cliente

### DIFF
--- a/app/api/produtos/[slug]/route.ts
+++ b/app/api/produtos/[slug]/route.ts
@@ -23,14 +23,9 @@ export async function GET(req: NextRequest) {
   try {
     const p = await pb
       .collection('produtos')
-      .getFirstListItem<Produto>(`slug="${slug}"`)
-
-    if (p.cliente !== tenantId) {
-      return NextResponse.json(
-        { error: 'Produto não pertence ao tenant' },
-        { status: 403 },
+      .getFirstListItem<Produto>(
+        `slug='${slug}' && cliente='${tenantId}'`,
       )
-    }
     if (!role && p.exclusivo_user) {
       return NextResponse.json(
         { error: 'Produto exclusivo para usuários logados' },

--- a/lib/getTenantHost.ts
+++ b/lib/getTenantHost.ts
@@ -4,13 +4,18 @@ import createPocketBase from '@/lib/pocketbase'
  * Retorna o host configurado para o tenant informado.
  * Remove barras extras ao final para evitar urls duplicadas.
  */
+interface ClienteConfig {
+  host?: string
+  dominio?: string
+}
+
 export async function getTenantHost(tenantId: string): Promise<string | null> {
   try {
     const pb = createPocketBase()
     const cfg = await pb
       .collection('clientes_config')
-      .getFirstListItem(`cliente='${tenantId}'`)
-    const rawHost = (cfg as any).host ?? (cfg as any).dominio ?? ''
+      .getFirstListItem<ClienteConfig>(`cliente='${tenantId}'`)
+    const rawHost = cfg.host ?? cfg.dominio ?? ''
     const host = String(rawHost).replace(/\/+$/, '')
     return host || null
   } catch {

--- a/logs/ERR_LOG.md
+++ b/logs/ERR_LOG.md
@@ -191,3 +191,4 @@
 ## [2025-06-30] Correção paginação em /api/inscricoes - dev - 237edb0
 ## [2025-06-30] Lista de pedidos duplicada ao carregar admin/pedidos. Adicionada deduplicação no fetch - dev - c29e2ce4
 ## [2025-06-30] Cadastro da loja não salvava endereço e role ao criar novo usuário. Rota /loja/api/inscricoes agora utiliza data.role e campos completos - dev
+## [2025-06-30] Consulta de produto ja filtra por cliente na API, evitando verificacao redundante do tenant - dev


### PR DESCRIPTION
## Summary
- filtra produto pelo tenant diretamente na query da API
- evita cast com `any` em `getTenantHost`
- registra correção de filtro de produtos em ERR_LOG

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68631bf49a58832ca72a928e59996c17