### PR TITLE
Implement /api/recuperar-link endpoint

### DIFF
--- a/__tests__/api/recuperarLinkRoute.test.ts
+++ b/__tests__/api/recuperarLinkRoute.test.ts
@@ -1,0 +1,58 @@
+import { describe, it, expect, vi } from 'vitest'
+import { POST } from '../../app/api/recuperar-link/route'
+import { NextRequest } from 'next/server'
+import createPocketBaseMock from '../mocks/pocketbase'
+
+const pb = createPocketBaseMock()
+const getFullListMock = vi.fn()
+
+pb.collection.mockImplementation((name: string) => {
+  if (name === 'inscricoes') {
+    return { getFullList: getFullListMock }
+  }
+  return {}
+})
+
+vi.mock('../../lib/pocketbase', () => ({ default: vi.fn(() => pb) }))
+vi.mock('../../lib/getTenantFromHost', () => ({ getTenantFromHost: vi.fn(() => 'cli1') }))
+
+describe('POST /api/recuperar-link', () => {
+  it('retorna link de pagamento quando pendente', async () => {
+    getFullListMock.mockResolvedValueOnce([
+      {
+        status: 'ativo',
+        confirmado_por_lider: true,
+        expand: { pedido: { status: 'pendente', link_pagamento: 'http://pay' } },
+      },
+    ])
+    const req = new Request('http://test', {
+      method: 'POST',
+      body: JSON.stringify({ cpf: '1' }),
+    })
+    const res = await POST(req as unknown as NextRequest)
+    expect(res.status).toBe(200)
+    const body = await res.json()
+    expect(body.status).toBe('pendente')
+    expect(body.link_pagamento).toBe('http://pay')
+  })
+
+  it('retorna 404 quando inscricao nao encontrada', async () => {
+    getFullListMock.mockResolvedValueOnce([])
+    const req = new Request('http://test', {
+      method: 'POST',
+      body: JSON.stringify({ cpf: '1' }),
+    })
+    const res = await POST(req as unknown as NextRequest)
+    expect(res.status).toBe(404)
+  })
+
+  it('retorna 500 em falha inesperada', async () => {
+    getFullListMock.mockRejectedValueOnce(new Error('fail'))
+    const req = new Request('http://test', {
+      method: 'POST',
+      body: JSON.stringify({ cpf: '1' }),
+    })
+    const res = await POST(req as unknown as NextRequest)
+    expect(res.status).toBe(500)
+  })
+})

--- a/app/api/recuperar-link/route.ts
+++ b/app/api/recuperar-link/route.ts
@@ -1,0 +1,101 @@
+import { NextRequest, NextResponse } from 'next/server'
+import createPocketBase from '@/lib/pocketbase'
+import { logInfo } from '@/lib/logger'
+import { getTenantFromHost } from '@/lib/getTenantFromHost'
+
+export async function POST(req: NextRequest) {
+  const pb = createPocketBase()
+  try {
+    const { cpf, telefone } = await req.json()
+
+    logInfo('📨 Dados recebidos:', { cpf, telefone })
+
+    if (!cpf && !telefone) {
+      logInfo('⚠️ CPF ou telefone não fornecido')
+      return NextResponse.json(
+        { error: 'Informe o CPF ou telefone.' },
+        { status: 400 },
+      )
+    }
+
+    const cliente = await getTenantFromHost()
+
+    if (!cliente) {
+      return NextResponse.json({ error: 'Tenant não informado' }, { status: 400 })
+    }
+
+    if (!pb.authStore.isValid) {
+      logInfo('🔐 Autenticando como admin...')
+      await pb.admins.authWithPassword(
+        process.env.PB_ADMIN_EMAIL!,
+        process.env.PB_ADMIN_PASSWORD!,
+      )
+      logInfo('✅ Autenticado com sucesso.')
+    }
+
+    const filtroBase = cpf ? `cpf = "${cpf}"` : `telefone = "${telefone}"`
+    const filtro = `${filtroBase} && cliente='${cliente}'`
+    logInfo('🔎 Filtro usado:', filtro)
+
+    const inscricoes = await pb.collection('inscricoes').getFullList({
+      filter: filtro,
+      expand: 'pedido',
+    })
+
+    logInfo(`📋 ${inscricoes.length} inscrição(ões) encontrada(s)`)
+
+    if (!inscricoes.length) {
+      logInfo('❌ Nenhuma inscrição encontrada.')
+      return NextResponse.json(
+        { error: 'Inscrição não encontrada. Por favor faça a inscrição.' },
+        { status: 404 },
+      )
+    }
+
+    const inscricao = inscricoes[0]
+    const pedido = inscricao.expand?.pedido
+
+    logInfo('🧾 Pedido expandido com sucesso')
+
+    if (inscricao.status === 'cancelado') {
+      logInfo('❌ Inscrição recusada pela liderança.')
+      return NextResponse.json({ status: 'recusado' })
+    }
+
+    if (!inscricao.confirmado_por_lider || !pedido) {
+      logInfo('⏳ Inscrição aguardando confirmação da liderança.')
+      return NextResponse.json({ status: 'aguardando_confirmacao' })
+    }
+
+    if (pedido.status === 'pago') {
+      logInfo('✅ Pagamento já confirmado.')
+      return NextResponse.json({ status: 'pago' })
+    }
+
+    if (pedido.status === 'cancelado') {
+      logInfo('❌ Pedido cancelado.')
+      return NextResponse.json({ status: 'cancelado' })
+    }
+
+    logInfo('⏳ Pagamento pendente. Link:', pedido.link_pagamento)
+
+    return NextResponse.json({
+      status: 'pendente',
+      link_pagamento: pedido.link_pagamento,
+    })
+  } catch (error: unknown) {
+    if (error instanceof Error) {
+      logInfo('❌ Erro na recuperação: ' + error.message)
+      return NextResponse.json(
+        { error: 'Erro interno: ' + error.message },
+        { status: 500 },
+      )
+    }
+
+    logInfo('❌ Erro desconhecido: ' + String(error))
+    return NextResponse.json(
+      { error: 'Erro interno desconhecido' },
+      { status: 500 },
+    )
+  }
+}


### PR DESCRIPTION
## Summary
- copy recuperar-link route from admin to public API
- remove dependency on body parameter `cliente`
- retrieve tenant from host
- add unit tests covering success, not found and internal error cases

## Testing
- `npm run lint`
- `npm run build`
- `npm test` *(fails: TypeError: Cannot read properties of undefined)*

------
https://chatgpt.com/codex/tasks/task_e_6864a0f7cd24832c98f26f7159e3b222