### PR TITLE
Prioritize user data in ConsultaInscricao auto query

### DIFF
--- a/components/organisms/ConsultaInscricao.tsx
+++ b/components/organisms/ConsultaInscricao.tsx
@@ -133,12 +133,25 @@ export default function ConsultaInscricao({
     const cpfParam = searchParams.get('cpf')
     const emailParam = searchParams.get('email')
     if (eventoParam === eventoId && cpfParam && emailParam) {
-      setCpf(cpfParam)
-      setEmail(emailParam)
       autoQueried.current = true
-      submitConsulta(cpfParam, emailParam)
+      if (isLoggedIn && user) {
+        submitConsulta(user.cpf ?? '', user.email ?? '')
+      } else {
+        setCpf(cpfParam)
+        setEmail(emailParam)
+        submitConsulta(cpfParam, emailParam)
+      }
     }
-  }, [eventoId, searchParams, loading, inscricao, errors, submitConsulta])
+  }, [
+    eventoId,
+    searchParams,
+    loading,
+    inscricao,
+    errors,
+    submitConsulta,
+    isLoggedIn,
+    user,
+  ])
 
   async function handleSubmit(e: React.FormEvent<HTMLFormElement>) {
     e.preventDefault()

--- a/docs/regras-inscricoes.md
+++ b/docs/regras-inscricoes.md
@@ -114,7 +114,10 @@ executa `router.replace` para voltar à página indicada. Assim, o fluxo de
 inscrição continua exatamente de onde parou.
 
 Quando o usuário já está logado, os campos de CPF e e‑mail ficam preenchidos com
-os dados da conta e permanecem desabilitados para edição.
+os dados da conta e permanecem desabilitados para edição. Caso a tela seja
+acessada com `cpf` e `email` na URL (após o redirecionamento de login, por
+exemplo), esses valores são ignorados e a consulta é feita diretamente com o CPF
+e o e‑mail do usuário autenticado.
 
 A seguir é feita uma requisição para `/api/inscricoes/public` passando `cpf`,
 `email` e `evento`. As respostas definem o que será exibido:

--- a/logs/DOC_LOG.md
+++ b/logs/DOC_LOG.md
@@ -534,3 +534,4 @@ na rota /loja/api/inscricoes e documentação atualizada. Lint e build executado
 ## [2025-07-05] Signup aceita campo e gênero; valores pré-definidos são bloqueados. Lint e build executados.
 ## [2025-07-05] Payload de inscricao unificado e documentados campos de cada endpoint. Lint e build executados.
 ## [2025-07-05] ConsultaInscricao preenche e bloqueia campos de CPF e email ao usuario logado. Lint e build executados.
+## [2025-07-05] ConsultaInscricao prioriza dados do usuário autenticado ao ler parametros de consulta. Documentação atualizada. Lint e build executados.


### PR DESCRIPTION
## Summary
- prefer authenticated user on ConsultaInscricao auto query
- document consultation behaviour
- log documentation update

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68698e343944832c819cf7d61db06fa0