### PR TITLE
Bloqueia status para líderes

### DIFF
--- a/app/admin/inscricoes/componentes/ModalEdit.tsx
+++ b/app/admin/inscricoes/componentes/ModalEdit.tsx
@@ -40,7 +40,9 @@ export default function ModalEditarInscricao({
     const atualizada: Partial<Inscricao & { eventoId: string }> = {
       nome: formData.get('nome')?.toString() || '',
       telefone: formData.get('telefone')?.toString() || '',
-      status: formData.get('status') as 'pendente' | 'confirmado' | 'cancelado',
+      ...(user?.role !== 'lider'
+        ? { status: formData.get('status') as 'pendente' | 'confirmado' | 'cancelado' }
+        : {}),
       tamanho: formData.get('tamanho')?.toString(),
       genero: formData.get('genero')?.toString(),
       eventoId: eventoId || inscricao.eventoId,
@@ -62,7 +64,12 @@ export default function ModalEditarInscricao({
             defaultValue={inscricao.telefone}
           />
 
-          <Select name="status" label="Status" defaultValue={inscricao.status}>
+          <Select
+            name="status"
+            label="Status"
+            defaultValue={inscricao.status}
+            disabled={user?.role === 'lider'}
+          >
             <option value="pendente">Pendente</option>
             <option value="confirmado">Confirmado</option>
             <option value="cancelado">Cancelado</option>
@@ -156,9 +163,10 @@ type SelectProps = {
   label: string
   defaultValue?: string
   children: React.ReactNode
+  disabled?: boolean
 }
 
-function Select({ name, label, defaultValue = '', children }: SelectProps) {
+function Select({ name, label, defaultValue = '', children, disabled }: SelectProps) {
   return (
     <div>
       <label htmlFor={name} className="text-sm font-medium block mb-1">
@@ -169,6 +177,7 @@ function Select({ name, label, defaultValue = '', children }: SelectProps) {
         name={name}
         defaultValue={defaultValue}
         className="w-full p-2 border rounded"
+        disabled={disabled}
       >
         {children}
       </select>

--- a/app/admin/pedidos/componentes/ModalEditarPedido.tsx
+++ b/app/admin/pedidos/componentes/ModalEditarPedido.tsx
@@ -7,9 +7,16 @@ type Props = {
   pedido: Pedido
   onClose: () => void
   onSave: (dadosAtualizados: Partial<Pedido>) => void
+  /** Quando true, o campo status fica somente leitura */
+  disableStatus?: boolean
 }
 
-export default function ModalEditarPedido({ pedido, onClose, onSave }: Props) {
+export default function ModalEditarPedido({
+  pedido,
+  onClose,
+  onSave,
+  disableStatus,
+}: Props) {
   const [formState, setFormState] = useState<Partial<Pedido>>({
     produto: pedido.produto,
     email: pedido.email,
@@ -30,7 +37,8 @@ export default function ModalEditarPedido({ pedido, onClose, onSave }: Props) {
 
   const handleSubmit = async (e: FormEvent<HTMLFormElement>) => {
     e.preventDefault()
-    onSave(formState)
+    const { status, ...rest } = formState
+    onSave(disableStatus ? rest : formState)
   }
 
   return (
@@ -71,6 +79,7 @@ export default function ModalEditarPedido({ pedido, onClose, onSave }: Props) {
             label="Status"
             value={formState.status || ''}
             onChange={handleChange}
+            disabled={disableStatus}
           >
             <option value="pendente">Pendente</option>
             <option value="pago">Pago</option>
@@ -128,9 +137,10 @@ type SelectProps = {
   value: string
   onChange: (e: React.ChangeEvent<HTMLSelectElement>) => void
   children: React.ReactNode
+  disabled?: boolean
 }
 
-function Select({ name, label, value, onChange, children }: SelectProps) {
+function Select({ name, label, value, onChange, children, disabled }: SelectProps) {
   return (
     <div>
       <label htmlFor={name} className="text-sm font-medium block mb-1">
@@ -142,6 +152,7 @@ function Select({ name, label, value, onChange, children }: SelectProps) {
         value={value}
         onChange={onChange}
         className="w-full p-2 border rounded"
+        disabled={disabled}
       >
         {children}
       </select>

--- a/app/admin/pedidos/page.tsx
+++ b/app/admin/pedidos/page.tsx
@@ -408,6 +408,7 @@ export default function PedidosPage() {
       {pedidoSelecionado && (
         <ModalEditarPedido
           pedido={pedidoSelecionado}
+          disableStatus={user?.role === 'lider'}
           onClose={() => setPedidoSelecionado(null)}
           onSave={async (dadosAtualizados) => {
             try {

--- a/app/api/inscricoes/[id]/route.ts
+++ b/app/api/inscricoes/[id]/route.ts
@@ -76,8 +76,12 @@ export async function PATCH(req: NextRequest) {
       )
     }
     const data = await req.json()
+    const payload = { ...data }
+    if (user.role === 'lider') {
+      delete (payload as Record<string, unknown>).status
+    }
     const updated = await pbRetry(() =>
-      pb.collection('inscricoes').update(id, data),
+      pb.collection('inscricoes').update(id, payload),
     )
     logRocketEvent('inscricao_atualizada', {
       inscricaoId: id,

--- a/app/api/pedidos/[id]/route.ts
+++ b/app/api/pedidos/[id]/route.ts
@@ -92,13 +92,16 @@ export async function PATCH(req: NextRequest) {
       )
     }
     const data = await req.json()
-    const updated = await pb.collection('pedidos').update(id, {
+    const updateData: Record<string, unknown> = {
       ...(data.produto !== undefined ? { produto: String(data.produto) } : {}),
       ...(data.email !== undefined ? { email: String(data.email) } : {}),
       ...(data.tamanho !== undefined ? { tamanho: String(data.tamanho) } : {}),
       ...(data.cor !== undefined ? { cor: String(data.cor) } : {}),
-      ...(data.status !== undefined ? { status: String(data.status) } : {}),
-    })
+    }
+    if (user.role !== 'lider' && data.status !== undefined) {
+      updateData.status = String(data.status)
+    }
+    const updated = await pb.collection('pedidos').update(id, updateData)
     return NextResponse.json(updated)
   } catch (err) {
     console.error('Erro ao atualizar pedido:', err)

--- a/docs/regras-inscricoes.md
+++ b/docs/regras-inscricoes.md
@@ -131,5 +131,11 @@ A seguir é feita uma requisição para `/api/inscricoes/public` passando `cpf`,
    é mostrado para criar uma nova inscrição. Ao abrir, o CPF e o e‑mail
    digitados na consulta são repassados ao formulário, poupando o usuário de
    redigitar essas informações. Com o período encerrado, é exibida uma mensagem
-   informando que não é mais possível se inscrever.
+informando que não é mais possível se inscrever.
+
+## Edição de Inscrição
+
+Líderes podem atualizar dados como nome ou tamanho da camiseta, mas **não**
+podem alterar o campo `status` durante a edição. Apenas coordenadores mantêm
+permissão para mudar o status manualmente.
 

--- a/docs/regras-pedidos.md
+++ b/docs/regras-pedidos.md
@@ -43,3 +43,9 @@ Se o pedido permanecer com status `pendente` e o campo `vencimento` estiver expi
 um administrador pode gerar uma nova cobrança pelo botão **Gerar nova cobrança**
 nos detalhes do pedido. O sistema envia a requisição para `/api/pedidos/[id]/nova-cobranca`,
 atualizando o `link_pagamento` e o `vencimento` com mais três dias.
+
+## Edição de Pedido
+
+O líder pode ajustar campos como email ou tamanho do produto, mas **não** tem
+permissão para alterar o `status` do pedido durante a edição. Essa ação fica
+restrita aos coordenadores.

--- a/logs/DOC_LOG.md
+++ b/logs/DOC_LOG.md
@@ -537,3 +537,4 @@ na rota /loja/api/inscricoes e documentação atualizada. Lint e build executado
 ## [2025-07-05] ConsultaInscricao prioriza dados do usuário autenticado ao ler parametros de consulta. Documentação atualizada. Lint e build executados.
 ## [2025-07-06] Adicionada etapa de Revisão no EventForm e documentação atualizada. Lint e build executados.
 ## [2025-07-06] Adicionada nota sobre necessidade de logout para cadastrar outra pessoa em docs/regras-inscricoes.md. Lint e build executados.
+## [2025-07-06] Líder não pode alterar status ao editar inscrição ou pedido. Documentação atualizada.


### PR DESCRIPTION
## Summary
- prevent status field from being sent when leaders edit a Pedido
- add UI guard to keep status read-only for lider
- document that only coordenador can alterar status

## Testing
- `npm run lint` *(fails: `next` not found)*
- `npm run build` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_686ac2ab3434832cb128ef2e206cc9c3