### PR TITLE
Ajuste rota recuperar-link

### DIFF
--- a/__tests__/api/recuperarLinkRoute.test.ts
+++ b/__tests__/api/recuperarLinkRoute.test.ts
@@ -4,11 +4,15 @@ import { NextRequest } from 'next/server'
 import createPocketBaseMock from '../mocks/pocketbase'
 
 const pb = createPocketBaseMock()
-const getFullListMock = vi.fn()
+const getFirstCobranca = vi.fn()
+const getFirstInscricao = vi.fn()
 
 pb.collection.mockImplementation((name: string) => {
+  if (name === 'cobrancas') {
+    return { getFirstListItem: getFirstCobranca }
+  }
   if (name === 'inscricoes') {
-    return { getFullList: getFullListMock }
+    return { getFirstListItem: getFirstInscricao }
   }
   return {}
 })
@@ -17,41 +21,59 @@ vi.mock('../../lib/pocketbase', () => ({ default: vi.fn(() => pb) }))
 vi.mock('../../lib/getTenantFromHost', () => ({ getTenantFromHost: vi.fn(() => 'cli1') }))
 
 describe('POST /api/recuperar-link', () => {
-  it('retorna link de pagamento quando pendente', async () => {
-    getFullListMock.mockResolvedValueOnce([
-      {
-        status: 'ativo',
-        confirmado_por_lider: true,
-        expand: { pedido: { status: 'pendente', link_pagamento: 'http://pay' } },
-      },
-    ])
+  it('retorna link de pagamento quando cobranca ativa', async () => {
+    getFirstCobranca.mockResolvedValueOnce({
+      status: 'PENDING',
+      dueDate: new Date().toISOString(),
+      invoiceUrl: 'http://pay',
+      pedido: 'p1',
+      nomeUsuario: 'U'
+    })
     const req = new Request('http://test', {
       method: 'POST',
-      body: JSON.stringify({ cpf: '1' }),
+      body: JSON.stringify({ cpf: '1' })
     })
+    ;(req as any).nextUrl = new URL('http://test')
+    const res = await POST(req as unknown as NextRequest)
+    expect(res.status).toBe(200)
+    const body = await res.json()
+    expect(body.linkPagamento).toBe('http://pay')
+    expect(body.nomeUsuario).toBe('U')
+  })
+
+  it('retorna status pendente quando inscricao em aprovacao', async () => {
+    getFirstCobranca.mockRejectedValueOnce(new Error('not found'))
+    getFirstInscricao.mockResolvedValueOnce({ status: 'pendente' })
+    const req = new Request('http://test', {
+      method: 'POST',
+      body: JSON.stringify({ cpf: '1' })
+    })
+    ;(req as any).nextUrl = new URL('http://test')
     const res = await POST(req as unknown as NextRequest)
     expect(res.status).toBe(200)
     const body = await res.json()
     expect(body.status).toBe('pendente')
-    expect(body.link_pagamento).toBe('http://pay')
   })
 
-  it('retorna 404 quando inscricao nao encontrada', async () => {
-    getFullListMock.mockResolvedValueOnce([])
+  it('retorna 404 quando inscricao inexistente', async () => {
+    getFirstCobranca.mockRejectedValueOnce(new Error('not found'))
+    getFirstInscricao.mockRejectedValueOnce(new Error('not found'))
     const req = new Request('http://test', {
       method: 'POST',
-      body: JSON.stringify({ cpf: '1' }),
+      body: JSON.stringify({ cpf: '1' })
     })
+    ;(req as any).nextUrl = new URL('http://test')
     const res = await POST(req as unknown as NextRequest)
     expect(res.status).toBe(404)
   })
 
   it('retorna 500 em falha inesperada', async () => {
-    getFullListMock.mockRejectedValueOnce(new Error('fail'))
+    getFirstCobranca.mockRejectedValueOnce(new Error('fail'))
     const req = new Request('http://test', {
       method: 'POST',
-      body: JSON.stringify({ cpf: '1' }),
+      body: JSON.stringify({ cpf: '1' })
     })
+    ;(req as any).nextUrl = new URL('http://test')
     const res = await POST(req as unknown as NextRequest)
     expect(res.status).toBe(500)
   })

--- a/logs/DOC_LOG.md
+++ b/logs/DOC_LOG.md
@@ -521,3 +521,5 @@ executados.
 ## [2025-08-17] NEXT_PUBLIC_SITE_URL substituido por host do tenant. Lint e build executados.
 ## [2025-08-17] Removida opcao de pagamento 'credito' em inscricoes e produtos. Documentacao atualizada. Lint e build executados.
 ## [2025-07-03] exportarPDF em Pedidos passa a buscar todas as paginas para gerar relatorio completo conforme filtros. Lint: ok - Build: falhou (erro de tipos)
+
+## [2025-07-04] Rota /api/recuperar-link consulta inscricoes quando cobranca nao encontrada. Lint e build executados.


### PR DESCRIPTION
## Resumo
- verifica inscrições quando cobrança não é encontrada
- cobre novos cenários de recuperação de link nos testes
- registra alteração em DOC_LOG

## Testes
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6868676b097c832c99b6487c28ee9221