### PR TITLE
Add LogRocket event logs

### DIFF
--- a/README.md
+++ b/README.md
@@ -362,6 +362,8 @@ Os arquivos dentro do diretório `logs/` guardam o histórico do projeto.
 
 Em ambientes serverless (como a hospedagem na Vercel) o log de erros é gravado em `/tmp/ERR_LOG.md` ou encaminhado para o LogRocket (`4pjmeb/m24`), pois o diretório do projeto é efêmero. Para inspecionar, baixe esse arquivo ou consulte o painel do LogRocket.
 
+Além dos erros, o LogRocket registra eventos importantes como criação de usuários, inscrições confirmadas e pedidos gerados, facilitando a auditoria.
+
 Para adicionar uma nova entrada manualmente, abra o arquivo correspondente e inclua uma linha no formato:
 
 ```

--- a/app/api/inscricoes/[id]/route.ts
+++ b/app/api/inscricoes/[id]/route.ts
@@ -3,6 +3,7 @@ import { requireRole } from '@/lib/apiAuth'
 import { getTenantFromHost } from '@/lib/getTenantFromHost'
 import type { Inscricao } from '@/types'
 import type { RecordModel } from 'pocketbase'
+import { logRocketEvent } from '@/lib/server/logger'
 
 async function checkAccess(
   inscricao: Inscricao,
@@ -75,6 +76,10 @@ export async function PATCH(req: NextRequest) {
     }
     const data = await req.json()
     const updated = await pb.collection('inscricoes').update(id, data)
+    logRocketEvent('inscricao_atualizada', {
+      inscricaoId: id,
+      status: updated.status,
+    })
     return NextResponse.json(updated)
   } catch (err) {
     console.error('Erro ao atualizar inscricao:', err)
@@ -98,6 +103,7 @@ export async function DELETE(req: NextRequest) {
       return NextResponse.json({ error: 'Acesso negado' }, { status: 403 })
     }
     await pb.collection('inscricoes').update(id, { status: 'cancelado' })
+    logRocketEvent('inscricao_cancelada', { inscricaoId: id })
     return NextResponse.json({ ok: true })
   } catch (err) {
     console.error('Erro ao cancelar inscricao:', err)

--- a/app/api/pedidos/route.ts
+++ b/app/api/pedidos/route.ts
@@ -3,7 +3,7 @@ import createPocketBase from '@/lib/pocketbase'
 import { getUserFromHeaders } from '@/lib/getUserFromHeaders'
 import { requireRole } from '@/lib/apiAuth'
 import { getTenantFromHost } from '@/lib/getTenantFromHost'
-import { logConciliacaoErro } from '@/lib/server/logger'
+import { logConciliacaoErro, logRocketEvent } from '@/lib/server/logger'
 import type { Inscricao, Pedido, Produto } from '@/types'
 import colorName from 'color-namer'
 
@@ -242,6 +242,10 @@ export async function POST(req: NextRequest) {
       try {
         const pedido = await pb.collection('pedidos').create<Pedido>(payload)
         console.log('[PEDIDOS][POST] Pedido criado:', pedido)
+        logRocketEvent('pedido_criado', {
+          pedidoId: pedido.id,
+          responsavel: userId,
+        })
 
         return NextResponse.json({
           pedidoId: pedido.id,
@@ -344,6 +348,10 @@ export async function POST(req: NextRequest) {
     try {
       const pedido = await pb.collection('pedidos').create<Pedido>(payload)
       console.log('[PEDIDOS][POST] Pedido criado:', pedido)
+      logRocketEvent('pedido_criado', {
+        pedidoId: pedido.id,
+        responsavel: responsavelId,
+      })
 
       return NextResponse.json({
         pedidoId: pedido.id,

--- a/app/api/signup/route.ts
+++ b/app/api/signup/route.ts
@@ -1,6 +1,7 @@
 import { NextRequest, NextResponse } from 'next/server'
 import createPocketBase from '@/lib/pocketbase'
 import { getTenantFromHost } from '@/lib/getTenantFromHost'
+import { logRocketEvent } from '@/lib/server/logger'
 
 export async function POST(req: NextRequest) {
   const pb = createPocketBase()
@@ -74,6 +75,8 @@ export async function POST(req: NextRequest) {
     } catch (err) {
       console.error('Falha ao enviar mensagem de boas-vindas', err)
     }
+
+    logRocketEvent('novo_usuario', { userId: usuario.id })
 
     return NextResponse.json(usuario, { status: 201 })
   } catch (err: unknown) {

--- a/app/loja/api/inscricoes/route.ts
+++ b/app/loja/api/inscricoes/route.ts
@@ -2,7 +2,7 @@ import { NextRequest, NextResponse } from 'next/server'
 import createPocketBase from '@/lib/pocketbase'
 import { ClientResponseError } from 'pocketbase'
 import { getTenantFromHost } from '@/lib/getTenantFromHost'
-import { logConciliacaoErro } from '@/lib/server/logger'
+import { logConciliacaoErro, logRocketEvent } from '@/lib/server/logger'
 import type { PaymentMethod } from '@/lib/asaasFees'
 import { criarInscricao, InscricaoTemplate } from '@/lib/templates/inscricao'
 
@@ -110,6 +110,10 @@ export async function POST(req: NextRequest) {
     const evento = await pb.collection('eventos').getOne(data.evento)
 
     console.log('Registro criado com sucesso:', record)
+    logRocketEvent('inscricao_loja', {
+      inscricaoId: record.id,
+      userId: usuario?.id,
+    })
 
     let eventType: 'nova_inscricao' | 'confirmacao_inscricao' =
       'confirmacao_inscricao'

--- a/lib/server/logger.ts
+++ b/lib/server/logger.ts
@@ -1,5 +1,20 @@
 import { appendFile } from 'fs/promises'
 import path from 'path'
+import LogRocket from 'logrocket'
+
+let lrInitialized = false
+
+function ensureLogRocket() {
+  if (!lrInitialized) {
+    try {
+      LogRocket.init('4pjmeb/m24')
+      lrInitialized = true
+    } catch (err) {
+      console.error('Falha ao iniciar LogRocket', err)
+    }
+  }
+  return lrInitialized
+}
 
 export async function logConciliacaoErro(message: string) {
   const date = new Date().toISOString().split('T')[0]
@@ -17,5 +32,35 @@ export async function logConciliacaoErro(message: string) {
     // await sendLogToExternalService(line)
   } catch (err) {
     console.error('Falha ao registrar ERR_LOG', err)
+  }
+}
+
+export function logRocketEvent(
+  message: string,
+  data?: Record<string, unknown>,
+) {
+  if (process.env.NODE_ENV !== 'production') return
+  if (!ensureLogRocket()) return
+  try {
+    if (data) {
+      LogRocket.track(
+        message,
+        data as Record<
+          string,
+          | string
+          | number
+          | boolean
+          | string[]
+          | number[]
+          | boolean[]
+          | null
+          | undefined
+        >,
+      )
+    } else {
+      LogRocket.captureMessage(message)
+    }
+  } catch (err) {
+    console.error('Falha ao enviar log ao LogRocket', err)
   }
 }

--- a/logs/DOC_LOG.md
+++ b/logs/DOC_LOG.md
@@ -1,5 +1,6 @@
 # Registro de Alterações Documentais
 
+## [2025-07-01] Registrados eventos de inscrição e pedidos no LogRocket
 ## [2025-07-01] Documentado caminho de logs em ambientes serverless no README e no cabeçalho do ERR_LOG
 ## [2025-07-01] Integrado LogRocket para coleta de erros e atualizada documentação
 


### PR DESCRIPTION
## Summary
- track signup creation with LogRocket
- log new inscriptions and auto-generated orders
- send events for order creation
- document LogRocket events
- record documentation update in DOC_LOG

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6863fd272b50832c911a75ad27f01c36