### PR TITLE
Handle finalized events

### DIFF
--- a/__tests__/EventoDetalhePage.test.tsx
+++ b/__tests__/EventoDetalhePage.test.tsx
@@ -1,0 +1,36 @@
+/* @vitest-environment jsdom */
+import React from 'react'
+import { render, screen } from '@testing-library/react'
+import { vi } from 'vitest'
+import EventoDetalhePage from '@/app/loja/eventos/[id]/page'
+
+vi.mock('next/image', () => ({
+  __esModule: true,
+  default: (props: any) => <img {...props} alt={props.alt} />,
+}))
+
+vi.mock('next/headers', () => ({
+  headers: () => new Headers({ host: 'localhost:3000' }),
+}))
+
+describe('EventoDetalhePage', () => {
+  it('nao exibe formulario quando evento esta realizado', async () => {
+    global.fetch = vi.fn().mockResolvedValue({
+      ok: true,
+      json: () =>
+        Promise.resolve({
+          id: 'e1',
+          titulo: 'Ev',
+          descricao: 'Desc',
+          status: 'realizado',
+        }),
+    })
+
+    render(
+      await EventoDetalhePage({ params: Promise.resolve({ id: 'e1' }) } as any),
+    )
+
+    expect(screen.getByText(/inscrições encerradas/i)).toBeInTheDocument()
+    expect(screen.queryByText(/inscrever/i)).not.toBeInTheDocument()
+  })
+})

--- a/__tests__/InscricoesLiderPage.test.tsx
+++ b/__tests__/InscricoesLiderPage.test.tsx
@@ -1,0 +1,39 @@
+/* @vitest-environment jsdom */
+import React from 'react'
+import { render, screen } from '@testing-library/react'
+import { vi } from 'vitest'
+import EscolherEventoPage from '@/app/inscricoes/lider/[liderId]/page'
+
+vi.mock('next/navigation', () => ({
+  useParams: () => ({ liderId: 'l1' }),
+}))
+
+vi.mock('next/image', () => ({
+  __esModule: true,
+  default: (props: any) => <img {...props} alt={props.alt} />,
+}))
+
+describe('EscolherEventoPage', () => {
+  it('nao exibe link para eventos realizados', async () => {
+    global.fetch = vi.fn().mockResolvedValueOnce({
+      ok: true,
+      json: () =>
+        Promise.resolve([
+          {
+            id: 'e1',
+            titulo: 'Ev',
+            descricao: 'Desc',
+            data: '',
+            cidade: '',
+            status: 'realizado',
+          },
+        ]),
+    })
+
+    render(<EscolherEventoPage />)
+
+    await screen.findByText('Ev')
+    expect(screen.getByText(/inscrições encerradas/i)).toBeInTheDocument()
+    expect(screen.queryByRole('link', { name: /inscrever/i })).not.toBeInTheDocument()
+  })
+})

--- a/app/inscricoes/lider/[liderId]/page.tsx
+++ b/app/inscricoes/lider/[liderId]/page.tsx
@@ -91,12 +91,18 @@ export default function EscolherEventoPage() {
                 </p>
                 <p className="text-sm text-gray-500 mt-2">{evento.cidade}</p>
 
-                <Link
-                  href={`/inscricoes/lider/${liderId}/evento/${evento.id}`}
-                  className="btn btn-primary mt-auto"
-                >
-                  Inscrever
-                </Link>
+                {evento.status === 'realizado' ? (
+                  <span className="mt-auto text-sm text-gray-500">
+                    Inscrições encerradas
+                  </span>
+                ) : (
+                  <Link
+                    href={`/inscricoes/lider/${liderId}/evento/${evento.id}`}
+                    className="btn btn-primary mt-auto"
+                  >
+                    Inscrever
+                  </Link>
+                )}
               </div>
             </article>
           ))}

--- a/app/loja/eventos/[id]/page.tsx
+++ b/app/loja/eventos/[id]/page.tsx
@@ -1,13 +1,7 @@
 import Image from 'next/image'
 import { headers } from 'next/headers'
 import { InscricaoLojaWizard } from '@/components/organisms'
-
-interface Evento {
-  id: string
-  titulo: string
-  descricao: string
-  imagem?: string
-}
+import type { Evento } from '@/types'
 
 async function getEvento(id: string): Promise<Evento | null> {
   try {
@@ -41,6 +35,8 @@ export default async function EventoDetalhePage({
     )
   }
 
+  const inscricoesEncerradas = evento.status === 'realizado'
+
   return (
     <main className="px-4 py-10 md:px-16 space-y-6 font-sans">
       {evento.imagem && (
@@ -54,7 +50,11 @@ export default async function EventoDetalhePage({
       )}
       <h1 className="text-2xl text-center font-bold">{evento.titulo}</h1>
       <p className="text-center">{evento.descricao}</p>
-      <InscricaoLojaWizard eventoId={id} />
+      {inscricoesEncerradas ? (
+        <p className="text-center text-gray-500">Inscrições encerradas</p>
+      ) : (
+        <InscricaoLojaWizard eventoId={id} />
+      )}
     </main>
   )
 }


### PR DESCRIPTION
## Summary
- hide InscricaoLojaWizard when event is `realizado`
- show message instead of sign-up button on leader list page
- add tests checking event realized state

## Testing
- `npm run lint` *(fails: next not found)*
- `npm run build` *(fails: next not found)*
- `npm run test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_686872aec94c832c8a86d4d585b0a277