### PR TITLE
Update login error handling

### DIFF
--- a/components/templates/LoginForm.tsx
+++ b/components/templates/LoginForm.tsx
@@ -50,9 +50,13 @@ export default function LoginForm({
     try {
       await login(email, senha)
       // Redirecionamento ocorre no useEffect
-    } catch (e) {
+    } catch (e: unknown) {
       console.error('❌ Erro no login:', e)
-      showError('Credenciais inválidas.')
+      if (e instanceof Error) {
+        showError(e.message || 'Credenciais inválidas.')
+      } else {
+        showError('Credenciais inválidas.')
+      }
     } finally {
       setIsSubmitting(false)
     }

--- a/lib/context/AuthContext.tsx
+++ b/lib/context/AuthContext.tsx
@@ -96,7 +96,10 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
       credentials: 'include',
       body: JSON.stringify({ email, password }),
     })
-    if (!res.ok) throw new Error('Login failed')
+    if (!res.ok) {
+      const data = await res.json().catch(() => null)
+      throw new Error(data?.error || 'Login failed')
+    }
     const data = await res.json()
     pb.authStore.save(data.token, data.user)
     updateBaseAuth(data.token, data.user)


### PR DESCRIPTION
## Summary
- enhance login error parsing to show server messages
- show server-provided login errors in LoginForm

## Testing
- `npm run lint`
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68640213116c832ca180aa365758b631