### PR TITLE
Padroniza payload de inscrições

### DIFF
--- a/__tests__/EventFormSignup.test.tsx
+++ b/__tests__/EventFormSignup.test.tsx
@@ -110,7 +110,16 @@ describe('EventForm signup flow', () => {
     })
 
     const body = JSON.parse((fetchMock.mock.calls[3][1] as RequestInit).body as string)
-    expect(body.userId).toBe('u1')
+    expect(body).toEqual(
+      expect.objectContaining({
+        user_first_name: 'Fulano',
+        user_email: 'f@x.com',
+        campo: 'c1',
+        evento: 'ev1',
+        produtoId: 'p1',
+        paymentMethod: 'pix',
+      }),
+    )
 
     vi.useRealTimers()
   })

--- a/__tests__/api/inscricoesRoutePost.test.ts
+++ b/__tests__/api/inscricoesRoutePost.test.ts
@@ -51,4 +51,39 @@ describe('POST /api/inscricoes', () => {
     expect(body.erro).toBe('Usuário já inscrito neste evento')
     expect(createInscricaoMock).not.toHaveBeenCalled()
   })
+
+  it('cria inscricao quando dados validos', async () => {
+    getFirstInscricaoMock.mockReset()
+    getFirstInscricaoMock.mockRejectedValueOnce(new Error('not found'))
+    createInscricaoMock.mockResolvedValueOnce({ id: 'i2' })
+    const req = new Request('http://test/api/inscricoes', {
+      method: 'POST',
+      body: JSON.stringify({
+        nome: 'Fulano',
+        email: 'e@test.com',
+        telefone: '11999999999',
+        cpf: '11111111111',
+        data_nascimento: '2000-01-01',
+        genero: 'masculino',
+        liderId: 'lid1',
+        eventoId: 'ev1',
+        produtoId: 'p1',
+        tamanho: 'M',
+        paymentMethod: 'pix',
+      }),
+    })
+    ;(req as any).nextUrl = new URL('http://test/api/inscricoes')
+
+    const res = await POST(req as unknown as NextRequest)
+    expect(res.status).toBe(201)
+    expect(createInscricaoMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        evento: 'ev1',
+        campo: 'c1',
+        produto: 'p1',
+        tamanho: 'M',
+        paymentMethod: 'pix',
+      }),
+    )
+  })
 })

--- a/components/organisms/EventForm.tsx
+++ b/components/organisms/EventForm.tsx
@@ -8,6 +8,7 @@ import { useRouter } from 'next/navigation'
 import { useAuthContext } from '@/lib/context/AuthContext'
 import createPocketBase from '@/lib/pocketbase'
 import { getAuthHeaders } from '@/lib/authHeaders'
+import { buildInscricaoPayload } from '@/utils/buildInscricaoPayload'
 import FormWizard from './FormWizard'
 import LoadingOverlay from './LoadingOverlay'
 import InscricoesTable from '@/app/cliente/components/InscricoesTable'
@@ -205,28 +206,7 @@ export default function EventForm({
         return
       }
       const url = liderId ? '/api/inscricoes' : '/loja/api/inscricoes'
-      const [firstName, ...rest] = String(userData.nome || '').split(' ')
-      const base = {
-        user_first_name: firstName,
-        user_last_name: rest.join(' '),
-        user_email: userData.email,
-        user_phone: userData.telefone,
-        user_cpf: userData.cpf,
-        user_birth_date: String(userData.data_nascimento ?? '').split(' ')[0],
-        user_gender: form.genero || userData.genero,
-        user_cep: userData.cep,
-        user_address: userData.endereco,
-        user_neighborhood: userData.bairro,
-        user_state: userData.estado,
-        user_city: userData.cidade,
-        user_number: userData.numero,
-        campo: form.campoId,
-        evento: eventoId,
-        produtoId: form.produtoId,
-        tamanho: form.tamanho,
-        paymentMethod: form.paymentMethod,
-      }
-      const payload = liderId ? { ...base, liderId } : base
+      const payload = buildInscricaoPayload(userData, form, eventoId, liderId)
       const res = await fetch(url, {
         method: 'POST',
         headers: { ...getAuthHeaders(pb), 'Content-Type': 'application/json' },

--- a/docs/regras-inscricoes.md
+++ b/docs/regras-inscricoes.md
@@ -35,6 +35,13 @@ A rota `GET /api/inscricoes` aceita os seguintes filtros:
 - `status` – filtra por status da inscri\u00e7\u00e3o (ex.: `pendente`, `aprovado`, `cancelado`).
 - `perPage` – define a quantidade de registros retornados por p\u00e1gina.
 
+### Campos esperados nos endpoints
+
+- **POST /api/inscricoes**
+  - `nome`, `email`, `telefone`, `cpf`, `data_nascimento`, `genero`, `campo`, `eventoId`, `produtoId`, `tamanho`, `paymentMethod`, `liderId`
+- **POST /loja/api/inscricoes**
+  - `user_first_name`, `user_last_name`, `user_email`, `user_phone`, `user_cpf`, `user_birth_date`, `user_gender`, `user_cep`, `user_address`, `user_neighborhood`, `user_state`, `user_city`, `user_number`, `campo`, `evento`, `produtoId`, `tamanho`, `paymentMethod`
+
 ## Efeito de `confirma_inscricoes`
 
 Quando `confirma_inscricoes` está **ativado** em `clientes_config`, cada inscrição permanece `pendente` até que um líder ou coordenador a aprove na tela **Inscrições**. Somente após essa aprovação o pedido é criado e o link de pagamento é enviado.

--- a/logs/DOC_LOG.md
+++ b/logs/DOC_LOG.md
@@ -532,3 +532,4 @@ na rota /loja/api/inscricoes e documentação atualizada. Lint e build executado
 ## [2025-07-05] EventForm preenche CPF e email da etapa anterior
 ## [2025-07-05] FormWizard aguarda onFinish assíncrono e EventForm redireciona após envio. Documentação atualizada. Lint e build executados.
 ## [2025-07-05] Signup aceita campo e gênero; valores pré-definidos são bloqueados. Lint e build executados.
+## [2025-07-05] Payload de inscricao unificado e documentados campos de cada endpoint. Lint e build executados.

--- a/utils/buildInscricaoPayload.ts
+++ b/utils/buildInscricaoPayload.ts
@@ -1,0 +1,56 @@
+import type { UserModel } from '@/types/UserModel'
+
+export interface FormValues {
+  genero: string
+  campoId: string
+  produtoId: string
+  tamanho: string
+  paymentMethod: string
+}
+
+export function buildInscricaoPayload(
+  user: UserModel,
+  form: FormValues,
+  eventoId: string,
+  liderId?: string,
+) {
+  const [firstName, ...rest] = String(user.nome || '').split(' ')
+  if (liderId) {
+    return {
+      nome: user.nome,
+      email: user.email,
+      telefone: user.telefone,
+      cpf: user.cpf,
+      data_nascimento: String(user.data_nascimento ?? '').split(' ')[0],
+      genero: form.genero || user.genero,
+      campo: form.campoId,
+      eventoId,
+      produtoId: form.produtoId,
+      tamanho: form.tamanho,
+      paymentMethod: form.paymentMethod,
+      liderId,
+    }
+  }
+  return {
+    user_first_name: firstName,
+    user_last_name: rest.join(' '),
+    user_email: user.email,
+    user_phone: user.telefone,
+    user_cpf: user.cpf,
+    user_birth_date: String(user.data_nascimento ?? '').split(' ')[0],
+    user_gender: form.genero || user.genero,
+    user_cep: user.cep,
+    user_address: user.endereco,
+    user_neighborhood: user.bairro,
+    user_state: user.estado,
+    user_city: user.cidade,
+    user_number: user.numero,
+    campo: form.campoId,
+    evento: eventoId,
+    produtoId: form.produtoId,
+    tamanho: form.tamanho,
+    paymentMethod: form.paymentMethod,
+  }
+}
+
+export type InscricaoPayload = ReturnType<typeof buildInscricaoPayload>


### PR DESCRIPTION
## Summary
- padronizar corpo enviado pelo `EventForm` com nova utilidade `buildInscricaoPayload`
- validar payload nos testes do formulário e da rota `/api/inscricoes`
- documentar campos aceitos em cada endpoint de inscrição
- registrar atualização no log

## Testing
- `npm run lint`
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_6868d20e02d8832caff47e770575b8b3