### PR TITLE
Fix CPF validation for logged in users

### DIFF
--- a/app/api/usuarios/exists/route.ts
+++ b/app/api/usuarios/exists/route.ts
@@ -5,6 +5,7 @@ export async function GET(req: NextRequest) {
   const pb = createPocketBase(false)
   const cpf = req.nextUrl.searchParams.get('cpf')?.replace(/\D/g, '') || ''
   const email = req.nextUrl.searchParams.get('email') || ''
+  const excludeId = req.nextUrl.searchParams.get('excludeId') || ''
 
   if (!cpf && !email) {
     return NextResponse.json({ error: 'Parâmetros inválidos' }, { status: 400 })
@@ -14,8 +15,9 @@ export async function GET(req: NextRequest) {
 
   try {
     if (cpf) {
+      const filter = `cpf='${cpf}'${excludeId ? ` && id!='${excludeId}'` : ''}`
       const r = await pb.collection('usuarios').getList(1, 1, {
-        filter: `cpf='${cpf}'`,
+        filter,
       })
       result.cpf = r.items.length > 0
     }
@@ -25,8 +27,9 @@ export async function GET(req: NextRequest) {
 
   try {
     if (email) {
+      const filter = `email='${email}'${excludeId ? ` && id!='${excludeId}'` : ''}`
       const r = await pb.collection('usuarios').getList(1, 1, {
-        filter: `email='${email}'`,
+        filter,
       })
       result.email = r.items.length > 0
     }

--- a/components/organisms/EventForm.tsx
+++ b/components/organisms/EventForm.tsx
@@ -230,9 +230,11 @@ export default function EventForm({ eventoId, liderId }: EventFormProps) {
         return false
       }
       try {
-        const res = await fetch(
-          `/api/usuarios/exists?cpf=${cpfNumerico}&email=${encodeURIComponent(form.email)}`,
-        )
+        const query =
+          `/api/usuarios/exists?cpf=${cpfNumerico}&email=${encodeURIComponent(form.email)}${
+            isLoggedIn && user ? `&excludeId=${user.id}` : ''
+          }`
+        const res = await fetch(query)
         if (res.ok) {
           const data = await res.json()
           if (data.cpf) {

--- a/logs/ERR_LOG.md
+++ b/logs/ERR_LOG.md
@@ -230,3 +230,6 @@
 ## [2025-08-15] PATCH /api/inscricoes/[id] excedeu tentativas de retry - dev - <commit-link>
 ## [2025-07-02] Erro ao criar pedido: TypeError: Cannot read properties of undefined (reading 'id') - test
 ## [2025-07-02] Erro ao criar pedido: TypeError: Cannot read properties of undefined (reading 'id') - test
+
+## [2025-08-16] Inscricoes bloqueavam usuario logado por CPF existente. Rota /api/usuarios/exists aceita excludeId e EventForm ignora o proprio usuario - dev - cb2b0073
+## [2025-07-02] Erro ao criar pedido: TypeError: Cannot read properties of undefined (reading 'id') - test


### PR DESCRIPTION
## Summary
- allow API to ignore a specific user when checking for existing CPF/email
- exclude current user on EventForm CPF/email validation
- log fix in ERR_LOG

## Testing
- `npm run lint`
- `npm run test` *(fails: Cannot read properties of undefined, useRouter mock issues)*
- `npm run a11y` *(fails: No test files found)*
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_6865374d7ac8832c9aba96111bdca127