### PR TITLE
Implement duplicate checks on user registration

### DIFF
--- a/app/api/register/route.ts
+++ b/app/api/register/route.ts
@@ -61,7 +61,7 @@ export async function POST(req: NextRequest) {
     const telefoneNumerico = String(telefone).replace(/\D/g, '')
     try {
       const dup = await pb.collection('usuarios').getList(1, 1, {
-        filter: `cpf='${cpfNumerico}' || email='${email}' || telefone='${telefoneNumerico}'`,
+        filter: `cpf='${cpfNumerico}' || email='${email}'`,
       })
       if (dup.items.length > 0) {
         return NextResponse.json(

--- a/app/api/register/route.ts
+++ b/app/api/register/route.ts
@@ -57,13 +57,26 @@ export async function POST(req: NextRequest) {
         { status: 404 },
       )
     }
+    const cpfNumerico = String(cpf).replace(/\D/g, '')
+    const telefoneNumerico = String(telefone).replace(/\D/g, '')
+    try {
+      const dup = await pb.collection('usuarios').getList(1, 1, {
+        filter: `cpf='${cpfNumerico}' || email='${email}' || telefone='${telefoneNumerico}'`,
+      })
+      if (dup.items.length > 0) {
+        return NextResponse.json(
+          { erro: 'Já existe um usuário com este CPF ou e-mail.' },
+          { status: 409 },
+        )
+      }
+    } catch {}
     const novoUsuario = await pb.collection('usuarios').create({
       nome: String(nome).trim(),
       email: String(email).trim(),
       emailVisibility: true,
       cliente: String(cliente),
-      telefone: String(telefone).trim(),
-      cpf: String(cpf).trim(),
+      telefone: telefoneNumerico,
+      cpf: cpfNumerico,
       data_nascimento: String(data_nascimento),
       endereco: String(endereco).trim(),
       numero: String(numero).trim(),

--- a/app/api/signup/route.ts
+++ b/app/api/signup/route.ts
@@ -20,7 +20,7 @@ export async function POST(req: NextRequest) {
     const cpfNumerico = String(cpf).replace(/\D/g, '')
     try {
       const dup = await pb.collection('usuarios').getList(1, 1, {
-        filter: `cpf='${cpfNumerico}' || email='${email}' || telefone='${telefoneNumerico}'`,
+        filter: `cpf='${cpfNumerico}' || email='${email}'`,
       })
       if (dup.items.length > 0) {
         return NextResponse.json(

--- a/app/api/signup/route.ts
+++ b/app/api/signup/route.ts
@@ -18,6 +18,17 @@ export async function POST(req: NextRequest) {
     const tenantId = await getTenantFromHost()
     const telefoneNumerico = String(telefone).replace(/\D/g, '')
     const cpfNumerico = String(cpf).replace(/\D/g, '')
+    try {
+      const dup = await pb.collection('usuarios').getList(1, 1, {
+        filter: `cpf='${cpfNumerico}' || email='${email}' || telefone='${telefoneNumerico}'`,
+      })
+      if (dup.items.length > 0) {
+        return NextResponse.json(
+          { error: 'Já existe um usuário com este CPF ou e-mail.' },
+          { status: 409 },
+        )
+      }
+    } catch {}
     const usuario = await pb.collection('usuarios').create({
       nome: String(nome).trim(),
       email: String(email).trim(),

--- a/app/loja/api/inscricoes/route.ts
+++ b/app/loja/api/inscricoes/route.ts
@@ -26,6 +26,19 @@ export async function POST(req: NextRequest) {
           .collection('usuarios')
           .getFirstListItem(`email='${data.user_email}'`)
       } catch {
+        const cpf = String(data.user_cpf).replace(/\D/g, '')
+        const telefone = String(data.user_phone).replace(/\D/g, '')
+        try {
+          const dup = await pb.collection('usuarios').getList(1, 1, {
+            filter: `cpf='${cpf}' || email='${data.user_email}' || telefone='${telefone}'`,
+          })
+          if (dup.items.length > 0) {
+            return NextResponse.json(
+              { error: 'Já existe um usuário com este CPF ou e-mail.' },
+              { status: 409 },
+            )
+          }
+        } catch {}
         if (!tenantId) {
           return NextResponse.json(
             { error: 'Tenant não informado' },
@@ -37,8 +50,8 @@ export async function POST(req: NextRequest) {
           nome,
           email: data.user_email,
           emailVisibility: true,
-          cpf: String(data.user_cpf).replace(/\D/g, ''),
-          telefone: String(data.user_phone).replace(/\D/g, ''),
+          cpf,
+          telefone,
           data_nascimento: data.user_birth_date,
           genero: data.user_gender?.toLowerCase(),
           endereco: data.user_address,

--- a/app/loja/api/inscricoes/route.ts
+++ b/app/loja/api/inscricoes/route.ts
@@ -30,7 +30,7 @@ export async function POST(req: NextRequest) {
         const telefone = String(data.user_phone).replace(/\D/g, '')
         try {
           const dup = await pb.collection('usuarios').getList(1, 1, {
-            filter: `cpf='${cpf}' || email='${data.user_email}' || telefone='${telefone}'`,
+            filter: `cpf='${cpf}' || email='${data.user_email}'`,
           })
           if (dup.items.length > 0) {
             return NextResponse.json(

--- a/components/templates/SignUpForm.tsx
+++ b/components/templates/SignUpForm.tsx
@@ -4,7 +4,6 @@ import { useState, useEffect, useMemo } from 'react'
 import { fetchCep } from '@/utils/cep'
 import { useAuthContext } from '@/lib/context/AuthContext'
 import { useToast } from '@/lib/context/ToastContext'
-import type { ClientResponseError } from 'pocketbase'
 import Spinner from '@/components/atoms/Spinner'
 import createPocketBase from '@/lib/pocketbase'
 import { getAuthHeaders } from '@/lib/authHeaders'
@@ -135,16 +134,8 @@ export default function SignUpForm({
       }, 500)
     } catch (err: unknown) {
       console.error('Erro no cadastro:', err)
-      const e = err as ClientResponseError
-      const data = e.response?.data as
-        | { telefone?: { message: string }; cpf?: { message: string } }
-        | undefined
-      const dupMsg = data?.telefone?.message || data?.cpf?.message
-      if (dupMsg) {
-        showError(dupMsg)
-      } else {
-        showError('Não foi possível criar a conta.')
-      }
+      const message = err instanceof Error ? err.message : 'Não foi possível criar a conta.'
+      showError(message)
     } finally {
       setLoading(false)
     }

--- a/lib/context/AuthContext.tsx
+++ b/lib/context/AuthContext.tsx
@@ -148,7 +148,7 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
       setTenantId(null)
     }
 
-    await fetch('/api/register', {
+    const res = await fetch('/api/register', {
       method: 'POST',
       headers: { ...getAuthHeaders(pb), 'Content-Type': 'application/json' },
       credentials: 'include',
@@ -168,6 +168,11 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
         cliente: clienteId,
       }),
     })
+    if (!res.ok) {
+      const data = await res.json().catch(() => null)
+      const msg = data?.erro || data?.error || 'Falha no cadastro'
+      throw new Error(msg)
+    }
     await login(email, password)
   }
 


### PR DESCRIPTION
## Summary
- block repeated users on shop sign up endpoint
- block repeated users on `/api/register`
- block repeated users on `/api/signup`
- surface backend sign up error in AuthContext
- show sign up error text in UI

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6863edec7670832c8bd937e90dab3842