### PR TITLE
Fix confirm-password-reset params

### DIFF
--- a/app/auth/confirm-password-reset/[token]/page.tsx
+++ b/app/auth/confirm-password-reset/[token]/page.tsx
@@ -1,11 +1,11 @@
 import ConfirmResetForm from '@/components/ConfirmResetForm'
 
-export default function Page({
+export default async function Page({
   params,
 }: {
-  params: { token: string }
+  params: Promise<{ token: string }>
 }) {
-  const { token } = params
+  const { token } = await params
   return (
     <div className="min-h-screen flex items-center justify-center bg-gray-50">
       <ConfirmResetForm token={token} />

--- a/logs/ERR_LOG.md
+++ b/logs/ERR_LOG.md
@@ -193,3 +193,5 @@
 ## [2025-06-30] Cadastro da loja não salvava endereço e role ao criar novo usuário. Rota /loja/api/inscricoes agora utiliza data.role e campos completos - dev
 ## [2025-06-30] Consulta de produto ja filtra por cliente na API, evitando verificacao redundante do tenant - dev
 ## [2025-06-30] Produtos exclusivos retornavam erro 403 na loja. Página agora exibe detalhes e exige login apenas na compra - dev - c18ad74d
+
+## [2025-07-01] Corrigida tipagem de params na página de confirmação de senha; build falhava por incompatibilidade com PageProps - dev - 7d2b5981


### PR DESCRIPTION
## Summary
- fix confirm reset page type to use async params
- log resolution for failed Next.js build due to type mismatch

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68632606a320832cb92551e9e4acc085