### PR TITLE
Validate duplicated CPF/email in EventForm

### DIFF
--- a/__tests__/FormWizard.test.tsx
+++ b/__tests__/FormWizard.test.tsx
@@ -1,6 +1,7 @@
 /* @vitest-environment jsdom */
 import React from 'react'
 import { render, screen, fireEvent } from '@testing-library/react'
+import { vi } from 'vitest'
 import FormWizard from '@/components/organisms/FormWizard'
 
 describe('FormWizard', () => {
@@ -17,5 +18,50 @@ describe('FormWizard', () => {
     fireEvent.click(screen.getByText('Avançar'))
 
     expect(screen.getByText('Passo 1 de 2')).toBeInTheDocument()
+  })
+
+  it('executa onStepValidate e bloqueia avanço quando retorna false', async () => {
+    const validate = vi.fn().mockResolvedValue(false)
+    render(
+      <FormWizard
+        onStepValidate={validate}
+        steps={[
+          { title: 'Um', content: <input required placeholder="a" /> },
+          { title: 'Dois', content: <div>Etapa 2</div> },
+        ]}
+      />,
+    )
+
+    fireEvent.click(screen.getByText('Avançar'))
+
+    await vi.waitFor(() => {
+      expect(validate).toHaveBeenCalledWith(0)
+    })
+
+    expect(screen.getByText('Passo 1 de 2')).toBeInTheDocument()
+  })
+
+  it('desabilita botão enquanto validação está pendente', async () => {
+    let resolveFn: (v: boolean) => void = () => {}
+    const validate = vi.fn().mockImplementation(
+      () => new Promise<boolean>((res) => {
+        resolveFn = res
+      }),
+    )
+    render(
+      <FormWizard
+        onStepValidate={validate}
+        steps={[
+          { title: 'Um', content: <input required placeholder="a" /> },
+          { title: 'Dois', content: <div>Etapa 2</div> },
+        ]}
+      />,
+    )
+
+    const button = screen.getByText('Avançar')
+    fireEvent.click(button)
+    expect(button).toBeDisabled()
+    resolveFn(true)
+    await vi.waitFor(() => expect(button).not.toBeDisabled())
   })
 })

--- a/app/api/usuarios/exists/route.ts
+++ b/app/api/usuarios/exists/route.ts
@@ -1,0 +1,38 @@
+import { NextRequest, NextResponse } from 'next/server'
+import createPocketBase from '@/lib/pocketbase'
+
+export async function GET(req: NextRequest) {
+  const pb = createPocketBase(false)
+  const cpf = req.nextUrl.searchParams.get('cpf')?.replace(/\D/g, '') || ''
+  const email = req.nextUrl.searchParams.get('email') || ''
+
+  if (!cpf && !email) {
+    return NextResponse.json({ error: 'Parâmetros inválidos' }, { status: 400 })
+  }
+
+  const result: { cpf?: boolean; email?: boolean } = {}
+
+  try {
+    if (cpf) {
+      const r = await pb.collection('usuarios').getList(1, 1, {
+        filter: `cpf='${cpf}'`,
+      })
+      result.cpf = r.items.length > 0
+    }
+  } catch {
+    return NextResponse.json({ error: 'Erro ao verificar CPF' }, { status: 500 })
+  }
+
+  try {
+    if (email) {
+      const r = await pb.collection('usuarios').getList(1, 1, {
+        filter: `email='${email}'`,
+      })
+      result.email = r.items.length > 0
+    }
+  } catch {
+    return NextResponse.json({ error: 'Erro ao verificar email' }, { status: 500 })
+  }
+
+  return NextResponse.json(result)
+}


### PR DESCRIPTION
## Summary
- extend FormWizard with internal loading state to prevent rapid clicks
- show overlay while validation occurs
- disable Next button until validation resolves
- show inline validation errors for duplicated CPF/email in EventForm

## Testing
- `npm run lint` *(fails: next not found)*
- `npm run build` *(fails: next not found)*
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68641df248d0832cb2d6b331d5a05ae0