### PR TITLE
Improve signup error handling

### DIFF
--- a/app/signup/page.tsx
+++ b/app/signup/page.tsx
@@ -53,7 +53,8 @@ export default function SignUpPage() {
       })
       const data = await res.json()
       if (!res.ok) {
-        const dupMsg = data?.telefone?.message || data?.cpf?.message
+        const dupMsg =
+          data?.telefone?.message || data?.cpf?.message || data?.email?.message
         showError(dupMsg || data?.error || 'Erro ao criar conta.')
         return
       }
@@ -62,7 +63,11 @@ export default function SignUpPage() {
       router.push('/completar-cadastro')
     } catch (err) {
       console.error('Erro no cadastro:', err)
-      showError('Erro ao criar conta.')
+      if (err instanceof Error) {
+        showError(err.message)
+      } else {
+        showError('Falha de conexão')
+      }
     } finally {
       setLoading(false)
     }


### PR DESCRIPTION
## Summary
- surface backend error messages on signup
- show network error message when signup fails

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6864060e608c832cb1513e40b881b2fa