### PR TITLE
Add email validation to EventForm

### DIFF
--- a/components/organisms/EventForm.tsx
+++ b/components/organisms/EventForm.tsx
@@ -9,7 +9,7 @@ import { useAuthContext } from '@/lib/context/AuthContext'
 import createPocketBase from '@/lib/pocketbase'
 import { getAuthHeaders } from '@/lib/authHeaders'
 import { fetchCep } from '@/utils/cep'
-import { isValidCPF } from '@/utils/validators'
+import { isValidCPF, isValidEmail } from '@/utils/validators'
 import FormWizard from './FormWizard'
 import LoadingOverlay from './LoadingOverlay'
 import {
@@ -223,6 +223,10 @@ export default function EventForm({ eventoId, liderId }: EventFormProps) {
       const cpfNumerico = form.cpf.replace(/\D/g, '')
       if (!isValidCPF(cpfNumerico)) {
         setFieldErrors({ cpf: 'CPF inválido.' })
+        return false
+      }
+      if (!isValidEmail(form.email)) {
+        setFieldErrors({ email: 'E-mail inválido.' })
         return false
       }
       try {

--- a/utils/validators.ts
+++ b/utils/validators.ts
@@ -13,6 +13,10 @@ export function isValidCPF(value: string): boolean {
   return rest === parseInt(cpf.charAt(10))
 }
 
+export function isValidEmail(value: string): boolean {
+  return /^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(value)
+}
+
 export function isValidCNPJ(value: string): boolean {
   const cnpj = value.replace(/\D/g, '')
   if (cnpj.length !== 14 || /^([0-9])\1+$/.test(cnpj)) return false


### PR DESCRIPTION
## Summary
- add `isValidEmail` helper
- require valid email before proceeding in `EventForm`

## Testing
- `npx --yes next lint`
- `npm run build` *(fails: collecting page data)*

------
https://chatgpt.com/codex/tasks/task_e_6864ae110b20832cb72bb15d4b3e43c4