### PR TITLE
Fix MD import typing

### DIFF
--- a/types/md.d.ts
+++ b/types/md.d.ts
@@ -1,0 +1,4 @@
+declare module '*.md' {
+  const content: string
+  export default content
+}


### PR DESCRIPTION
## Summary
- declare `*.md` modules as strings

## Testing
- `npm run lint`
- `npm run build`
- `npm test` *(fails: Expression expected, [vitest] No "useSearchParams" export defined)*

------
https://chatgpt.com/codex/tasks/task_e_686c18cbd304832c809542a366b189b8