### PR TITLE
feat: tenant host usage

### DIFF
--- a/app/blog/page.tsx
+++ b/app/blog/page.tsx
@@ -4,6 +4,8 @@ import LoadingOverlay from '@/components/organisms/LoadingOverlay'
 import type { Metadata } from 'next'
 import { getPostsFromPB } from '@/lib/posts/getPostsFromPB'
 import { isExternalUrl } from '@/utils/isExternalUrl'
+import { getTenantFromHost } from '@/lib/getTenantFromHost'
+import { getTenantHost } from '@/lib/getTenantHost'
 
 export async function generateMetadata(): Promise<Metadata> {
   const posts = await getPostsFromPB()
@@ -14,7 +16,9 @@ export async function generateMetadata(): Promise<Metadata> {
     }
   }
   const first = posts[0]
-  const siteUrl = process.env.NEXT_PUBLIC_SITE_URL || 'https://m24saude.com.br'
+  const tenantId = await getTenantFromHost()
+  const host = tenantId ? await getTenantHost(tenantId) : null
+  const siteUrl = host || 'https://m24saude.com.br'
   const image = first.thumbnail
     ? isExternalUrl(first.thumbnail)
       ? first.thumbnail

--- a/app/blog/post/[slug]/page.tsx
+++ b/app/blog/post/[slug]/page.tsx
@@ -3,6 +3,8 @@ import Footer from '@/components/templates/Footer'
 import Image from 'next/image'
 import { Share2, Clock } from 'lucide-react'
 import { isExternalUrl } from '@/utils/isExternalUrl'
+import { getTenantFromHost } from '@/lib/getTenantFromHost'
+import { getTenantHost } from '@/lib/getTenantHost'
 import type { Metadata } from 'next'
 import { getRelatedPostsFromPB } from '@/lib/posts/getRelatedPostsFromPB'
 import { getPostBySlug } from '@/lib/posts/getPostBySlug'
@@ -71,7 +73,9 @@ export default async function BlogPostPage({
   const words = mdxContent.split(/\s+/).length
   const readingTime = Math.ceil(words / 200)
 
-  const siteUrl = process.env.NEXT_PUBLIC_SITE_URL || 'https://m24saude.com.br'
+  const tenantId = await getTenantFromHost()
+  const host = tenantId ? await getTenantHost(tenantId) : null
+  const siteUrl = host || 'https://m24saude.com.br'
 
   const schema = {
     '@context': 'https://schema.org',

--- a/lib/webhookProcessor.ts
+++ b/lib/webhookProcessor.ts
@@ -1,5 +1,6 @@
 import createPocketBase from './pocketbase'
 import { logConciliacaoErro } from './server/logger'
+import { getTenantHost } from '@/lib/getTenantHost'
 
 export type AsaasWebhookPayload = {
   payment?: {
@@ -46,7 +47,7 @@ interface InscricaoRecord {
 export async function processWebhook(body: AsaasWebhookPayload) {
   const pb = createPocketBase()
   const baseUrl = process.env.ASAAS_API_URL
-  const site = process.env.NEXT_PUBLIC_SITE_URL
+  let site: string | null = null
 
   if (!pb.authStore.isValid) {
     await pb.admins.authWithPassword(
@@ -68,6 +69,7 @@ export async function processWebhook(body: AsaasWebhookPayload) {
   let clienteNome: string | undefined
   let usuarioId: string | undefined
   let inscricaoId: string | undefined
+  let clienteId: string | undefined
 
   const accountId = payment.accountId || body.accountId
   if (accountId) {
@@ -77,6 +79,7 @@ export async function processWebhook(body: AsaasWebhookPayload) {
         .getFirstListItem<ClienteRecord>(`asaas_account_id = "${accountId}"`)
       clienteApiKey = cliente.asaas_api_key ?? null
       clienteNome = cliente.nome
+      clienteId = cliente.id
     } catch {
       /* não encontrado */
     }
@@ -89,7 +92,7 @@ export async function processWebhook(body: AsaasWebhookPayload) {
     if (match) {
       usuarioId = match[2]
       inscricaoId = match[3]
-      const clienteId = match[1]
+      clienteId = match[1]
       if (!clienteApiKey) {
         try {
           const fallback = await pb
@@ -109,6 +112,10 @@ export async function processWebhook(body: AsaasWebhookPayload) {
       `Cliente não encontrado (accountId: ${accountId ?? 'indefinido'}, externalReference: ${payment.externalReference ?? 'indefinido'})`,
     )
     throw new Error('Cliente não encontrado')
+  }
+
+  if (clienteId) {
+    site = await getTenantHost(clienteId)
   }
 
   const keyHeader = clienteApiKey.startsWith('$') ? clienteApiKey : `$${clienteApiKey}`

--- a/logs/DOC_LOG.md
+++ b/logs/DOC_LOG.md
@@ -518,3 +518,4 @@ executados.
 ## [2025-08-16] Ajustada funcao calculateGross comparando valor de credito com Pix e testes atualizados. Lint e build executados.
 ## [2025-07-02] Implementado webhook assíncrono com fila e worker. Lint e build executados.
 ## [2025-07-02] Ajustado cron para 1 minuto em vercel.json. Lint e build executados.
+## [2025-08-17] NEXT_PUBLIC_SITE_URL substituido por host do tenant. Lint e build executados.

--- a/scripts/generate-sitemap.js
+++ b/scripts/generate-sitemap.js
@@ -2,8 +2,8 @@ const fs = require('fs')
 const path = require('path')
 const matter = require('gray-matter')
 
-// Usa a URL definida nas variáveis de ambiente ou mantém o domínio padrão
-const BASE_URL = process.env.NEXT_PUBLIC_SITE_URL || 'https://m24saude.com.br' // sem barra no final
+// Usa o host configurado para o tenant ou mantém o domínio padrão
+const BASE_URL = process.env.TENANT_HOST || process.env.NEXT_PUBLIC_SITE_URL || 'https://m24saude.com.br' // sem barra no final
 
 function getStaticRoutes() {
   const appDir = path.join(process.cwd(), 'app')


### PR DESCRIPTION
## Summary
- get tenant host for blog pages, webhook processor and sitemap
- update DOC_LOG

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6865884953c4832cab180a720e4e48d0