### PR TITLE
Prevent duplicate pedidos

### DIFF
--- a/app/admin/inscricoes/page.tsx
+++ b/app/admin/inscricoes/page.tsx
@@ -395,6 +395,15 @@ export default function ListaInscricoesPage() {
           '[confirmarInscricao] Erro ao gerar link de pagamento:',
           checkout,
         )
+        try {
+          await fetch(`/api/pedidos/${pedido.pedidoId}`, {
+            method: 'DELETE',
+            credentials: 'include',
+            headers: getAuthHeaders(pb),
+          })
+        } catch (e) {
+          console.error('[confirmarInscricao] Falha ao remover pedido:', e)
+        }
         throw new Error('Erro ao gerar link de pagamento.')
       }
 

--- a/app/api/pedidos/route.ts
+++ b/app/api/pedidos/route.ts
@@ -279,6 +279,26 @@ export async function POST(req: NextRequest) {
       )
     }
 
+    // Verificar se já existe pedido vinculado à inscrição
+    try {
+      const existente = await pb
+        .collection('pedidos')
+        .getFirstListItem<Pedido>(
+          `id_inscricao="${inscricaoId}" && status!='cancelado'`,
+        )
+      if (existente) {
+        console.log('[PEDIDOS][POST] Pedido existente:', existente.id)
+        return NextResponse.json({
+          pedidoId: existente.id,
+          valor: existente.valor,
+          status: existente.status,
+        })
+      }
+    } catch (err) {
+      console.log('[PEDIDOS][POST] Nenhum pedido existente encontrado')
+      console.error(err)
+    }
+
     const campoId = inscricao.expand?.campo?.id
     const responsavelId = inscricao.expand?.criado_por
     let produtoRecord: Produto | undefined


### PR DESCRIPTION
## Summary
- add deletion step on Asaas link failure to avoid stray orders
- ensure the API checks for existing pedidos before creating new ones

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_686430b708ec832c971af891f0b20000