### PR TITLE
Corrige exibição do erro de checkout

### DIFF
--- a/app/admin/inscricoes/page.tsx
+++ b/app/admin/inscricoes/page.tsx
@@ -394,7 +394,8 @@ export default function ListaInscricoesPage() {
       if (!asaasRes.ok || !checkout?.url) {
         const msg =
           checkout?.message ||
-          (checkout?.errors && checkout.errors[0]?.description) ||
+          checkout?.error ||
+          checkout?.errors?.[0]?.description ||
           'Tivemos um problema ao gerar seu link de pagamento. Por favor, entre em contato com a equipe.'
         console.error(
           '[confirmarInscricao] Erro ao gerar link de pagamento:',

--- a/logs/ERR_LOG.md
+++ b/logs/ERR_LOG.md
@@ -207,3 +207,4 @@
 ## [2025-08-12] Página de produto travava quando não havia imagens. Galeria oculta quando array vazio - dev - cc4a5671
 ## [2025-08-13] Erro persistia quando objeto de imagens estava vazio; fallback para array vazio e uso de useMemo - dev - 636db478
 ## [2025-08-14] inscricoes.some is not a function quando API retorna objeto; parseado data.items em useInscricoes - dev - 09a133f7
+## [2025-07-02] Erro de checkout retornava campo 'error' nao tratado; exibicao atualizada - prod - aaccd7eb


### PR DESCRIPTION
## Resumo
- ajustar mensagem de erro na página de inscrições
- registrar correção no ERR_LOG

## Testes
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68648aec8544832cbf6b84319e83727e