### PR TITLE
Atualiza docs rota /recuperar

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@ As preferências de fonte, cor, logotipo e confirmação de inscrições ficam n
 Para um passo a passo inicial do sistema consulte [docs/iniciar-tour.md](docs/iniciar-tour.md).
 Coordenadores podem iniciar o tour clicando no ícone de mapa ao lado do sino de notificações no painel admin ou acessando `/iniciar-tour` diretamente.
 Usuários que perderam o link de pagamento podem acessar `/recuperar` para recebê-lo novamente.
+Essa página envia o CPF informado para `/api/recuperar-link`, que retorna o `link_pagamento` quando há cobrança registrada. Se a inscrição existir mas ainda não houve cobrança, a resposta contém apenas o `status` correspondente. Caso nenhum registro seja encontrado, crie a inscrição normalmente para receber o link.
 
 ## Diretórios Principais
 

--- a/docs/function-index.md
+++ b/docs/function-index.md
@@ -1,5 +1,7 @@
 # Índice de Funções e Componentes
 
+A página `/recuperar` usa a rota `/api/recuperar-link` para retornar o `link_pagamento`. Quando houver inscrição sem cobrança, a resposta contém somente o `status` atual. Caso nenhum registro seja encontrado, crie a inscrição para gerar o link.
+
 - **app/admin/api/asaas/estatisticas/route.ts**
   - GET
 - **app/admin/api/asaas/extrato/route.ts**

--- a/logs/DOC_LOG.md
+++ b/logs/DOC_LOG.md
@@ -523,3 +523,4 @@ executados.
 ## [2025-07-03] exportarPDF em Pedidos passa a buscar todas as paginas para gerar relatorio completo conforme filtros. Lint: ok - Build: falhou (erro de tipos)
 
 ## [2025-07-04] Rota /api/recuperar-link consulta inscricoes quando cobranca nao encontrada. Lint e build executados.
+## [2025-07-04] Documentadas rotas /recuperar e /api/recuperar-link, orientando criar inscricao quando nao houver cobranca. Lint: ok - Build: ok


### PR DESCRIPTION
## Summary
- explicar uso da rota `/recuperar` e `/api/recuperar-link`
- incluir orientação em `function-index.md`
- registrar alteração de documentação

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_686869b44664832c99085b98b6479b96