### PR TITLE
Store Asaas ID when creating charges

### DIFF
--- a/__tests__/ModalVisualizarPedido.test.tsx
+++ b/__tests__/ModalVisualizarPedido.test.tsx
@@ -18,6 +18,7 @@ function mockPedido() {
     status: 'pendente',
     produto: [],
     id_pagamento: 'c1',
+    id_asaas: 'pay1',
     link_pagamento: 'pay',
     vencimento: new Date(Date.now() - 86400000).toISOString(),
     expand: {

--- a/__tests__/admin/asaasRoute.test.ts
+++ b/__tests__/admin/asaasRoute.test.ts
@@ -119,6 +119,7 @@ describe('POST /admin/api/asaas', () => {
     const body = await res.json()
     expect(body.url).toBe('pay')
     expect(body.vencimento).toBe('2025-01-01T00:00:00.000Z')
+    expect(body.id_asaas).toBe('c1')
     const sent = JSON.parse((global.fetch as any).mock.calls[2][1].body)
     expect(sent.billingType).toBe('PIX')
   })

--- a/app/admin/inscricoes/componentes/ModalVisualizarPedido.tsx
+++ b/app/admin/inscricoes/componentes/ModalVisualizarPedido.tsx
@@ -16,6 +16,7 @@ type PedidoExpandido = {
   status: string
   produto: string[]
   id_pagamento?: string
+  id_asaas?: string
   link_pagamento?: string
   vencimento?: string
   cor?: string
@@ -137,7 +138,12 @@ export default function ModalVisualizarPedido({ pedidoId, onClose }: Props) {
       if (!res.ok) throw new Error('fail')
       const data = await res.json()
       setUrlPagamento(data.link_pagamento)
-      setPedido({ ...pedido, link_pagamento: data.link_pagamento, vencimento: data.vencimento })
+      setPedido({
+        ...pedido,
+        link_pagamento: data.link_pagamento,
+        vencimento: data.vencimento,
+        ...(data.id_asaas ? { id_asaas: data.id_asaas } : {}),
+      })
       showSuccess('Nova cobrança gerada!')
     } catch {
       showError('Erro ao gerar nova cobrança')

--- a/app/api/asaas/route.ts
+++ b/app/api/asaas/route.ts
@@ -289,6 +289,7 @@ export async function POST(req: NextRequest) {
 
     const cobranca = JSON.parse(cobrancaRaw)
     const link = cobranca.invoiceUrl || cobranca.bankSlipUrl
+    const asaasId: string | undefined = cobranca.id
     const dueDateISO = cobranca.dueDate
       ? new Date(cobranca.dueDate).toISOString()
       : new Date(dueDate).toISOString()
@@ -306,10 +307,11 @@ export async function POST(req: NextRequest) {
       formaPagamento: paymentMethod,
       parcelas: installments,
       vencimento: dueDateISO,
+      ...(asaasId ? { id_asaas: asaasId } : {}),
     })
     console.log('🟢 Pedido atualizado com link de pagamento')
 
-    return NextResponse.json({ url: link, vencimento: dueDateISO })
+    return NextResponse.json({ url: link, vencimento: dueDateISO, id_asaas: asaasId })
   } catch (err: unknown) {
     await logConciliacaoErro(
       `Erro ao gerar link de pagamento Asaas: ${String(err)}`,

--- a/app/api/inscricoes/route.ts
+++ b/app/api/inscricoes/route.ts
@@ -239,6 +239,10 @@ export async function POST(req: NextRequest) {
             link_pagamento = data.url
             // eslint-disable-next-line @typescript-eslint/no-unused-vars
             const _vencimento = data.vencimento
+            const _idAsaas = data.id_asaas
+            if (_idAsaas) {
+              await pb.collection('pedidos').update(pedidoId, { id_asaas: _idAsaas })
+            }
           } else {
             await pb.collection('pedidos').delete(pedidoId)
           }

--- a/app/api/pedidos/[id]/nova-cobranca/route.ts
+++ b/app/api/pedidos/[id]/nova-cobranca/route.ts
@@ -181,14 +181,16 @@ export async function POST(req: NextRequest) {
     }
     const cobranca = JSON.parse(cobrancaRaw)
     const link = cobranca.invoiceUrl || cobranca.bankSlipUrl
+    const asaasId: string | undefined = cobranca.id
     const dueDateStr = cobranca.dueDate
       ? new Date(cobranca.dueDate).toISOString()
       : new Date(defaultDue).toISOString()
     await pb.collection('pedidos').update(pedido.id, {
       link_pagamento: link,
       vencimento: dueDateStr,
+      ...(asaasId ? { id_asaas: asaasId } : {}),
     })
-    return NextResponse.json({ link_pagamento: link, vencimento: dueDateStr })
+    return NextResponse.json({ link_pagamento: link, vencimento: dueDateStr, id_asaas: asaasId })
   } catch (err: unknown) {
     await logConciliacaoErro(`Erro ao criar nova cobrança: ${String(err)}`)
     return NextResponse.json(

--- a/app/api/pedidos/route.ts
+++ b/app/api/pedidos/route.ts
@@ -225,6 +225,7 @@ export async function POST(req: NextRequest) {
       const payload = {
         id_inscricao: '',
         id_pagamento: '',
+        id_asaas: '',
         produto: produtoIds,
         tamanho,
         status: 'pendente',
@@ -340,6 +341,7 @@ export async function POST(req: NextRequest) {
       id_inscricao: inscricaoId,
       valor,
       status: 'pendente',
+      id_asaas: '',
       produto: produtoIdInscricao
         ? [produtoIdInscricao]
         : produtoRecord

--- a/types/index.ts
+++ b/types/index.ts
@@ -46,6 +46,8 @@ export type Inscricao = {
 export type Pedido = {
   id: string
   id_pagamento: string
+  /** ID da cobrança gerada no Asaas */
+  id_asaas?: string
   id_inscricao: string
   produto: string[]
   tamanho?: string


### PR DESCRIPTION
## Summary
- save `id` from Asaas as `id_asaas` in `pedidos`
- propagate the new field in Nova Cobrança and Inscrições flows
- expose `id_asaas` in APIs and admin modal
- adjust tests and types for the new attribute

## Testing
- `npm run lint`
- `npm run build`
- `npm test` *(fails: 24 failed, 45 passed)*

------
https://chatgpt.com/codex/tasks/task_e_6864951a25c4832ca2791e9c134e6191