### PR TITLE
Fix login redirect fallback

### DIFF
--- a/components/templates/LoginForm.tsx
+++ b/components/templates/LoginForm.tsx
@@ -28,13 +28,7 @@ export default function LoginForm({
   // Redirecionamento pós-login com verificação de sucesso
   useEffect(() => {
     if (!isLoading && isLoggedIn && user) {
-      const target = redirectTo
-        ? redirectTo
-        : user.role === 'coordenador'
-        ? '/admin/dashboard'
-        : user.role === 'lider'
-        ? '/admin/lider-painel'
-        : '/cliente/dashboard'
+      const target = redirectTo || '/'
 
       const prevUrl =
         typeof window !== 'undefined'
@@ -51,6 +45,8 @@ export default function LoginForm({
             'Não foi possível retomar a inscrição automaticamente.',
           )
           router.replace(`/inscricoes?evento=${eventoId}`)
+        } else {
+          router.replace('/')
         }
       }
 

--- a/logs/ERR_LOG.md
+++ b/logs/ERR_LOG.md
@@ -242,3 +242,4 @@
 ## [2025-07-05] Forma de pagamento 'Credito' mapeada para pix nas rotas - dev - 10307d3
 ## [2025-07-05] Consulta de inscrição pública retornava erro "Token ou usuário ausente" ao usar rota protegida. Componente ConsultaInscricao chama /api/inscricoes/public - dev
 ## [2025-07-05] GET /api/inscricoes/public retornava "Erro interno" quando nenhuma inscrição era encontrada. Rota atualizada para retornar 404 com "Inscrição não encontrada". Commit 6d3daeac - dev
+## [2025-07-05] Login falhava sem redirectTo; fallback para '/' implementado - dev - 75187664


### PR DESCRIPTION
## Summary
- always default `LoginForm` redirects to `/`
- fallback to `/` when redirect target is invalid
- log the fix in ERR_LOG

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68689d4f7284832ca6689bd38eef6a2c