### PR TITLE
Fix WhatsApp broadcast docs

### DIFF
--- a/docs/Evolution/ControleEnvioWhatsApp.md
+++ b/docs/Evolution/ControleEnvioWhatsApp.md
@@ -212,11 +212,7 @@ CREATE TABLE whatsapp_broadcast_config (
 ### Executar Testes
 
 ```bash
-# Testes do sistema de filas
-npm test __tests__/api/broadcastQueue.test.ts
-
-# Testes da API de broadcast
-npm test __tests__/api/broadcastRoute.test.ts
+npm test
 ```
 
 ### Cenários Testados

--- a/logs/DOC_LOG.md
+++ b/logs/DOC_LOG.md
@@ -569,3 +569,5 @@ na rota /loja/api/inscricoes e documentação atualizada. Lint e build executado
 
 ## [2025-07-06] Líder não pode alterar status ao editar inscrição ou pedido. Documentação atualizada.
 ## [2025-07-07] Endereço opcional para inscrições; formulários e API atualizados. Documentação revisada.
+
+## [2025-07-07] Atualizada seção de testes em docs/Evolution/ControleEnvioWhatsApp.md; removidas referências a arquivos inexistentes. Lint e build executados.


### PR DESCRIPTION
## Summary
- update *ControleEnvioWhatsApp* doc to remove references to missing tests
- log documentation update

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_686bd2a29774832cadf560204c69ad29