### PR TITLE
Fix form wizard async flow

### DIFF
--- a/components/organisms/EventForm.tsx
+++ b/components/organisms/EventForm.tsx
@@ -233,9 +233,7 @@ export default function EventForm({
         return
       }
       showSuccess('Inscrição enviada com sucesso!')
-      setTimeout(() => {
-        router.push('/inscricoes/conclusao')
-      }, 500)
+      router.replace('/inscricoes/conclusao')
     } catch {
       showError('Erro ao enviar inscrição.')
     } finally {

--- a/components/organisms/FormWizard.tsx
+++ b/components/organisms/FormWizard.tsx
@@ -9,7 +9,7 @@ export interface WizardStep {
 
 interface FormWizardProps {
   steps: WizardStep[]
-  onFinish?: () => void
+  onFinish?: () => void | Promise<void>
   className?: string
   loading?: boolean
   onStepValidate?: (index: number) => Promise<boolean> | boolean
@@ -53,7 +53,7 @@ export default function FormWizard({
         const ok = await onStepValidate(current)
         if (!ok) return
       }
-      if (isLast) onFinish?.()
+      if (isLast) await onFinish?.()
       else setCurrent((c) => Math.min(c + 1, steps.length - 1))
     } finally {
       setStepLoading(false)

--- a/docs/regras-inscricoes.md
+++ b/docs/regras-inscricoes.md
@@ -25,6 +25,7 @@ Este documento descreve como cada perfil acessa as inscri\u00e7\u00f5es, o proce
    - Caso contrário, cria usuário e vincula o ID à inscrição.
 6. Quando a inscrição é enviada pela rota `/loja/api/inscricoes`, o sistema
    efetua o login automaticamente caso o usuário ainda não esteja autenticado.
+7. Após a confirmação bem-sucedida, o usuário é redirecionado para `/inscricoes/conclusao`.
 
 ## Par\u00e2metros da API
 

--- a/logs/DOC_LOG.md
+++ b/logs/DOC_LOG.md
@@ -530,3 +530,4 @@ executados.
 ## [2025-07-05] EventForm passa a logar automaticamente o novo usuário após POST
 na rota /loja/api/inscricoes e documentação atualizada. Lint e build executados.
 ## [2025-07-05] EventForm preenche CPF e email da etapa anterior
+## [2025-07-05] FormWizard aguarda onFinish assíncrono e EventForm redireciona após envio. Documentação atualizada. Lint e build executados.


### PR DESCRIPTION
## Summary
- await `onFinish` if it returns a promise
- use `router.replace` only after successful submission
- test redirect to `/inscricoes/conclusao`
- document new redirect behaviour
- log documentation update

## Testing
- `npm run lint`
- `npm run build`
- `npx vitest run __tests__/EventFormSignup.test.tsx` *(fails: Test timed out)*

------
https://chatgpt.com/codex/tasks/task_e_6868c2aa8c74832c9580b81f3d10f887