### PR TITLE
Add event filter to inscriptions API

### DIFF
--- a/__tests__/api/inscricoesRoute.test.ts
+++ b/__tests__/api/inscricoesRoute.test.ts
@@ -48,6 +48,33 @@ describe('GET /api/inscricoes', () => {
     )
   })
 
+  it('filtra por evento quando informado', async () => {
+    ;(
+      requireRole as unknown as { mockReturnValue: (v: any) => void }
+    ).mockReturnValue({
+      pb,
+      user: { id: 'u1', role: 'usuario' },
+    })
+    const req = new Request(
+      'http://test/api/inscricoes?status=pendente&evento=ev1',
+    )
+    ;(req as any).nextUrl = new URL(
+      'http://test/api/inscricoes?status=pendente&evento=ev1',
+    )
+    const res = await GET(req as unknown as NextRequest)
+    expect(res.status).toBe(200)
+    await res.json()
+    expect(getListMock).toHaveBeenLastCalledWith(
+      1,
+      50,
+      expect.objectContaining({
+        filter: 'criado_por = "u1" && status=\'pendente\' && evento=\'ev1\'',
+        expand: 'evento,campo,pedido,produto',
+        sort: '-created',
+      }),
+    )
+  })
+
   it('usa page da URL quando informado', async () => {
     ;(
       requireRole as unknown as { mockReturnValue: (v: any) => void }

--- a/app/api/inscricoes/route.ts
+++ b/app/api/inscricoes/route.ts
@@ -16,6 +16,7 @@ export async function GET(req: NextRequest) {
   const page = Number(req.nextUrl.searchParams.get('page') || '1')
   const perPage = Number(req.nextUrl.searchParams.get('perPage') || '50')
   const status = req.nextUrl.searchParams.get('status') || ''
+  const eventoId = req.nextUrl.searchParams.get('evento') || ''
   try {
     let baseFilter = ''
     if (user.role === 'usuario') {
@@ -32,7 +33,10 @@ export async function GET(req: NextRequest) {
       }
       baseFilter = `cliente = "${tenantId}"`
     }
-    const filtro = status ? `${baseFilter} && status='${status}'` : baseFilter
+    const filtroParts = [baseFilter]
+    if (status) filtroParts.push(`status='${status}'`)
+    if (eventoId) filtroParts.push(`evento='${eventoId}'`)
+    const filtro = filtroParts.filter(Boolean).join(' && ')
     const sortParam = req.nextUrl.searchParams.get('sort') || '-created'
     const result = await pb.collection('inscricoes').getList(page, perPage, {
       filter: filtro,


### PR DESCRIPTION
## Summary
- support filtering inscriptions by event in `GET /api/inscricoes`
- cover new filter with unit test

## Testing
- `npm run lint` *(fails: next not found)*
- `npm run build` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_686bd1b85f54832cbb0cd0d4b48f21ac