### PR TITLE
Atualiza ConsultaInscricao com dados do usuário logado

### DIFF
--- a/components/organisms/ConsultaInscricao.tsx
+++ b/components/organisms/ConsultaInscricao.tsx
@@ -24,8 +24,12 @@ export default function ConsultaInscricao({
   inscricoesEncerradas,
 }: ConsultaInscricaoProps) {
   const { user, isLoggedIn } = useAuthContext()
-  const [cpf, setCpf] = useState('')
-  const [email, setEmail] = useState('')
+  const [cpf, setCpf] = useState(() =>
+    isLoggedIn && user?.cpf ? user.cpf : '',
+  )
+  const [email, setEmail] = useState(() =>
+    isLoggedIn && user?.email ? user.email : '',
+  )
   const [errors, setErrors] = useState<{
     cpf?: string
     email?: string
@@ -37,6 +41,13 @@ export default function ConsultaInscricao({
   const [showLoginModal, setShowLoginModal] = useState(false)
   const searchParams = useSearchParams()
   const autoQueried = useRef(false)
+
+  useEffect(() => {
+    if (isLoggedIn && user) {
+      setCpf(user.cpf ?? '')
+      setEmail(user.email ?? '')
+    }
+  }, [isLoggedIn, user])
 
   const submitConsulta = useCallback(
     async (cpfVal: string, emailVal: string) => {
@@ -148,23 +159,25 @@ export default function ConsultaInscricao({
   return (
     <div className="space-y-4 mx-auto max-w-xs md:max-w-sm">
       <form onSubmit={handleSubmit} className="space-y-4">
-        <FormField label="CPF" htmlFor="consulta-cpf" error={errors.cpf}>
-          <InputWithMask
-            id="consulta-cpf"
-            mask="cpf"
-            value={cpf}
-            onChange={(e) => setCpf(e.target.value)}
-            required
-          />
-        </FormField>
-        <FormField label="E-mail" htmlFor="consulta-email" error={errors.email}>
-          <TextField
-            id="consulta-email"
-            type="email"
-            value={email}
-            onChange={(e) => setEmail(e.target.value)}
-            required
-          />
+          <FormField label="CPF" htmlFor="consulta-cpf" error={errors.cpf}>
+            <InputWithMask
+              id="consulta-cpf"
+              mask="cpf"
+              value={cpf}
+              onChange={(e) => setCpf(e.target.value)}
+              disabled={isLoggedIn}
+              required
+            />
+          </FormField>
+          <FormField label="E-mail" htmlFor="consulta-email" error={errors.email}>
+            <TextField
+              id="consulta-email"
+              type="email"
+              value={email}
+              onChange={(e) => setEmail(e.target.value)}
+              disabled={isLoggedIn}
+              required
+            />
         </FormField>
         {errors.geral && (
           <p role="alert" className="text-error-600">

--- a/docs/regras-inscricoes.md
+++ b/docs/regras-inscricoes.md
@@ -113,6 +113,9 @@ Ao concluir o login, o componente `LoginForm` lê o parâmetro `redirectTo` e
 executa `router.replace` para voltar à página indicada. Assim, o fluxo de
 inscrição continua exatamente de onde parou.
 
+Quando o usuário já está logado, os campos de CPF e e‑mail ficam preenchidos com
+os dados da conta e permanecem desabilitados para edição.
+
 A seguir é feita uma requisição para `/api/inscricoes/public` passando `cpf`,
 `email` e `evento`. As respostas definem o que será exibido:
 

--- a/logs/DOC_LOG.md
+++ b/logs/DOC_LOG.md
@@ -533,3 +533,4 @@ na rota /loja/api/inscricoes e documentação atualizada. Lint e build executado
 ## [2025-07-05] FormWizard aguarda onFinish assíncrono e EventForm redireciona após envio. Documentação atualizada. Lint e build executados.
 ## [2025-07-05] Signup aceita campo e gênero; valores pré-definidos são bloqueados. Lint e build executados.
 ## [2025-07-05] Payload de inscricao unificado e documentados campos de cada endpoint. Lint e build executados.
+## [2025-07-05] ConsultaInscricao preenche e bloqueia campos de CPF e email ao usuario logado. Lint e build executados.


### PR DESCRIPTION
## Summary
- preenche estados de CPF e email em ConsultaInscricao ao logar
- bloqueia edições quando autenticado
- registra no DOC_LOG
- documenta comportamento nos fluxos de inscrição

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6869575443bc832cb8032b8fbe6d496e