### PR TITLE
Atualiza rotas de mensagem para enfileirar envios

### DIFF
--- a/app/api/chats/message/sendPayment/route.ts
+++ b/app/api/chats/message/sendPayment/route.ts
@@ -48,7 +48,7 @@ export async function POST(req: NextRequest) {
   try {
     const finalMessage =
       message ?? `Para concluir seu pagamento, acesse: ${link}`
-    const result = await queueTextMessage(
+    queueTextMessage(
       {
         tenant,
         instanceName: rec.instanceName,
@@ -58,7 +58,10 @@ export async function POST(req: NextRequest) {
       },
       false,
     )
-    return NextResponse.json(result, { status: 200 })
+    return NextResponse.json(
+      { message: 'mensagem enfileirada' },
+      { status: 200 },
+    )
   } catch (err: unknown) {
     const message = err instanceof Error ? err.message : 'Erro desconhecido'
     return NextResponse.json({ error: message }, { status: 500 })

--- a/app/api/chats/message/sendText/[instanceName]/route.ts
+++ b/app/api/chats/message/sendText/[instanceName]/route.ts
@@ -54,7 +54,7 @@ export async function POST(
 
   // 3) envia mensagem com controle
   try {
-    const result = await queueTextMessage(
+    queueTextMessage(
       {
         tenant,
         instanceName,
@@ -64,7 +64,10 @@ export async function POST(
       },
       false,
     )
-    return NextResponse.json(result, { status: 200 })
+    return NextResponse.json(
+      { message: 'mensagem enfileirada' },
+      { status: 200 },
+    )
   } catch (err: unknown) {
     console.error('[sendText] sendTextMessage error:', err)
     const message = err instanceof Error ? err.message : 'Erro desconhecido'

--- a/app/api/chats/message/sendWelcome/route.ts
+++ b/app/api/chats/message/sendWelcome/route.ts
@@ -103,7 +103,7 @@ export async function POST(req: NextRequest) {
         message = ''
     }
 
-    const result = await queueTextMessage(
+    queueTextMessage(
       {
         tenant: tenantId,
         instanceName: waCfg.instanceName,
@@ -114,7 +114,10 @@ export async function POST(req: NextRequest) {
       false,
     )
 
-    return NextResponse.json(result, { status: 200 })
+    return NextResponse.json(
+      { message: 'mensagem enfileirada' },
+      { status: 200 },
+    )
   } catch (err: unknown) {
     const msg = err instanceof Error ? err.message : 'Erro desconhecido'
     return NextResponse.json({ error: msg }, { status: 500 })

--- a/app/api/chats/whatsapp/message/sendTest/[instanceName]/route.ts
+++ b/app/api/chats/whatsapp/message/sendTest/[instanceName]/route.ts
@@ -60,7 +60,7 @@ export async function POST(
 
   // 6) envia com controle
   try {
-    const result = await queueTextMessage(
+    queueTextMessage(
       {
         tenant,
         instanceName,
@@ -76,7 +76,10 @@ export async function POST(
       .collection('whatsapp_clientes')
       .update(rec.id, { config_finished: true })
 
-    return NextResponse.json({ ok: true, result }, { status: 200 })
+    return NextResponse.json(
+      { message: 'mensagem enfileirada' },
+      { status: 200 },
+    )
   } catch (err: unknown) {
     console.error('[sendTest] erro ao enviar teste:', err)
     const message = err instanceof Error ? err.message : 'Erro desconhecido'

--- a/logs/ERR_LOG.md
+++ b/logs/ERR_LOG.md
@@ -269,3 +269,6 @@
 ## [2025-07-06] Etapa de revisão exibe ícone de edição para ajustar dados antes do envio - dev - 6d8ffadc
 
 ## [2025-07-06] Revisão inclui endereço completo e valida ausência antes do envio - dev - 3968f02f
+## [2025-07-07] Build falhou devido a 'Unexpected character' ao compilar template.md?raw - dev
+## [2025-07-07] Erro ao criar pedido: TypeError: Cannot read properties of undefined (reading 'id') - test
+## [2025-07-07] Erro ao gerar link de pagamento Asaas: TypeError: cobrancaResponse.clone is not a function - test


### PR DESCRIPTION
## Summary
- remove `await` ao enfileirar mensagens no WhatsApp
- retorna resposta padronizada nas rotas de chat
- registra falha de build em `ERR_LOG.md`

## Testing
- `npm run lint`
- `npm run build` *(falha: Module parse failed: Unexpected character)*

------
https://chatgpt.com/codex/tasks/task_e_686c0e241aec832c8ffe1421ed4979bb