### PR TITLE
Implement LogRocket logging for /recuperar

### DIFF
--- a/__tests__/api/recuperarLinkRoute.test.ts
+++ b/__tests__/api/recuperarLinkRoute.test.ts
@@ -3,6 +3,11 @@ import { POST } from '../../app/api/recuperar-link/route'
 import { NextRequest } from 'next/server'
 import createPocketBaseMock from '../mocks/pocketbase'
 
+vi.mock('../../lib/server/logger', () => ({
+  logConciliacaoErro: vi.fn(),
+  logRocketEvent: vi.fn(),
+}))
+
 const pb = createPocketBaseMock()
 const getFirstCobranca = vi.fn()
 const getFirstInscricao = vi.fn()


### PR DESCRIPTION
## Summary
- log `/recuperar` activity to LogRocket
- mock logger in recuperar link route test

## Testing
- `npm run lint`
- `npm run build`
- `npm test` *(fails: 27 failed, 50 passed)*

------
https://chatgpt.com/codex/tasks/task_e_686bdd0efe80832c9473c9eb0c8078ee