### PR TITLE
Fix redirect query in login flows

### DIFF
--- a/app/login/page.tsx
+++ b/app/login/page.tsx
@@ -16,7 +16,8 @@ export default function LoginPage() {
 function LoginClient() {
   'use client'
   const searchParams = useSearchParams()
-  const redirectTo = searchParams.get('redirect') || undefined
+  const redirectTo =
+    searchParams.get('redirect') || searchParams.get('redirectTo') || undefined
 
   return (
     <LayoutWrapper>

--- a/components/organisms/ConsultaInscricao.tsx
+++ b/components/organisms/ConsultaInscricao.tsx
@@ -149,7 +149,7 @@ export default function ConsultaInscricao({
           </Dialog.Description>
           <p>Já existe uma conta com este CPF e/ou e-mail. Por favor, faça login para continuar.</p>
           <Link
-            href={`/login?redirectTo=/inscricoes?evento=${eventoId}&cpf=${cpf.replace(/\D/g, '')}&email=${encodeURIComponent(email)}`}
+            href={`/login?redirect=/inscricoes?evento=${eventoId}&cpf=${cpf.replace(/\D/g, '')}&email=${encodeURIComponent(email)}`}
             className="btn btn-primary inline-block"
             onClick={() => setShowLoginModal(false)}
           >


### PR DESCRIPTION
## Summary
- rename redirect query for login modal
- support `redirectTo` or `redirect` params on login page

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6868969b0c38832ca1c937c1dc390621