### PR TITLE
Fix EventForm login ref

### DIFF
--- a/components/organisms/EventForm.tsx
+++ b/components/organisms/EventForm.tsx
@@ -48,7 +48,7 @@ export default function EventForm({ eventoId, liderId }: EventFormProps) {
   const { config } = useTenant()
   const { showSuccess, showError } = useToast()
   const router = useRouter()
-  const { isLoggedIn, user, login } = useAuthContext()
+  const { isLoggedIn, user } = useAuthContext()
   const pb = useMemo(() => createPocketBase(), [])
   const [campoNome, setCampoNome] = useState('')
   const [campos, setCampos] = useState<Campo[]>([])
@@ -224,13 +224,6 @@ export default function EventForm({ eventoId, liderId }: EventFormProps) {
         return
       }
       showSuccess('Inscrição enviada com sucesso!')
-      if (!isLoggedIn && url === '/loja/api/inscricoes') {
-        try {
-          await login(form.email, form.password)
-        } catch {
-          /* ignore erro de login */
-        }
-      }
       setTimeout(() => {
         router.push('/inscricoes/conclusao')
       }, 500)

--- a/logs/ERR_LOG.md
+++ b/logs/ERR_LOG.md
@@ -243,3 +243,5 @@
 ## [2025-07-05] Consulta de inscrição pública retornava erro "Token ou usuário ausente" ao usar rota protegida. Componente ConsultaInscricao chama /api/inscricoes/public - dev
 ## [2025-07-05] GET /api/inscricoes/public retornava "Erro interno" quando nenhuma inscrição era encontrada. Rota atualizada para retornar 404 com "Inscrição não encontrada". Commit 6d3daeac - dev
 ## [2025-07-05] Login falhava sem redirectTo; fallback para '/' implementado - dev - 75187664
+
+## [2025-07-05] Removida chamada de login com campos inexistentes apos refatoracao do CreateUserForm; erro de compilacao resolvido - dev - ea109718f369e58f51b00b3994a51ea16c9bee64


### PR DESCRIPTION
## Summary
- remove outdated login logic from `EventForm`
- document compile fix in ERR_LOG

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6868b137f120832cacd93ec10f4ad67d