### PR TITLE
Handle Credito payment method

### DIFF
--- a/__tests__/api/creditoMapping.test.ts
+++ b/__tests__/api/creditoMapping.test.ts
@@ -1,0 +1,102 @@
+import { describe, it, expect, vi } from 'vitest'
+import { POST as postInscricoes } from '../../app/api/inscricoes/route'
+import { POST as postAsaas } from '../../app/api/asaas/route'
+import { NextRequest } from 'next/server'
+import createPocketBaseMock from '../mocks/pocketbase'
+
+vi.mock('../../lib/pocketbase', () => ({ default: vi.fn() }))
+vi.mock('../../lib/clienteAuth', () => ({ requireClienteFromHost: vi.fn() }))
+import { requireClienteFromHost } from '../../lib/clienteAuth'
+
+describe('Mapeamento Credito para pix', () => {
+  it('normaliza na rota /api/inscricoes', async () => {
+    const getLider = vi.fn().mockResolvedValue({
+      expand: { campo: { id: 'c1' } },
+      cliente: 'cli1',
+    })
+    const getUser = vi.fn().mockResolvedValue({ id: 'u1' })
+    const getInscricao = vi.fn().mockRejectedValue(new Error('not found'))
+    const createInscricao = vi.fn().mockResolvedValue({ id: 'i1' })
+    const getEvento = vi.fn().mockResolvedValue({ cobra_inscricao: true, titulo: 'T' })
+    const getCfg = vi.fn().mockResolvedValue({ confirma_inscricoes: false })
+    const updatePedido = vi.fn()
+    const pb = createPocketBaseMock()
+    pb.collection.mockImplementation((name: string) => {
+      if (name === 'usuarios') return { getOne: getLider, getFirstListItem: getUser }
+      if (name === 'inscricoes') return { getFirstListItem: getInscricao, create: createInscricao }
+      if (name === 'eventos') return { getOne: getEvento }
+      if (name === 'clientes_config') return { getFirstListItem: getCfg }
+      if (name === 'pedidos') return { update: updatePedido, delete: vi.fn() }
+      return {} as any
+    })
+    ;(requireClienteFromHost as unknown as { mockResolvedValue: (v: any) => void }).mockResolvedValue({ pb, cliente: { nome: 'Cli', asaas_api_key: '$key' } })
+
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValueOnce({ ok: true, json: () => Promise.resolve({ pedidoId: 'p1', valor: 10 }) })
+      .mockResolvedValueOnce({ ok: true, json: () => Promise.resolve({ url: 'link' }) })
+      .mockResolvedValue({ ok: true, json: () => Promise.resolve({}) })
+    global.fetch = fetchMock as unknown as typeof fetch
+
+    const req = new Request('http://test/api/inscricoes', {
+      method: 'POST',
+      body: JSON.stringify({
+        nome: 'N',
+        email: 'e@test.com',
+        telefone: '111',
+        cpf: '111',
+        data_nascimento: '2000-01-01',
+        genero: 'masculino',
+        liderId: 'lid',
+        eventoId: 'e1',
+        paymentMethod: 'Credito',
+      }),
+    })
+    ;(req as any).nextUrl = new URL('http://test/api/inscricoes')
+
+    const pocketbaseModule = await import('../../lib/pocketbase')
+    ;(pocketbaseModule.default as unknown as { mockReturnValue: (v: any) => void }).mockReturnValue(pb)
+
+    const res = await postInscricoes(req as unknown as NextRequest)
+    expect(res.status).toBe(200)
+    expect(createInscricao).toHaveBeenCalledWith(expect.objectContaining({ paymentMethod: 'pix' }))
+    expect(JSON.parse(fetchMock.mock.calls[1][1].body as string).paymentMethod).toBe('pix')
+  })
+
+  it('normaliza na rota /api/asaas', async () => {
+    const pb = createPocketBaseMock()
+    pb.collection.mockImplementation((name: string) => {
+      if (name === 'pedidos')
+        return {
+          getOne: vi.fn().mockResolvedValue({ id: 'p1', id_inscricao: 'ins1', produto: 'P', cliente: 'cli1', responsavel: 'u1' }),
+          update: vi.fn(),
+        }
+      if (name === 'inscricoes')
+        return { getOne: vi.fn().mockResolvedValue({ id: 'ins1', cpf: '1', nome: 'N', email: 'e', telefone: '1', endereco: '', numero: '', cliente: 'cli1', criado_por: 'u1' }) }
+      return {} as any
+    })
+    ;(requireClienteFromHost as unknown as { mockResolvedValue: (v: any) => void }).mockResolvedValue({ pb, cliente: { nome: 'Cli', asaas_api_key: '$key' } })
+
+    process.env.ASAAS_API_URL = 'http://asaas'
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValueOnce({ ok: true, json: () => Promise.resolve({ data: [] }) })
+      .mockResolvedValueOnce({ ok: true, text: () => Promise.resolve('{"id":"c1"}') })
+      .mockResolvedValueOnce({ ok: true, text: () => Promise.resolve('{"id":"pay","invoiceUrl":"url"}') })
+    global.fetch = fetchMock as unknown as typeof fetch
+
+    const req = new Request('http://test/api/asaas', {
+      method: 'POST',
+      body: JSON.stringify({ pedidoId: 'p1', valorBruto: 10, paymentMethod: 'Credito', installments: 1 }),
+    })
+    ;(req as any).nextUrl = new URL('http://test/api/asaas')
+
+    const pocketbaseModule = await import('../../lib/pocketbase')
+    ;(pocketbaseModule.default as unknown as { mockReturnValue: (v: any) => void }).mockReturnValue(pb)
+
+    const res = await postAsaas(req as unknown as NextRequest)
+    expect(res.status).toBe(200)
+    const body = JSON.parse((fetchMock.mock.calls[2][1] as RequestInit).body as string)
+    expect(body.billingType).toBe('PIX')
+  })
+})

--- a/app/api/asaas/route.ts
+++ b/app/api/asaas/route.ts
@@ -44,7 +44,7 @@ export async function POST(req: NextRequest) {
   }
 
   try {
-    const {
+  const {
       pedidoId,
       valorBruto,
       paymentMethod,
@@ -63,6 +63,9 @@ export async function POST(req: NextRequest) {
       installments,
     })
 
+    const normalizedPaymentMethod: PaymentMethod =
+      paymentMethod?.toLowerCase() === 'credito' ? 'pix' : paymentMethod
+
     if (!pedidoId || valorBruto === undefined || valorBruto === null) {
       console.log('🔴 [POST /api/asaas] pedidoId e valorBruto são obrigatórios')
       return NextResponse.json(
@@ -80,10 +83,10 @@ export async function POST(req: NextRequest) {
       )
     }
 
-    if (paymentMethod !== 'pix' && paymentMethod !== 'boleto') {
+    if (normalizedPaymentMethod !== 'pix' && normalizedPaymentMethod !== 'boleto') {
       console.log(
         '🔴 [POST /api/asaas] Forma de pagamento inválida:',
-        paymentMethod,
+        normalizedPaymentMethod,
       )
       return NextResponse.json(
         { error: 'Forma de pagamento inválida' },
@@ -235,12 +238,12 @@ export async function POST(req: NextRequest) {
     // Payload de pagamento
     const { gross, margin } = calculateGross(
       parsedValor,
-      paymentMethod as PaymentMethod,
+      normalizedPaymentMethod as PaymentMethod,
       installments,
     )
     console.log('💰 gross:', gross, 'margin:', margin)
 
-    const billingType = toAsaasBilling(paymentMethod as PaymentMethod)
+    const billingType = toAsaasBilling(normalizedPaymentMethod as PaymentMethod)
     if (!['PIX', 'BOLETO'].includes(billingType)) {
       console.log(
         '🔴 [POST /api/asaas] Forma de pagamento inválida:',
@@ -315,7 +318,7 @@ export async function POST(req: NextRequest) {
       valorBruto: gross,
       taxaAplicada,
       margemPlataforma: margin,
-      formaPagamento: paymentMethod,
+      formaPagamento: normalizedPaymentMethod,
       parcelas: installments,
       vencimento: dueDateISO,
       ...(asaasId ? { id_asaas: asaasId } : {}),

--- a/app/api/inscricoes/route.ts
+++ b/app/api/inscricoes/route.ts
@@ -65,6 +65,9 @@ export async function POST(req: NextRequest) {
       evento: eventoBody,
     } = body
 
+    const paymentMethodNormalized: PaymentMethod =
+      paymentMethod?.toLowerCase() === 'credito' ? 'pix' : paymentMethod
+
     const produtoIdFinal: string | undefined = produtoId || produtoId
 
     // Limpa CPF e telefone
@@ -99,7 +102,7 @@ export async function POST(req: NextRequest) {
       )
     }
 
-    if (!['pix', 'boleto'].includes(paymentMethod)) {
+    if (!['pix', 'boleto'].includes(paymentMethodNormalized)) {
       return NextResponse.json(
         { erro: 'Forma de pagamento inválida.' },
         { status: 400 },
@@ -203,11 +206,11 @@ export async function POST(req: NextRequest) {
     const dadosInscricao: Omit<Inscricao, 'id'> & {
       paymentMethod: PaymentMethod
       installments: number
-    } = {
-      ...dadosBaseSemId,
-      paymentMethod,
-      installments,
-    }
+      } = {
+        ...dadosBaseSemId,
+        paymentMethod: paymentMethodNormalized,
+        installments,
+      }
 
     const inscricao = await pb.collection('inscricoes').create(dadosInscricao)
     logRocketEvent('nova_inscricao_admin', {
@@ -243,13 +246,13 @@ export async function POST(req: NextRequest) {
           const asaasRes = await fetch(`${base}/api/asaas`, {
             method: 'POST',
             headers: { 'Content-Type': 'application/json' },
-            body: JSON.stringify({
-              pedidoId,
-              valorBruto: valor,
-              paymentMethod,
-              installments,
-            }),
-          })
+              body: JSON.stringify({
+                pedidoId,
+                valorBruto: valor,
+                paymentMethod: paymentMethodNormalized,
+                installments,
+              }),
+            })
 
           if (asaasRes.ok) {
             const data = await asaasRes.json()

--- a/docs/Documentacao_M24.md
+++ b/docs/Documentacao_M24.md
@@ -455,6 +455,7 @@ Para cada coleção, utilize a seguinte estrutura:
 - **Índices**: único em `cpf`.
 - **Validações**: formatos de dados e valores obrigatórios.
 - **Webhooks**: cobrança, aprovação e cancelamento.
+- O valor `credito` no campo `paymentMethod` é aceito, mas tratado como `pix` para compatibilidade.
 
 ---
 

--- a/logs/DOC_LOG.md
+++ b/logs/DOC_LOG.md
@@ -524,3 +524,4 @@ executados.
 
 ## [2025-07-04] Rota /api/recuperar-link consulta inscricoes quando cobranca nao encontrada. Lint e build executados.
 ## [2025-07-04] Documentadas rotas /recuperar e /api/recuperar-link, orientando criar inscricao quando nao houver cobranca. Lint: ok - Build: ok
+## [2025-07-05] Aceita pagamento 'credito' mapeado para pix nas inscricoes e rota Asaas.

--- a/logs/ERR_LOG.md
+++ b/logs/ERR_LOG.md
@@ -239,3 +239,4 @@
 ## [2025-07-02] Webhook Asaas nao usa mais NEXT_PUBLIC_SITE_URL; host obtido do tenant - dev - fcee1eaf7bdf79c55c4c019c94e5c91d38117490
 ## [2025-07-02] getTenantHost retornava dominio sem protocolo, causando erros de redirecionamento - dev - 3d2de08d
 ## [2025-07-05] Validação de paymentMethod na rota Asaas - dev - 83c8b653
+## [2025-07-05] Forma de pagamento 'Credito' mapeada para pix nas rotas - dev - 10307d3


### PR DESCRIPTION
## Summary
- normalize `Credito` to `pix` in inscricoes API route
- normalize `Credito` to `pix` in asaas API route
- document accepted `credito` value in M24 docs
- log documentation update
- add unit tests for `Credito` mapping
- log bug fix reference

## Testing
- `npm run lint` *(fails: next not found)*
- `npm run build` *(fails: next not found)*
- `npm run test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_686879bc8e58832cb8279f76bb18caaa