### PR TITLE
Fix missing fields in review step

### DIFF
--- a/components/organisms/EventForm.tsx
+++ b/components/organisms/EventForm.tsx
@@ -239,6 +239,21 @@ export default function EventForm({
       const ok = await createUserRef.current?.submit()
       return Boolean(ok)
     }
+
+    const reviewStepIndex = steps.length - 2
+    if (index === reviewStepIndex) {
+      const missing: string[] = []
+      if (!user?.telefone) missing.push('telefone')
+      if (!user?.data_nascimento) missing.push('data de nascimento')
+      if (!user?.genero && !form.genero) missing.push('gênero')
+      if (missing.length > 0) {
+        showError(
+          `Atualize seu perfil: faltam ${missing.join(', ')} antes de prosseguir.`,
+        )
+        return false
+      }
+    }
+
     return true
   }
 

--- a/components/organisms/EventForm.tsx
+++ b/components/organisms/EventForm.tsx
@@ -431,10 +431,21 @@ export default function EventForm({
           <span className="font-medium">Nome:</span> {user?.nome}
         </p>
         <p>
+          <span className="font-medium">Telefone:</span> {user?.telefone}
+        </p>
+        <p>
           <span className="font-medium">CPF:</span> {user?.cpf}
         </p>
         <p>
           <span className="font-medium">E-mail:</span> {user?.email}
+        </p>
+        <p>
+          <span className="font-medium">Data de Nascimento:</span>{' '}
+          {user?.data_nascimento}
+        </p>
+        <p>
+          <span className="font-medium">Gênero:</span>{' '}
+          {form.genero || user?.genero}
         </p>
         <p>
           <span className="font-medium">Campo:</span>{' '}

--- a/logs/ERR_LOG.md
+++ b/logs/ERR_LOG.md
@@ -245,3 +245,4 @@
 ## [2025-07-05] Login falhava sem redirectTo; fallback para '/' implementado - dev - 75187664
 
 ## [2025-07-05] Removida chamada de login com campos inexistentes apos refatoracao do CreateUserForm; erro de compilacao resolvido - dev - ea109718f369e58f51b00b3994a51ea16c9bee64
+## [2025-07-06] Erro "Todos os campos obrigatórios" ao enviar inscrição sem dados completos. Etapa de revisão agora exibe telefone, nascimento e gênero antes de concluir - dev - 3b2d91f4

--- a/logs/ERR_LOG.md
+++ b/logs/ERR_LOG.md
@@ -246,3 +246,4 @@
 
 ## [2025-07-05] Removida chamada de login com campos inexistentes apos refatoracao do CreateUserForm; erro de compilacao resolvido - dev - ea109718f369e58f51b00b3994a51ea16c9bee64
 ## [2025-07-06] Erro "Todos os campos obrigatórios" ao enviar inscrição sem dados completos. Etapa de revisão agora exibe telefone, nascimento e gênero antes de concluir - dev - 3b2d91f4
+## [2025-07-06] Validação de dados ausentes na etapa de revisão impede erro de campos obrigatórios - dev - 8fd176cd


### PR DESCRIPTION
## Summary
- add telefone, nascimento e gênero no passo de revisão do formulário de inscrição
- registrar correção de campos obrigatórios no `ERR_LOG`

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_686ac31fb468832ca19bca9e99b6ce12