### PR TITLE
Fix lint error in ModalEditarPedido

### DIFF
--- a/app/admin/pedidos/componentes/ModalEditarPedido.tsx
+++ b/app/admin/pedidos/componentes/ModalEditarPedido.tsx
@@ -35,11 +35,14 @@ export default function ModalEditarPedido({
     }))
   }
 
-    const handleSubmit = async (e: FormEvent<HTMLFormElement>) => {
-      e.preventDefault()
-      const { status: _discard, ...rest } = formState
-      onSave(disableStatus ? rest : formState)
+  const handleSubmit = async (e: FormEvent<HTMLFormElement>) => {
+    e.preventDefault()
+    const data = { ...formState }
+    if (disableStatus) {
+      delete data.status
     }
+    onSave(data)
+  }
 
   return (
     <div className="fixed inset-0 bg-black/40 backdrop-blur-sm flex justify-center items-center z-50">


### PR DESCRIPTION
## Summary
- remove unused `_discard` variable in `ModalEditarPedido`

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_686ad1f95884832c87c1419c6710e98b