### PR TITLE
Extend Pedido with vencimento field

### DIFF
--- a/__tests__/ModalVisualizarPedido.test.tsx
+++ b/__tests__/ModalVisualizarPedido.test.tsx
@@ -18,6 +18,7 @@ function mockPedido() {
     status: 'pendente',
     produto: [],
     id_pagamento: 'c1',
+    vencimento: '2024-01-01',
     link_pagamento: 'pay',
     expand: {
       id_inscricao: {

--- a/app/api/asaas/route.ts
+++ b/app/api/asaas/route.ts
@@ -296,6 +296,7 @@ export async function POST(req: NextRequest) {
     const taxaAplicada = Number((gross - parsedValor - margin).toFixed(2))
     await pb.collection('pedidos').update(pedido.id, {
       link_pagamento: link,
+      vencimento: dueDateStr,
       valorBrutoDesejado: parsedValor,
       valorBruto: gross,
       taxaAplicada,

--- a/app/api/pedidos/[id]/route.ts
+++ b/app/api/pedidos/[id]/route.ts
@@ -98,6 +98,9 @@ export async function PATCH(req: NextRequest) {
       ...(data.tamanho !== undefined ? { tamanho: String(data.tamanho) } : {}),
       ...(data.cor !== undefined ? { cor: String(data.cor) } : {}),
       ...(data.status !== undefined ? { status: String(data.status) } : {}),
+      ...(data.vencimento !== undefined
+        ? { vencimento: String(data.vencimento) }
+        : {}),
     })
     return NextResponse.json(updated)
   } catch (err) {

--- a/types/index.ts
+++ b/types/index.ts
@@ -58,6 +58,8 @@ export type Pedido = {
   email: string
   canal: 'loja' | 'inscricao'
   created?: string
+  /** Data de vencimento do pagamento */
+  vencimento?: string
   valor: string
   /** URL gerada pelo Asaas */
   link_pagamento?: string


### PR DESCRIPTION
## Summary
- add optional `vencimento` to `Pedido`
- persist `vencimento` when generating payments
- allow editing `vencimento` via `/api/pedidos/[id]`
- update tests for the new field

## Testing
- `npx next lint` *(fails: need to install next)*
- `npx next build` *(fails: need to install next)*
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6863dc6941f4832cae10f21c2c69c66a