### PR TITLE
Implement WhatsApp send queue

### DIFF
--- a/app/api/chats/message/sendPayment/route.ts
+++ b/app/api/chats/message/sendPayment/route.ts
@@ -1,5 +1,5 @@
 import { NextRequest, NextResponse } from 'next/server'
-import { sendTextMessage } from '@/lib/server/chats'
+import { queueTextMessage } from '@/lib/server/chats'
 import createPocketBase from '@/lib/pocketbase'
 
 export async function POST(req: NextRequest) {
@@ -46,9 +46,10 @@ export async function POST(req: NextRequest) {
   const rec = list[0]
 
   try {
-    const finalMessage = message ??
-      `Para concluir seu pagamento, acesse: ${link}`
-    const result = await sendTextMessage({
+    const finalMessage =
+      message ?? `Para concluir seu pagamento, acesse: ${link}`
+    const result = await queueTextMessage({
+      tenant,
       instanceName: rec.instanceName,
       apiKey: rec.apiKey,
       to: telefone,

--- a/app/api/chats/message/sendText/[instanceName]/route.ts
+++ b/app/api/chats/message/sendText/[instanceName]/route.ts
@@ -1,7 +1,7 @@
 // ./app/api/chats/message/sendText/[instanceName]/route.ts
 
 import { NextRequest, NextResponse } from 'next/server'
-import { sendTextMessage } from '@/lib/server/chats'
+import { queueTextMessage } from '@/lib/server/chats'
 import createPocketBase from '@/lib/pocketbase'
 
 export async function POST(
@@ -52,9 +52,10 @@ export async function POST(
     )
   }
 
-  // 3) envia mensagem
+  // 3) envia mensagem com controle
   try {
-    const result = await sendTextMessage({
+    const result = await queueTextMessage({
+      tenant,
       instanceName,
       apiKey: rec.apiKey,
       to,

--- a/app/api/chats/message/sendWelcome/route.ts
+++ b/app/api/chats/message/sendWelcome/route.ts
@@ -1,5 +1,5 @@
 import { NextRequest, NextResponse } from 'next/server'
-import { sendTextMessage } from '@/lib/server/chats'
+import { queueTextMessage } from '@/lib/server/chats'
 import createPocketBase from '@/lib/pocketbase'
 import { getTenantFromHost } from '@/lib/getTenantFromHost'
 
@@ -94,7 +94,8 @@ export async function POST(req: NextRequest) {
         message = ''
     }
 
-    const result = await sendTextMessage({
+    const result = await queueTextMessage({
+      tenant: tenantId,
       instanceName: waCfg.instanceName,
       apiKey: waCfg.apiKey,
       to: telefone,

--- a/app/api/chats/whatsapp/message/sendTest/[instanceName]/route.ts
+++ b/app/api/chats/whatsapp/message/sendTest/[instanceName]/route.ts
@@ -1,7 +1,7 @@
 // ./app/api/chats/whatsapp/message/sendTest/[instanceName]/route.ts
 
 import { NextRequest, NextResponse } from 'next/server'
-import { sendTextMessage } from '@/lib/server/chats'
+import { queueTextMessage } from '@/lib/server/chats'
 import createPocketBase from '@/lib/pocketbase'
 
 export async function POST(
@@ -58,9 +58,10 @@ export async function POST(
   const text =
     typeof message === 'string' ? message : 'Olá! QR autenticado com sucesso!'
 
-  // 6) envia
+  // 6) envia com controle
   try {
-    const result = await sendTextMessage({
+    const result = await queueTextMessage({
+      tenant,
       instanceName,
       apiKey: rec.apiKey,
       to,

--- a/lib/server/chats.ts
+++ b/lib/server/chats.ts
@@ -2,6 +2,7 @@
 
 import PocketBase from 'pocketbase'
 import { pbRetry } from '@/lib/pbRetry'
+import { broadcastManager } from '@/lib/server/flows/whatsapp'
 
 const EVOLUTION_API_URL = process.env.EVOLUTION_API_URL?.replace(/\/$/, '')
 const PB_URL = process.env.PB_URL!
@@ -127,4 +128,22 @@ export async function sendMessage(params: {
     to: params.to,
     message: params.message,
   })
+}
+
+/** Enfileira o envio respeitando limites e horários */
+export async function queueTextMessage(params: {
+  tenant: string
+  instanceName: string
+  apiKey: string
+  to: string
+  message: string
+}) {
+  return broadcastManager.enqueue(params.tenant, () =>
+    sendTextMessage({
+      instanceName: params.instanceName,
+      apiKey: params.apiKey,
+      to: params.to,
+      message: params.message,
+    }),
+  )
 }

--- a/lib/server/flows/whatsapp/broadcastManager.ts
+++ b/lib/server/flows/whatsapp/broadcastManager.ts
@@ -1,0 +1,33 @@
+import { BroadcastQueue, BroadcastConfig, DEFAULT_CONFIG } from './broadcastQueue'
+
+class BroadcastManager {
+  private queues = new Map<string, BroadcastQueue>()
+
+  private getQueue(tenant: string) {
+    let q = this.queues.get(tenant)
+    if (!q) {
+      q = new BroadcastQueue({ ...DEFAULT_CONFIG })
+      this.queues.set(tenant, q)
+    }
+    return q
+  }
+
+  enqueue<T>(tenant: string, task: () => Promise<T>): Promise<T> {
+    return this.getQueue(tenant).add(task)
+  }
+
+  updateTenantConfig(tenant: string, config: Partial<BroadcastConfig>) {
+    const q = this.getQueue(tenant)
+    Object.assign(q.config, config)
+  }
+
+  getAllStats() {
+    const stats: Record<string, { pending: number }> = {}
+    for (const [tenant, q] of this.queues.entries()) {
+      stats[tenant] = { pending: q.pending }
+    }
+    return stats
+  }
+}
+
+export const broadcastManager = new BroadcastManager()

--- a/lib/server/flows/whatsapp/broadcastQueue.ts
+++ b/lib/server/flows/whatsapp/broadcastQueue.ts
@@ -1,0 +1,121 @@
+export interface BroadcastConfig {
+  delayBetweenMessages: number
+  delayBetweenBatches: number
+  batchSize: number
+  maxMessagesPerMinute: number
+  maxMessagesPerHour: number
+  maxRetries: number
+  retryDelay: number
+  allowedHours: { start: number; end: number }
+  timezone: string
+}
+
+export const DEFAULT_CONFIG: BroadcastConfig = {
+  delayBetweenMessages: 3000,
+  delayBetweenBatches: 15000,
+  batchSize: 3,
+  maxMessagesPerMinute: 20,
+  maxMessagesPerHour: 80,
+  maxRetries: 2,
+  retryDelay: 10000,
+  allowedHours: { start: 9, end: 21 },
+  timezone: 'America/Sao_Paulo',
+}
+
+function sleep(ms: number) {
+  return new Promise(resolve => setTimeout(resolve, ms))
+}
+
+interface QueueItem<T> {
+  task: () => Promise<T>
+  resolve: (value: T) => void
+  reject: (reason?: unknown) => void
+}
+
+export class BroadcastQueue {
+  private queue: QueueItem<unknown>[] = []
+  private processing = false
+  private timestamps: number[] = []
+  constructor(public config: BroadcastConfig = { ...DEFAULT_CONFIG }) {}
+
+  get pending() {
+    return this.queue.length
+  }
+
+  add<T>(task: () => Promise<T>): Promise<T> {
+    return new Promise<T>((resolve, reject) => {
+      this.queue.push({
+        task: task as () => Promise<unknown>,
+        resolve: resolve as (value: unknown) => void,
+        reject,
+      })
+      this.process().catch(err =>
+        console.error('Erro no processamento da fila:', err),
+      )
+    })
+  }
+
+  private async process() {
+    if (this.processing) return
+    this.processing = true
+    while (this.queue.length) {
+      await this.waitForAllowedTime()
+      await this.ensureRateLimit()
+      const batch = this.queue.splice(0, this.config.batchSize)
+      for (const item of batch) {
+        try {
+          const res = await this.executeWithRetry(item.task, this.config.maxRetries)
+          item.resolve(res)
+        } catch (err) {
+          item.reject(err)
+          console.error('Erro no processamento da fila:', err)
+        }
+        this.timestamps.push(Date.now())
+        await sleep(this.config.delayBetweenMessages)
+      }
+      if (this.queue.length) {
+        await sleep(this.config.delayBetweenBatches)
+      }
+    }
+    this.processing = false
+  }
+
+  private async executeWithRetry<T>(task: () => Promise<T>, retries: number): Promise<T> {
+    try {
+      return await task()
+    } catch (err) {
+      if (retries > 0) {
+        await sleep(this.config.retryDelay)
+        return this.executeWithRetry(task, retries - 1)
+      }
+      throw err
+    }
+  }
+
+  private async waitForAllowedTime() {
+    const { allowedHours, timezone } = this.config
+    const now = new Date()
+    const tzNow = new Date(now.toLocaleString('en-US', { timeZone: timezone }))
+    const hour = tzNow.getHours()
+    if (hour >= allowedHours.start && hour < allowedHours.end) return
+    const start = new Date(tzNow)
+    if (hour >= allowedHours.end) start.setDate(start.getDate() + 1)
+    start.setHours(allowedHours.start, 0, 0, 0)
+    const diff = start.getTime() - tzNow.getTime()
+    if (diff > 0) await sleep(diff)
+  }
+
+  private async ensureRateLimit() {
+    const now = Date.now()
+    this.timestamps = this.timestamps.filter(t => now - t < 3600_000)
+    const lastMinute = this.timestamps.filter(t => now - t < 60_000)
+    if (lastMinute.length >= this.config.maxMessagesPerMinute) {
+      const wait = 60_000 - (now - lastMinute[0])
+      await sleep(wait)
+    }
+    if (this.timestamps.length >= this.config.maxMessagesPerHour) {
+      const wait = 3600_000 - (now - this.timestamps[0])
+      await sleep(wait)
+    }
+  }
+}

--- a/lib/server/flows/whatsapp/index.ts
+++ b/lib/server/flows/whatsapp/index.ts
@@ -1,0 +1,2 @@
+export * from './broadcastQueue'
+export * from './broadcastManager'


### PR DESCRIPTION
## Summary
- implement `BroadcastQueue` and `BroadcastManager` for WhatsApp messages
- add `queueTextMessage` helper
- use the queue in all WhatsApp send routes to respect delays and rate limits

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68654f49594c832ca2a7a5cf14b86abb