### PR TITLE
Implement serverless logging path

### DIFF
--- a/README.md
+++ b/README.md
@@ -360,7 +360,9 @@ Os arquivos dentro do diretório `logs/` guardam o histórico do projeto.
 - `logs/DOC_LOG.md` registra alterações de documentação e processos.
 - `logs/ERR_LOG.md` armazena erros ocorridos e como foram corrigidos.
 
-Para adicionar uma nova entrada, abra o arquivo correspondente e inclua uma linha no formato:
+Em ambientes serverless (como a hospedagem na Vercel) o log de erros é gravado em `/tmp/ERR_LOG.md` ou enviado para um serviço externo, pois o diretório do projeto é efêmero. Para inspecionar, baixe esse arquivo ou acesse a ferramenta configurada.
+
+Para adicionar uma nova entrada manualmente, abra o arquivo correspondente e inclua uma linha no formato:
 
 ```
 ## [DATA] Descrição - ambiente - [link do commit]

--- a/__tests__/serverLogger.test.ts
+++ b/__tests__/serverLogger.test.ts
@@ -9,6 +9,7 @@ import * as fsPromises from 'fs/promises'
 describe('logConciliacaoErro', () => {
   afterEach(() => {
     vi.restoreAllMocks()
+    delete process.env.VERCEL
   })
 
   it('escreve mensagem no arquivo de log', async () => {
@@ -18,6 +19,17 @@ describe('logConciliacaoErro', () => {
     expect(appendFileSpy).toHaveBeenCalledWith(
       logPath,
       expect.stringContaining('teste'),
+    )
+  })
+
+  it('usa /tmp/ERR_LOG.md em ambiente serverless', async () => {
+    process.env.VERCEL = '1'
+    const appendFileSpy = vi.spyOn(fsPromises, 'appendFile')
+    await logConciliacaoErro('serverless')
+    const logPath = path.join('/tmp', 'ERR_LOG.md')
+    expect(appendFileSpy).toHaveBeenCalledWith(
+      logPath,
+      expect.stringContaining('serverless'),
     )
   })
 

--- a/lib/server/logger.ts
+++ b/lib/server/logger.ts
@@ -6,8 +6,15 @@ export async function logConciliacaoErro(message: string) {
   const env = process.env.NODE_ENV || 'dev'
   const line = `## [${date}] ${message} - ${env}\n`
   try {
-    const logPath = path.join(process.cwd(), 'logs', 'ERR_LOG.md')
+    const isServerless = Boolean(process.env.VERCEL || process.env.AWS_EXECUTION_ENV)
+    const logPath = isServerless
+      ? path.join('/tmp', 'ERR_LOG.md')
+      : path.join(process.cwd(), 'logs', 'ERR_LOG.md')
+
     await appendFile(logPath, line)
+
+    // em ambientes serverless, opcionalmente envie a linha para um servico externo
+    // await sendLogToExternalService(line)
   } catch (err) {
     console.error('Falha ao registrar ERR_LOG', err)
   }

--- a/logs/DOC_LOG.md
+++ b/logs/DOC_LOG.md
@@ -1,5 +1,7 @@
 # Registro de Alterações Documentais
 
+## [2025-07-01] Documentado caminho de logs em ambientes serverless no README e no cabeçalho do ERR_LOG
+
 ## [2025-06-06] Adicionada seção 'Registro de Logs' no README
 
 ## [2025-06-06] Adicionada variavel ASAAS_WEBHOOK_SECRET no README

--- a/logs/ERR_LOG.md
+++ b/logs/ERR_LOG.md
@@ -1,3 +1,7 @@
+# Registro de Erros
+
+> Em ambiente local o log é gravado em `logs/ERR_LOG.md`. Em produção (por exemplo, na Vercel) o arquivo é salvo em `/tmp/ERR_LOG.md` ou encaminhado para um serviço externo. Baixe esse arquivo ou acesse sua ferramenta de coleta para visualizar os registros.
+
 ## [2025-06-07] Corrigida tipagem da página de categoria que quebrava build - dev - 450cce4
 
 ## [2025-06-07] Corrigido efeito em ListaInscricoes que não respondia a mudanças de autenticação - dev - 668eeb0
@@ -195,3 +199,4 @@
 ## [2025-06-30] Produtos exclusivos retornavam erro 403 na loja. Página agora exibe detalhes e exige login apenas na compra - dev - c18ad74d
 
 ## [2025-07-01] Corrigida tipagem de params na página de confirmação de senha; build falhava por incompatibilidade com PageProps - dev - 7d2b5981
+## [2025-07-01] Erro ao criar pedido: TypeError: Cannot read properties of undefined (reading 'id') - test


### PR DESCRIPTION
## Summary
- write logs to `/tmp/ERR_LOG.md` when `process.env.VERCEL` is set
- test server logger behavior in serverless mode
- clarify serverless log path in `README.md`
- document logging guidance in `ERR_LOG.md`
- add doc log entry

## Testing
- `npm run lint`
- `npm test` *(fails: 30 failed, 121 passed)*
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_6863eef211cc832cbc445b76f0cd4dc9