### PR TITLE
Add public recuperar-link route and adjust error message

### DIFF
--- a/app/api/recuperar-link/route.ts
+++ b/app/api/recuperar-link/route.ts
@@ -1,11 +1,13 @@
 import { NextRequest, NextResponse } from 'next/server'
 import createPocketBase from '@/lib/pocketbase'
+import { getTenantFromHost } from '@/lib/getTenantFromHost'
 import { logInfo } from '@/lib/logger'
 
 export async function POST(req: NextRequest) {
   const pb = createPocketBase()
   try {
-    const { cpf, telefone, cliente } = await req.json()
+    const { cpf, telefone } = await req.json()
+    const cliente = await getTenantFromHost()
 
     logInfo('📨 Dados recebidos:', { cpf, telefone })
 


### PR DESCRIPTION
## Summary
- update error message in admin recuperar-link endpoint
- add public recuperar-link API with same logic

## Testing
- `npm run lint` *(fails: next not found)*
- `npm run build` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_6864a11919ec832cb197a79026557b4c