### PR TITLE
Implement check for pending event subscription

### DIFF
--- a/app/cliente/components/InscricoesTable.tsx
+++ b/app/cliente/components/InscricoesTable.tsx
@@ -6,12 +6,25 @@ import { getAuthHeaders } from '@/lib/authHeaders'
 import type { Inscricao } from '@/types'
 import { formatDate } from '@/utils/formatDate'
 
-export default function InscricoesTable({ limit }: { limit?: number }) {
+export interface InscricoesTableProps {
+  limit?: number
+  inscricoes?: Inscricao[]
+  variant?: 'default' | 'details'
+}
+
+export default function InscricoesTable({
+  limit,
+  inscricoes: inscricoesProp,
+  variant = 'default',
+}: InscricoesTableProps) {
   const { user, authChecked } = useAuthGuard(['usuario'])
   const pb = useMemo(() => createPocketBase(), [])
-  const [inscricoes, setInscricoes] = useState<Inscricao[]>([])
+  const [inscricoes, setInscricoes] = useState<Inscricao[]>(
+    inscricoesProp ?? [],
+  )
 
   useEffect(() => {
+    if (inscricoesProp) return
     if (!authChecked || !user) return
     const headers = getAuthHeaders(pb)
     fetch('/api/inscricoes', { headers, credentials: 'include' })
@@ -25,7 +38,7 @@ export default function InscricoesTable({ limit }: { limit?: number }) {
         setInscricoes(items.slice(0, limit ?? items.length))
       })
       .catch(() => setInscricoes([]))
-  }, [authChecked, user, pb, limit])
+  }, [authChecked, user, pb, limit, inscricoesProp])
 
   if (!authChecked) return null
 
@@ -34,19 +47,37 @@ export default function InscricoesTable({ limit }: { limit?: number }) {
       <h3 className="text-lg font-semibold mb-2">Inscrições</h3>
       <table className="table-base">
         <thead>
-          <tr>
-            <th>Status</th>
-            <th>Evento</th>
-            <th>Data</th>
-          </tr>
+          {variant === 'details' ? (
+            <tr>
+              <th>Nome</th>
+              <th>CPF</th>
+              <th>E-mail</th>
+              <th>Status</th>
+            </tr>
+          ) : (
+            <tr>
+              <th>Status</th>
+              <th>Evento</th>
+              <th>Data</th>
+            </tr>
+          )}
         </thead>
         <tbody>
           {inscricoes.map((i) => (
-            <tr key={i.id}>
-              <td className="capitalize">{i.status}</td>
-              <td>{i.expand?.evento?.titulo || '-'}</td>
-              <td>{i.created ? formatDate(i.created) : '-'}</td>
-            </tr>
+            variant === 'details' ? (
+              <tr key={i.id}>
+                <td>{i.nome}</td>
+                <td>{i.cpf || '-'}</td>
+                <td>{i.email || '-'}</td>
+                <td className="capitalize">{i.status}</td>
+              </tr>
+            ) : (
+              <tr key={i.id}>
+                <td className="capitalize">{i.status}</td>
+                <td>{i.expand?.evento?.titulo || '-'}</td>
+                <td>{i.created ? formatDate(i.created) : '-'}</td>
+              </tr>
+            )
           ))}
         </tbody>
       </table>


### PR DESCRIPTION
## Summary
- reuse `InscricoesTable` to display detailed inscription data
- show pending inscriptions before rendering `EventForm`

## Testing
- `npm run lint` *(fails: next not found)*
- `npm run build` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_68687462f7d8832c9cad85686377361b