### PR TITLE
Add review step to EventForm

### DIFF
--- a/components/organisms/EventForm.tsx
+++ b/components/organisms/EventForm.tsx
@@ -424,6 +424,40 @@ export default function EventForm({
   }
 
   steps.push({
+    title: 'Revisão',
+    content: (
+      <div className="space-y-2 text-sm">
+        <p>
+          <span className="font-medium">Nome:</span> {user?.nome}
+        </p>
+        <p>
+          <span className="font-medium">CPF:</span> {user?.cpf}
+        </p>
+        <p>
+          <span className="font-medium">E-mail:</span> {user?.email}
+        </p>
+        <p>
+          <span className="font-medium">Campo:</span>{' '}
+          {campoNome ||
+            campos.find((c) => c.id === form.campoId)?.nome ||
+            user?.campo}
+        </p>
+        <p>
+          <span className="font-medium">Produto/Tamanho:</span>{' '}
+          {produtos.find((p) => p.id === form.produtoId)?.nome}
+          {form.tamanho ? ` - ${form.tamanho}` : ''}
+        </p>
+        {cobraInscricao && (
+          <p>
+            <span className="font-medium">Forma de Pagamento:</span>{' '}
+            {form.paymentMethod === 'pix' ? 'Pix' : 'Boleto'}
+          </p>
+        )}
+      </div>
+    ),
+  })
+
+  steps.push({
     title: 'Confirmação',
     content: (
       <div className="space-y-4">

--- a/docs/regras-inscricoes.md
+++ b/docs/regras-inscricoes.md
@@ -57,8 +57,9 @@ As etapas são:
 2. Endereço
 3. Campo de Atuação
 4. Produto Vinculado
-5. Forma de Pagamento (exibida apenas quando `confirmaInscricoes` está desativado)
-6. Confirmação final do envio
+5. Revisão
+6. Forma de Pagamento (exibida apenas quando `confirmaInscricoes` está desativado)
+7. Confirmação final do envio
 
 ## Geração de Pedidos
 

--- a/logs/DOC_LOG.md
+++ b/logs/DOC_LOG.md
@@ -535,3 +535,4 @@ na rota /loja/api/inscricoes e documentação atualizada. Lint e build executado
 ## [2025-07-05] Payload de inscricao unificado e documentados campos de cada endpoint. Lint e build executados.
 ## [2025-07-05] ConsultaInscricao preenche e bloqueia campos de CPF e email ao usuario logado. Lint e build executados.
 ## [2025-07-05] ConsultaInscricao prioriza dados do usuário autenticado ao ler parametros de consulta. Documentação atualizada. Lint e build executados.
+## [2025-07-06] Adicionada etapa de Revisão no EventForm e documentação atualizada. Lint e build executados.


### PR DESCRIPTION
## Summary
- show review step in EventForm before final confirmation
- document new `Revisão` step in registration flow
- log documentation update

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_686a88956e78832cba0d3f80dbb3332c