### PR TITLE
Fix missing base URL error handling

### DIFF
--- a/app/loja/api/inscricoes/route.ts
+++ b/app/loja/api/inscricoes/route.ts
@@ -139,7 +139,10 @@ export async function POST(req: NextRequest) {
     const base = req.nextUrl?.origin || req.headers.get('origin')
     if (!base) {
       console.error('Base URL não encontrada para envio de notificações')
-      return
+      return NextResponse.json(
+        { error: 'Base URL não encontrada' },
+        { status: 500 },
+      )
     }
 
     let liderId: string | undefined

--- a/logs/ERR_LOG.md
+++ b/logs/ERR_LOG.md
@@ -245,3 +245,4 @@
 ## [2025-07-05] Login falhava sem redirectTo; fallback para '/' implementado - dev - 75187664
 
 ## [2025-07-05] Removida chamada de login com campos inexistentes apos refatoracao do CreateUserForm; erro de compilacao resolvido - dev - ea109718f369e58f51b00b3994a51ea16c9bee64
+## [2025-07-05] Tratamento de base URL ausente em /loja/api/inscricoes - dev - a95cfbe


### PR DESCRIPTION
## Summary
- handle missing base URL in inscricoes API route
- document fix in error log

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6868d0c80bcc832ca24d758578d00494