### PR TITLE
Update saldo exports with dynamic logo

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -23,6 +23,7 @@
         "framer-motion": "^12.17.3",
         "gray-matter": "^4.0.3",
         "jspdf": "^2.5.1",
+        "jspdf-autotable": "^5.0.2",
         "logrocket": "^10.1.0",
         "lucide-react": "^0.511.0",
         "next": "15.3.2",
@@ -12148,6 +12149,15 @@
         "core-js": "^3.6.0",
         "dompurify": "^2.2.0",
         "html2canvas": "^1.0.0-rc.5"
+      }
+    },
+    "node_modules/jspdf-autotable": {
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/jspdf-autotable/-/jspdf-autotable-5.0.2.tgz",
+      "integrity": "sha512-YNKeB7qmx3pxOLcNeoqAv3qTS7KuvVwkFe5AduCawpop3NOkBUtqDToxNc225MlNecxT4kP2Zy3z/y/yvGdXUQ==",
+      "license": "MIT",
+      "peerDependencies": {
+        "jspdf": "^2 || ^3"
       }
     },
     "node_modules/jsx-ast-utils": {

--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
     "framer-motion": "^12.17.3",
     "gray-matter": "^4.0.3",
     "jspdf": "^2.5.1",
+    "jspdf-autotable": "^5.0.2",
     "logrocket": "^10.1.0",
     "lucide-react": "^0.511.0",
     "next": "15.3.2",


### PR DESCRIPTION
## Summary
- fetch logo from tenant config for PDF/XLSX exports

## Testing
- `npm run lint` *(fails: next not found)*
- `npm run build` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_686493d1e9b8832cb771583aa66f6d91