### PR TITLE
Add realtime password validation message

### DIFF
--- a/components/ConfirmResetForm.tsx
+++ b/components/ConfirmResetForm.tsx
@@ -1,11 +1,10 @@
 'use client'
 import { useState, useMemo } from 'react'
-import { Eye, EyeOff } from 'lucide-react'
 import createPocketBase from '@/lib/pocketbase'
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
-import { Input } from '@/components/ui/input'
 import { Label } from '@/components/ui/label'
 import { Button } from '@/components/ui/button'
+import { PasswordField } from '@/components'
 
 interface Props {
   token: string
@@ -16,7 +15,6 @@ export default function ConfirmResetForm({ token }: Props) {
 
   const [password, setPassword] = useState('')
   const [confirm, setConfirm] = useState('')
-  const [show, setShow] = useState(false)
   const [error, setError] = useState<string>()
   const [success, setSuccess] = useState(false)
 
@@ -70,29 +68,17 @@ export default function ConfirmResetForm({ token }: Props) {
         <form onSubmit={handleSubmit} className="space-y-4">
           <div>
             <Label htmlFor="password">Nova senha</Label>
-            <div className="relative">
-              <Input
-                id="password"
-                type={show ? 'text' : 'password'}
-                value={password}
-                onChange={(e) => setPassword(e.target.value)}
-                required
-              />
-              <button
-                type="button"
-                onClick={() => setShow(!show)}
-                className="absolute right-2 top-1/2 -translate-y-1/2"
-                aria-label="Mostrar senha"
-              >
-                {show ? <EyeOff size={16} /> : <Eye size={16} />}
-              </button>
-            </div>
+            <PasswordField
+              id="password"
+              value={password}
+              onChange={(e) => setPassword(e.target.value)}
+              required
+            />
           </div>
           <div>
             <Label htmlFor="confirm">Confirme a senha</Label>
-            <Input
+            <PasswordField
               id="confirm"
-              type={show ? 'text' : 'password'}
               value={confirm}
               onChange={(e) => setConfirm(e.target.value)}
               required

--- a/components/molecules/PasswordField.tsx
+++ b/components/molecules/PasswordField.tsx
@@ -5,29 +5,52 @@ import { Eye, EyeOff } from 'lucide-react'
 export interface PasswordFieldProps
   extends React.InputHTMLAttributes<HTMLInputElement> {
   className?: string
+  /**
+   * Exibe a mensagem de validação de tamanho mínimo.
+   * Por padrão, true para formularios de cadastro.
+   */
+  showValidation?: boolean
 }
 
 export default function PasswordField({
   className = '',
+  showValidation = true,
   ...props
 }: PasswordFieldProps) {
   const [visible, setVisible] = useState(false)
+  const [touched, setTouched] = useState(false)
+
+  const handleChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    if (showValidation) setTouched(true)
+    props.onChange?.(e)
+  }
+
+  const value = (props.value ?? '').toString()
+  const isValid = value.length >= 8
 
   return (
-    <div className="relative">
-      <TextField
-        type={visible ? 'text' : 'password'}
-        className={className}
-        {...props}
-      />
-      <button
-        type="button"
-        aria-label={visible ? 'Esconder senha' : 'Mostrar senha'}
-        onClick={() => setVisible((v) => !v)}
-        className="absolute inset-y-0 right-0 flex items-center px-3 text-neutral-500"
-      >
-        {visible ? <EyeOff className="w-4 h-4" /> : <Eye className="w-4 h-4" />}
-      </button>
+    <div className="space-y-1">
+      <div className="relative">
+        <TextField
+          type={visible ? 'text' : 'password'}
+          className={className}
+          {...props}
+          onChange={handleChange}
+        />
+        <button
+          type="button"
+          aria-label={visible ? 'Esconder senha' : 'Mostrar senha'}
+          onClick={() => setVisible((v) => !v)}
+          className="absolute inset-y-0 right-0 flex items-center px-3 text-neutral-500"
+        >
+          {visible ? <EyeOff className="w-4 h-4" /> : <Eye className="w-4 h-4" />}
+        </button>
+      </div>
+      {showValidation && touched && (
+        <p className={`text-sm ${isValid ? 'text-green-600' : 'text-error-600'}`.trim()}>
+          {isValid ? 'Senha válida ✅' : 'A senha precisa ter pelo menos 8 caracteres.'}
+        </p>
+      )}
     </div>
   )
 }

--- a/components/templates/LoginForm.tsx
+++ b/components/templates/LoginForm.tsx
@@ -121,6 +121,7 @@ export default function LoginForm({
             value={senha}
             onChange={(e) => setSenha(e.target.value)}
             className="input-base w-full rounded-md px-4 py-2"
+            showValidation={false}
             required
           />
 


### PR DESCRIPTION
## Summary
- show validation helper in `PasswordField` after typing
- use `PasswordField` in `ConfirmResetForm`
- hide validation in login by disabling it

## Testing
- `npm run lint` *(fails: next not found)*
- `npm run build` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_68646b50296c832c9b80bee536d05f49