### PR TITLE
Fix param type for confirm password page

### DIFF
--- a/app/auth/confirm-password-reset/[token]/page.tsx
+++ b/app/auth/confirm-password-reset/[token]/page.tsx
@@ -3,9 +3,9 @@ import ConfirmResetForm from '@/components/ConfirmResetForm'
 export default async function Page({
   params,
 }: {
-  params: Promise<{ token: string }>
+  params: { token: string }
 }) {
-  const { token } = await params
+  const { token } = params
   return (
     <div className="min-h-screen flex items-center justify-center bg-gray-50">
       <ConfirmResetForm token={token} />


### PR DESCRIPTION
## Summary
- update param type for confirm-reset page

## Testing
- `npm run lint` *(fails: next not found)*
- `npm run build` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_6863207f98b0832c92f0d38feb98a800