### PR TITLE
Improve error handling in InscricaoForm

### DIFF
--- a/components/organisms/InscricaoForm.tsx
+++ b/components/organisms/InscricaoForm.tsx
@@ -109,10 +109,13 @@ export default function InscricaoForm({ eventoId }: InscricaoFormProps) {
       setTimeout(() => {
         router.push('/loja/inscricoes/confirmacao')
       }, 500)
-    } catch (err) {
+    } catch (err: unknown) {
       console.warn('Erro ao enviar inscrição:', err)
       setStatus('error')
-      showError('Erro ao enviar a inscrição. Tente novamente.')
+      const msg =
+        (err as { response?: { error?: string } })?.response?.error ||
+        'Erro ao enviar a inscrição. Tente novamente.'
+      showError(msg)
     }
   }
 

--- a/logs/ERR_LOG.md
+++ b/logs/ERR_LOG.md
@@ -203,3 +203,4 @@
 ## [2025-06-30] Produtos exclusivos retornavam erro 403 na loja. Página agora exibe detalhes e exige login apenas na compra - dev - c18ad74d
 
 ## [2025-07-01] Corrigida tipagem de params na página de confirmação de senha; build falhava por incompatibilidade com PageProps - dev - 7d2b5981
+## [2025-08-11] Mostrar erro detalhado ao enviar inscrição no InscricaoForm - dev - 99686afe


### PR DESCRIPTION
## Summary
- show detailed API error on inscription submission
- log fix in `ERR_LOG.md`

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6864072df4bc832ca26798c0a1700284