### PR TITLE
Improve inscrição form error handling

### DIFF
--- a/components/organisms/InscricaoForm.tsx
+++ b/components/organisms/InscricaoForm.tsx
@@ -100,8 +100,16 @@ export default function InscricaoForm({ eventoId }: InscricaoFormProps) {
         headers: { 'Content-Type': 'application/json' },
       })
 
+      const respData = await response.json()
+
       if (!response.ok) {
-        throw new Error('Falha ao salvar inscrição')
+        setStatus('error')
+        showError(
+          respData.error ||
+            respData.erro ||
+            'Erro ao enviar a inscrição. Tente novamente.',
+        )
+        return
       }
 
       setStatus('success')
@@ -112,10 +120,7 @@ export default function InscricaoForm({ eventoId }: InscricaoFormProps) {
     } catch (err: unknown) {
       console.warn('Erro ao enviar inscrição:', err)
       setStatus('error')
-      const msg =
-        (err as { response?: { error?: string } })?.response?.error ||
-        'Erro ao enviar a inscrição. Tente novamente.'
-      showError(msg)
+      showError('Erro ao enviar a inscrição. Tente novamente.')
     }
   }
 


### PR DESCRIPTION
## Summary
- display API error message when inscrição POST fails
- parse response body before checking status

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68694d3415e4832c8825a4cc775f9476