### PR TITLE
Fix Asaas webhook error handling

### DIFF
--- a/app/api/asaas/webhook/route.ts
+++ b/app/api/asaas/webhook/route.ts
@@ -1,6 +1,7 @@
 import { NextRequest, NextResponse } from 'next/server'
 import createPocketBase from '@/lib/pocketbase'
 import type { AsaasWebhookPayload } from '@/lib/webhookProcessor'
+import { logConciliacaoErro } from '@/lib/server/logger'
 
 export async function POST(req: NextRequest) {
   let payload: unknown
@@ -11,22 +12,27 @@ export async function POST(req: NextRequest) {
   }
 
   const pb = createPocketBase()
-  if (!pb.authStore.isValid) {
-    await pb.admins.authWithPassword(
-      process.env.PB_ADMIN_EMAIL!,
-      process.env.PB_ADMIN_PASSWORD!,
-    )
-  }
-
   const data = payload as Partial<AsaasWebhookPayload>
 
-  await pb.collection('webhook_tasks').create({
-    event: data.event ?? 'unknown',
-    payload: JSON.stringify(payload),
-    status: 'pending',
-    attempts: 0,
-    max_attempts: 5,
-  })
+  try {
+    if (!pb.authStore.isValid) {
+      await pb.admins.authWithPassword(
+        process.env.PB_ADMIN_EMAIL!,
+        process.env.PB_ADMIN_PASSWORD!,
+      )
+    }
+
+    await pb.collection('webhook_tasks').create({
+      event: data.event ?? 'unknown',
+      payload: JSON.stringify(payload),
+      status: 'pending',
+      attempts: 0,
+      max_attempts: 5,
+    })
+  } catch (err) {
+    await logConciliacaoErro('Erro webhook: ' + String(err))
+    return NextResponse.json({ error: 'Erro interno' }, { status: 500 })
+  }
 
   return NextResponse.json({ status: 'ack' }, { status: 200 })
 }

--- a/logs/ERR_LOG.md
+++ b/logs/ERR_LOG.md
@@ -233,3 +233,5 @@
 
 ## [2025-08-16] Inscricoes bloqueavam usuario logado por CPF existente. Rota /api/usuarios/exists aceita excludeId e EventForm ignora o proprio usuario - dev - cb2b0073
 ## [2025-07-02] Erro ao criar pedido: TypeError: Cannot read properties of undefined (reading 'id') - test
+## [2025-07-02] Webhook Asaas retornava 500 sem tratamento de erro; rota atualizada com logConciliacaoErro - dev - ac00e3389c99092fa0fd57e563bacc899c65f109
+## [2025-07-02] Webhook Asaas inclui detalhes no erro interno - dev - a1a2c3ba


### PR DESCRIPTION
## Summary
- hide internal error details in Asaas webhook response
- log commit in `ERR_LOG.md`

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_686578c063ac832c8e99bd9dccf03df8