### PR TITLE
Fix auth cookie load in inscrições API

### DIFF
--- a/app/api/inscricoes/route.ts
+++ b/app/api/inscricoes/route.ts
@@ -47,6 +47,7 @@ export async function GET(req: NextRequest) {
 }
 export async function POST(req: NextRequest) {
   const pb = createPocketBase()
+  pb.authStore.loadFromCookie(req.headers.get('cookie') || '')
   try {
     const body = await req.json()
     const {


### PR DESCRIPTION
## Summary
- preserve auth cookie in inscrições POST route so authenticated user lookups work

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_686bcfef8c98832cabb567d485bf8ec0