### PR TITLE
Adjust payment flow for subscription confirmation

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,9 +122,9 @@ Ao abrir páginas que utilizam informações do cliente (checkout, dashboard etc
 
 1. O usuário preenche o formulário e os dados são enviados para `criarInscricao`.
 2. A função valida os campos e retorna uma inscrição com status `pendente`.
-3. Em seguida `criarPedido` só é finalizado se a chamada ao Asaas retornar com
-   sucesso, salvando `link_pagamento`. O campo `canal` recebe `inscricao` para
-   indicar a origem do pedido.
+3. A confirmação do pagamento primeiro chama `/api/asaas`; somente se
+   `checkout.url` estiver presente o pedido é criado em seguida, salvando
+   `link_pagamento` e definindo o campo `canal` como `inscricao`.
 4. Compras feitas na loja chamam primeiro `/api/asaas/checkout`; o pedido
    é criado somente após receber o `link` do Asaas, garantindo registros
    válidos.

--- a/docs/manual-aprovacao-inscricao.md
+++ b/docs/manual-aprovacao-inscricao.md
@@ -40,12 +40,13 @@ const pedidoPayload = {
   canal: 'inscricao',
 }
 
-// Enviar para /api/pedidos com esse payload
+// 1. Gerar link de pagamento via Asaas (`/api/asaas`)
+// 2. Se `checkout.url` existir, adicione `link_pagamento` ao payload
+// 3. Envie para /api/pedidos com esse payload
 ```
 
 - Atualizar campo `aprovada` → `true`
 - Atualizar campo `confirmado_por_lider` → `true`
-- Gerar link de pagamento via Asaas (`/api/asaas`)
 - Atualizar inscrição com:
 
 ```json

--- a/logs/DOC_LOG.md
+++ b/logs/DOC_LOG.md
@@ -479,3 +479,4 @@ executados.
 ## [2025-06-30] Dashboard agora busca todas as páginas para manter contagens em sincronia com o PocketBase. Lint e build executados.
 ## [2025-07-01] Rota /auth/password-reset removida e redirecionada para /auth/confirm-password-reset. Documentacao atualizada.
 ## [2025-06-30] Corrigido tipo de params na rota /auth/confirm-password-reset/[token]. Lint e build executados.
+## [2025-08-11] Fluxo de confirmação de inscrição ajustado: chamada ao Asaas ocorre antes da criação do pedido. README e manual atualizados. - Lint: falhou (next not found) - Build: falhou (next not found)


### PR DESCRIPTION
## Summary
- call `/api/asaas` before creating a pedido
- update docs about new order
- log documentation change

## Testing
- `npm run lint` *(fails: next not found)*
- `npm run build` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_6864673d1048832c82fe02fef0d2117b