### PR TITLE
Handle not found on public inscription lookup

### DIFF
--- a/logs/ERR_LOG.md
+++ b/logs/ERR_LOG.md
@@ -241,3 +241,4 @@
 ## [2025-07-05] Validação de paymentMethod na rota Asaas - dev - 83c8b653
 ## [2025-07-05] Forma de pagamento 'Credito' mapeada para pix nas rotas - dev - 10307d3
 ## [2025-07-05] Consulta de inscrição pública retornava erro "Token ou usuário ausente" ao usar rota protegida. Componente ConsultaInscricao chama /api/inscricoes/public - dev
+## [2025-07-05] GET /api/inscricoes/public retornava "Erro interno" quando nenhuma inscrição era encontrada. Rota atualizada para retornar 404 com "Inscrição não encontrada". Commit 6d3daeac - dev


### PR DESCRIPTION
## Summary
- handle 404 when an inscription is not found on `/api/inscricoes/public`
- log the fix in `ERR_LOG.md`

## Testing
- `npm run lint` *(fails: next not found)*
- `npm run build` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_68689194f654832cabf104759e65c065