### PR TITLE
Adjust payment flow for subscription confirmation

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,20 +122,18 @@ Ao abrir páginas que utilizam informações do cliente (checkout, dashboard etc
 
 1. O usuário preenche o formulário e os dados são enviados para `criarInscricao`.
 2. A função valida os campos e retorna uma inscrição com status `pendente`.
-3. Em seguida `criarPedido` só é finalizado se a chamada ao Asaas retornar com
-   sucesso, salvando `link_pagamento`. O campo `canal` recebe `inscricao` para
-   indicar a origem do pedido.
-4. Compras feitas na loja chamam primeiro `/api/asaas/checkout`; o pedido
-   é criado somente após receber o `link` do Asaas, garantindo registros
-   válidos.
-5. O usuário é redirecionado para essa URL para concluir o pagamento.
+3. A confirmação do pagamento cria primeiro um `pedido` via `/api/pedidos` e
+   utiliza o `pedidoId` para chamar `/api/asaas`. Se `checkout.url` for retornado
+   ele é salvo no pedido (campo `link_pagamento`) e a inscrição é atualizada com
+   `status` aguardando pagamento.
+4. Compras feitas na loja chamam `/api/asaas/checkout` e apenas em seguida
+   registram o pedido, garantindo que o link seja sempre válido.
+5. O usuário é redirecionado para a URL de pagamento para concluir a compra.
 
-### Inscrições x Compras na Loja
-
-- **Inscrições** – após um líder confirmar a inscrição pelo admin, o painel faz
-  uma chamada para `/api/asaas` informando `valorBruto`, `paymentMethod`
-  e `installments` para gerar o boleto e salvar o link de pagamento no pedido
-  correspondente.
+- **Inscrições** – após um líder confirmar a inscrição pelo admin, o painel cria
+  um pedido com os dados da inscrição e, em seguida, consulta `/api/asaas`
+  passando `pedidoId`, `valorBruto`, `paymentMethod` e `installments`.
+  Se o retorno contiver `checkout.url`, o link é salvo no pedido e enviado ao usuário.
 - Para o passo a passo completo do modo manual consulte
   [docs/manual-aprovacao-inscricao.md](docs/manual-aprovacao-inscricao.md).
 - **Compras de Loja** – os produtos adicionados ao carrinho são processados na

--- a/app/admin/inscricoes/page.tsx
+++ b/app/admin/inscricoes/page.tsx
@@ -391,6 +391,10 @@ export default function ListaInscricoesPage() {
       const checkout = await asaasRes.json()
 
       if (!asaasRes.ok || !checkout?.url) {
+        const msg =
+          checkout?.message ||
+          (checkout?.errors && checkout.errors[0]?.description) ||
+          'Tivemos um problema ao gerar seu link de pagamento. Nenhum valor foi registrado. Por favor, tente novamente ou entre em contato com a equipe.'
         console.error(
           '[confirmarInscricao] Erro ao gerar link de pagamento:',
           checkout,
@@ -404,7 +408,9 @@ export default function ListaInscricoesPage() {
         } catch (e) {
           console.error('[confirmarInscricao] Falha ao remover pedido:', e)
         }
-        throw new Error('Erro ao gerar link de pagamento.')
+        showError(msg)
+        setConfirmandoId(null)
+        return
       }
 
       // 4. Atualizar inscrição com o ID do pedido

--- a/docs/manual-aprovacao-inscricao.md
+++ b/docs/manual-aprovacao-inscricao.md
@@ -40,12 +40,13 @@ const pedidoPayload = {
   canal: 'inscricao',
 }
 
-// Enviar para /api/pedidos com esse payload
+// 1. Envie o payload acima para `/api/pedidos` e obtenha `pedidoId`
+// 2. Chame `/api/asaas` passando `pedidoId`, `valorBruto`, `paymentMethod` e `installments`
+// 3. Se `checkout.url` existir, atualize o pedido com `link_pagamento` e prossiga
 ```
 
 - Atualizar campo `aprovada` → `true`
 - Atualizar campo `confirmado_por_lider` → `true`
-- Gerar link de pagamento via Asaas (`/api/asaas`)
 - Atualizar inscrição com:
 
 ```json

--- a/logs/DOC_LOG.md
+++ b/logs/DOC_LOG.md
@@ -479,3 +479,5 @@ executados.
 ## [2025-06-30] Dashboard agora busca todas as páginas para manter contagens em sincronia com o PocketBase. Lint e build executados.
 ## [2025-07-01] Rota /auth/password-reset removida e redirecionada para /auth/confirm-password-reset. Documentacao atualizada.
 ## [2025-06-30] Corrigido tipo de params na rota /auth/confirm-password-reset/[token]. Lint e build executados.
+## [2025-08-11] Fluxo de confirmação de inscrição ajustado: chamada ao Asaas ocorre antes da criação do pedido. README e manual atualizados. - Lint: falhou (next not found) - Build: falhou (next not found)
+## [2025-08-12] Correção do fluxo de inscrição: pedido é criado antes da chamada ao Asaas e removido se o link não for gerado. Documentação revisada. - Lint: falhou (next not found) - Build: falhou (next not found)


### PR DESCRIPTION
## Summary
- restore pedido creation before Asaas call in `confirmarInscricao`
- show detailed message and delete pedido if Asaas fails
- update README and manual docs about new order
- log documentation change

## Testing
- `npm run lint` *(fails: next not found)*
- `npm run build` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_6864673d1048832c82fe02fef0d2117b