### PR TITLE
Adicionar rota pública para inscrições

### DIFF
--- a/app/api/inscricoes/public/route.ts
+++ b/app/api/inscricoes/public/route.ts
@@ -1,0 +1,77 @@
+import { NextRequest, NextResponse } from 'next/server'
+import createPocketBase from '@/lib/pocketbase'
+import { getTenantFromHost } from '@/lib/getTenantFromHost'
+import { logConciliacaoErro } from '@/lib/server/logger'
+import { rateLimit } from '@/lib/server/rateLimit'
+
+export async function GET(req: NextRequest) {
+  const ip =
+    req.headers.get('x-forwarded-for')?.split(',')[0] || 'local'
+  if (rateLimit(ip)) {
+    return NextResponse.json(
+      { error: 'Muitas requisições' },
+      { status: 429 },
+    )
+  }
+
+  const email = req.nextUrl.searchParams.get('email')?.toLowerCase().trim() || ''
+  const cpf = req.nextUrl.searchParams.get('cpf')?.replace(/\D/g, '') || ''
+  const eventoId = req.nextUrl.searchParams.get('evento') || ''
+
+  if (!email || !cpf) {
+    await logConciliacaoErro('GET /inscricoes/public - parametros ausentes')
+    return NextResponse.json(
+      { error: 'cpf e email são obrigatórios' },
+      { status: 400 },
+    )
+  }
+  const emailRegex = /^[^\s@]+@[^\s@]+\.[^\s@]+$/
+  if (!emailRegex.test(email) || cpf.length !== 11) {
+    await logConciliacaoErro('GET /inscricoes/public - parametros invalidos')
+    return NextResponse.json(
+      { error: 'Parâmetros inválidos' },
+      { status: 400 },
+    )
+  }
+
+  try {
+    const pb = createPocketBase()
+    const tenantId = await getTenantFromHost()
+    if (!tenantId) {
+      return NextResponse.json(
+        { error: 'Tenant não informado' },
+        { status: 400 },
+      )
+    }
+
+    const filtroParts = [
+      `cpf="${cpf}"`,
+      `email="${email}"`,
+      `cliente="${tenantId}"`,
+    ]
+    if (eventoId) filtroParts.push(`evento="${eventoId}"`)
+    const filtro = filtroParts.join(' && ')
+
+    const record = await pb
+      .collection('inscricoes')
+      .getFirstListItem(filtro)
+
+    return NextResponse.json(
+      {
+        nome: record.nome,
+        email: record.email,
+        cpf: record.cpf,
+        status: record.status,
+      },
+      { status: 200 },
+    )
+  } catch (err) {
+    await logConciliacaoErro(
+      `GET /inscricoes/public - ${String(err)}`,
+    )
+    return NextResponse.json(
+      { error: 'Erro interno' },
+      { status: 500 },
+    )
+  }
+}

--- a/lib/server/rateLimit.ts
+++ b/lib/server/rateLimit.ts
@@ -1,0 +1,13 @@
+const requests = new Map<string, { count: number; first: number }>()
+
+export function rateLimit(key: string, windowMs = 60_000, max = 5) {
+  const now = Date.now()
+  const entry = requests.get(key)
+  if (!entry || now - entry.first > windowMs) {
+    requests.set(key, { count: 1, first: now })
+    return false
+  }
+  entry.count += 1
+  if (entry.count > max) return true
+  return false
+}


### PR DESCRIPTION
## Resumo
- criar utilitário `rateLimit` para limitar chamadas
- adicionar rota `GET /api/inscricoes/public` sem autenticação
- validar CPF e email, filtrar por tenant/evento e registrar erros

## Testes
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_686884ada0e8832c83b0092062868f84