### PR TITLE
Implement login check for ConsultaInscricao

### DIFF
--- a/components/organisms/ConsultaInscricao.tsx
+++ b/components/organisms/ConsultaInscricao.tsx
@@ -1,5 +1,9 @@
 'use client'
-import { useState } from 'react'
+import { useState, useEffect } from 'react'
+import { useSearchParams } from 'next/navigation'
+import Link from 'next/link'
+import * as Dialog from '@radix-ui/react-dialog'
+import ModalAnimated from './ModalAnimated'
 import EventForm from './EventForm'
 import InscricoesTable from '@/app/cliente/components/InscricoesTable'
 import { FormField, InputWithMask, TextField } from '@/components'
@@ -24,20 +28,44 @@ export default function ConsultaInscricao({
   const [inscricao, setInscricao] = useState<Inscricao | null>(null)
   const [loading, setLoading] = useState(false)
   const [showWizard, setShowWizard] = useState(false)
+  const [showLoginModal, setShowLoginModal] = useState(false)
+  const searchParams = useSearchParams()
 
-  async function handleSubmit(e: React.FormEvent<HTMLFormElement>) {
-    e.preventDefault()
+  useEffect(() => {
+    const eventoParam = searchParams.get('evento')
+    const cpfParam = searchParams.get('cpf')
+    const emailParam = searchParams.get('email')
+    if (eventoParam === eventoId && cpfParam && emailParam) {
+      setCpf(cpfParam)
+      setEmail(emailParam)
+      submitConsulta(cpfParam, emailParam)
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [eventoId, searchParams])
+
+  async function submitConsulta(cpfVal: string, emailVal: string) {
     const errs: { cpf?: string; email?: string } = {}
-    if (!isValidCPF(cpf)) errs.cpf = 'CPF inválido'
-    if (!isValidEmail(email)) errs.email = 'E-mail inválido'
+    if (!isValidCPF(cpfVal)) errs.cpf = 'CPF inválido'
+    if (!isValidEmail(emailVal)) errs.email = 'E-mail inválido'
     setErrors(errs)
     if (Object.keys(errs).length > 0) return
 
     setLoading(true)
     try {
+      const cleanCpf = cpfVal.replace(/\D/g, '')
+      const existsParams = new URLSearchParams({ cpf: cleanCpf, email: emailVal })
+      const existsRes = await fetch(`/api/usuarios/exists?${existsParams.toString()}`)
+      if (existsRes.ok) {
+        const data = await existsRes.json()
+        if (data.cpf || data.email) {
+          setShowLoginModal(true)
+          return
+        }
+      }
+
       const query = new URLSearchParams({
-        cpf: cpf.replace(/\D/g, ''),
-        email,
+        cpf: cleanCpf,
+        email: emailVal,
         evento: eventoId,
       })
       const res = await fetch(`/api/inscricoes/public?${query.toString()}`)
@@ -49,7 +77,10 @@ export default function ConsultaInscricao({
         setErrors({})
       } else if (res.status === 404) {
         if (inscricoesEncerradas) {
-          setErrors({ geral: 'O período de inscrições foi encerrado...' })
+          setErrors({
+            geral:
+              'O período de inscrições foi encerrado e não há cadastro para as credenciais informadas.',
+          })
         } else {
           setShowWizard(true)
         }
@@ -64,6 +95,11 @@ export default function ConsultaInscricao({
     } finally {
       setLoading(false)
     }
+  }
+
+  async function handleSubmit(e: React.FormEvent<HTMLFormElement>) {
+    e.preventDefault()
+    await submitConsulta(cpf, email)
   }
 
   if (showWizard) {
@@ -102,6 +138,25 @@ export default function ConsultaInscricao({
       </form>
 
       {inscricao && <InscricoesTable inscricoes={[inscricao]} variant="details" />}
+
+      <ModalAnimated open={showLoginModal} onOpenChange={setShowLoginModal}>
+        <div className="space-y-4 text-center w-72">
+          <Dialog.Title asChild>
+            <h3 className="text-lg font-semibold">Conta localizada</h3>
+          </Dialog.Title>
+          <Dialog.Description className="sr-only">
+            Conta já cadastrada
+          </Dialog.Description>
+          <p>Já existe uma conta com este CPF e/ou e-mail. Por favor, faça login para continuar.</p>
+          <Link
+            href={`/login?redirectTo=/inscricoes?evento=${eventoId}&cpf=${cpf.replace(/\D/g, '')}&email=${encodeURIComponent(email)}`}
+            className="btn btn-primary inline-block"
+            onClick={() => setShowLoginModal(false)}
+          >
+            Fazer Login
+          </Link>
+        </div>
+      </ModalAnimated>
     </div>
   )
 }


### PR DESCRIPTION
## Summary
- validate existing users before showing inscrição wizard
- redirect through a login modal when user already exists
- auto-submit form when query params are present

## Testing
- `npm run lint` *(fails: next not found)*
- `npm run build` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_686892d10b28832c9ea4c8d9a84b6fe5