### PR TITLE
Implement auto login after signup

### DIFF
--- a/__tests__/EventForm.test.tsx
+++ b/__tests__/EventForm.test.tsx
@@ -1,0 +1,82 @@
+/* @vitest-environment jsdom */
+import React from 'react'
+import { render, screen, fireEvent } from '@testing-library/react'
+import { vi } from 'vitest'
+import EventForm from '@/components/organisms/EventForm'
+
+vi.mock('next/image', () => ({
+  __esModule: true,
+  default: (props: any) => <img {...props} alt={props.alt} />,
+}))
+
+const push = vi.fn()
+vi.mock('next/navigation', () => ({
+  useRouter: () => ({ push }),
+}))
+
+vi.mock('@/lib/context/TenantContext', () => ({
+  useTenant: () => ({ config: { confirmaInscricoes: true } }),
+}))
+
+vi.mock('@/lib/context/ToastContext', () => ({
+  useToast: () => ({ showSuccess: vi.fn(), showError: vi.fn() }),
+}))
+
+const login = vi.fn()
+vi.mock('@/lib/context/AuthContext', () => ({
+  useAuthContext: () => ({ isLoggedIn: false, user: null, login }),
+}))
+
+vi.mock('@/utils/cep', () => ({
+  fetchCep: vi.fn().mockResolvedValue({ street: '', neighborhood: '', city: '', state: '' }),
+}))
+
+describe('EventForm login', () => {
+  it('chama login apos inscricao de novo usuario', async () => {
+    const fetchMock = vi.fn()
+    global.fetch = fetchMock as unknown as typeof fetch
+    fetchMock
+      .mockResolvedValueOnce({ ok: true, json: () => Promise.resolve([{ id: 'c1', nome: 'Campo 1' }]) })
+      .mockResolvedValueOnce({
+        ok: true,
+        json: () => Promise.resolve({ expand: { produto_inscricao: { id: 'p1', nome: 'Prod 1' } }, cobra_inscricao: false }),
+      })
+      .mockResolvedValueOnce({ ok: true, json: () => Promise.resolve({}) })
+      .mockResolvedValueOnce({ ok: true, json: () => Promise.resolve({}) })
+
+    const { container } = render(<EventForm eventoId="ev1" />)
+
+    fireEvent.change(await screen.findByLabelText(/nome/i), { target: { value: 'Fulano' } })
+    fireEvent.change(screen.getByLabelText(/e-mail/i), { target: { value: 'f@x.com' } })
+    fireEvent.change(screen.getByLabelText(/telefone/i), { target: { value: '11999999999' } })
+    fireEvent.change(screen.getByLabelText(/^cpf$/i), { target: { value: '52998224725' } })
+    fireEvent.change(screen.getByLabelText(/data de nascimento/i), { target: { value: '2000-01-01' } })
+    fireEvent.change(screen.getByLabelText(/gênero/i), { target: { value: 'masculino' } })
+    fireEvent.click(screen.getByText(/avançar/i))
+
+    fireEvent.change(await screen.findByLabelText(/cep/i), { target: { value: '12345678' } })
+    fireEvent.change(screen.getByLabelText(/endereço/i), { target: { value: 'Rua A' } })
+    fireEvent.change(screen.getByLabelText(/estado/i), { target: { value: 'SP' } })
+    fireEvent.change(screen.getByLabelText(/cidade/i), { target: { value: 'São Paulo' } })
+    fireEvent.change(screen.getByLabelText(/bairro/i), { target: { value: 'Centro' } })
+    fireEvent.change(screen.getByLabelText(/número/i), { target: { value: '10' } })
+    fireEvent.click(screen.getByText(/avançar/i))
+
+    fireEvent.change(await screen.findByLabelText(/campo/i), { target: { value: 'c1' } })
+    fireEvent.click(screen.getByText(/avançar/i))
+
+    fireEvent.click(await screen.findByRole('button', { name: /prod 1/i }))
+    fireEvent.click(screen.getByText(/avançar/i))
+
+    fireEvent.change(await screen.findByLabelText(/^senha$/i), { target: { value: '12345678' } })
+    fireEvent.change(screen.getByLabelText(/confirme a senha/i), { target: { value: '12345678' } })
+    fireEvent.click(screen.getByText(/avançar/i))
+
+    fireEvent.click(container.querySelector('input[type="checkbox"]') as HTMLInputElement)
+    fireEvent.click(screen.getByText(/concluir/i))
+
+    await vi.waitFor(() => {
+      expect(login).toHaveBeenCalledWith('f@x.com', '12345678')
+    })
+  })
+})

--- a/components/organisms/EventForm.tsx
+++ b/components/organisms/EventForm.tsx
@@ -54,7 +54,7 @@ export default function EventForm({ eventoId, liderId }: EventFormProps) {
   const { config } = useTenant()
   const { showSuccess, showError } = useToast()
   const router = useRouter()
-  const { isLoggedIn, user } = useAuthContext()
+  const { isLoggedIn, user, login } = useAuthContext()
   const pb = useMemo(() => createPocketBase(), [])
   const [campoNome, setCampoNome] = useState('')
   const [campos, setCampos] = useState<Campo[]>([])
@@ -363,6 +363,13 @@ export default function EventForm({ eventoId, liderId }: EventFormProps) {
         return
       }
       showSuccess('Inscrição enviada com sucesso!')
+      if (!isLoggedIn && url === '/loja/api/inscricoes') {
+        try {
+          await login(form.email, form.password)
+        } catch {
+          /* ignore erro de login */
+        }
+      }
       setTimeout(() => {
         router.push('/inscricoes/conclusao')
       }, 500)

--- a/docs/regras-inscricoes.md
+++ b/docs/regras-inscricoes.md
@@ -23,6 +23,8 @@ Este documento descreve como cada perfil acessa as inscri\u00e7\u00f5es, o proce
 5. A API verifica se já existe usuário com o e-mail informado.
    - Se existir, o ID é usado em `criado_por`.
    - Caso contrário, cria usuário e vincula o ID à inscrição.
+6. Quando a inscrição é enviada pela rota `/loja/api/inscricoes`, o sistema
+   efetua o login automaticamente caso o usuário ainda não esteja autenticado.
 
 ## Par\u00e2metros da API
 

--- a/logs/DOC_LOG.md
+++ b/logs/DOC_LOG.md
@@ -527,3 +527,5 @@ executados.
 ## [2025-07-05] Aceita pagamento 'credito' mapeado para pix nas inscricoes e rota Asaas.
 ## [2025-07-05] Página /inscricoes/conclusao adicionada e EventForm passa a redirecionar para ela. Documentação e índice atualizados. Lint e build executados.
 ## [2025-07-05] Documentado ajuste de rate limit da rota publica. Lint e build executados.
+## [2025-07-05] EventForm passa a logar automaticamente o novo usuário após POST
+na rota /loja/api/inscricoes e documentação atualizada. Lint e build executados.


### PR DESCRIPTION
## Summary
- trigger auto login for new users in `EventForm`
- test new login behavior
- document automatic login after signup
- log documentation update

## Testing
- `npm run lint`
- `npm run build`
- `npm test` *(fails: Worker terminated due to memory limit)*

------
https://chatgpt.com/codex/tasks/task_e_6868a8e3fcd8832cb374b3055fe8f55a