### PR TITLE
Fix DashboardAnalytics build error

### DIFF
--- a/app/admin/components/DashboardAnalytics.tsx
+++ b/app/admin/components/DashboardAnalytics.tsx
@@ -1,20 +1,22 @@
 'use client'
 
 import { useEffect, useState, useRef } from 'react'
-import { useEffect, useState, useRef } from 'react'
 import { setupCharts } from '@/lib/chartSetup'
-import { Line, Bar } from 'react-chartjs-2'
+import dynamic from 'next/dynamic'
 import { saveAs } from 'file-saver'
 import * as XLSX from 'xlsx'
-import type { Chart as ChartJS } from 'chart.js'
-import { generateDashboardPdf } from '@/lib/report/generateDashboardPdf'
-import { useToast } from '@/lib/context/ToastContext'
-import type { Chart as ChartJS } from 'chart.js'
+import type { Chart } from 'chart.js'
 import { generateDashboardPdf } from '@/lib/report/generateDashboardPdf'
 import { useToast } from '@/lib/context/ToastContext'
 import type { Inscricao, Pedido } from '@/types'
 import twColors from '@/utils/twColors'
 
+const LineChart = dynamic(() => import('react-chartjs-2').then((m) => m.Line), {
+  ssr: false,
+})
+const BarChart = dynamic(() => import('react-chartjs-2').then((m) => m.Bar), {
+  ssr: false,
+})
 
 interface DashboardAnalyticsProps {
   inscricoes: Inscricao[]
@@ -120,41 +122,9 @@ export default function DashboardAnalytics({
 
   const { showError } = useToast()
 
-  const inscricoesRef = useRef<ChartJS | null>(null)
-  const pedidosRef = useRef<ChartJS | null>(null)
-  const arrecadacaoRef = useRef<ChartJS | null>(null)
-
-  const handleExportPDF = async () => {
-    const charts = {
-      inscricoes: inscricoesRef.current?.toBase64Image(),
-      pedidos: pedidosRef.current?.toBase64Image(),
-      arrecadacao: mostrarFinanceiro
-        ? arrecadacaoRef.current?.toBase64Image()
-        : undefined,
-    }
-
-    const metrics = {
-      labels: inscricoesData.labels,
-      inscricoes: inscricoesData.data,
-      pedidos: pedidosData.data,
-      mediaValor,
-      arrecadacao: arrecadacaoCampo,
-    }
-
-    try {
-      await generateDashboardPdf(metrics, { start: startDate, end: endDate }, charts)
-    } catch (err) {
-      console.error('Erro ao gerar PDF', err)
-      const message =
-        err instanceof Error && err.message.includes('Tempo')
-          ? 'Tempo esgotado ao gerar PDF.'
-          : 'Não foi possível gerar o PDF. Tente novamente.'
-      showError(message)
-  const { showError } = useToast()
-
-  const inscricoesRef = useRef<ChartJS | null>(null)
-  const pedidosRef = useRef<ChartJS | null>(null)
-  const arrecadacaoRef = useRef<ChartJS | null>(null)
+  const inscricoesRef = useRef<Chart<'line'> | null>(null)
+  const pedidosRef = useRef<Chart<'line'> | null>(null)
+  const arrecadacaoRef = useRef<Chart<'bar'> | null>(null)
 
   const handleExportPDF = async () => {
     const charts = {
@@ -246,7 +216,8 @@ export default function DashboardAnalytics({
             Evolução de Inscrições
           </h4>
           <div className="aspect-video">
-            <Line
+            <LineChart
+              ref={inscricoesRef}
               data={inscricoesChart}
               options={{ responsive: true, maintainAspectRatio: false }}
             />
@@ -257,7 +228,8 @@ export default function DashboardAnalytics({
             Evolução de Pedidos
           </h4>
           <div className="aspect-video">
-            <Line
+            <LineChart
+              ref={pedidosRef}
               data={pedidosChart}
               options={{ responsive: true, maintainAspectRatio: false }}
             />
@@ -279,7 +251,8 @@ export default function DashboardAnalytics({
               Arrecadação por Campo
             </h4>
             <div className="aspect-video">
-              <Bar
+              <BarChart
+                ref={arrecadacaoRef}
                 data={arrecadacaoChart}
                 options={{ responsive: true, maintainAspectRatio: false }}
               />

--- a/app/admin/relatorios/page.tsx
+++ b/app/admin/relatorios/page.tsx
@@ -13,6 +13,8 @@ export default function RelatoriosPage() {
   const [pedidos, setPedidos] = useState<Pedido[]>([])
   const [totalInscricoes, setTotalInscricoes] = useState(0)
   const [totalPedidos, setTotalPedidos] = useState(0)
+  const [filtroStatus, setFiltroStatus] = useState('pago')
+  const [filtroInscricoes, setFiltroInscricoes] = useState('pendente')
   const [loading, setLoading] = useState(true)
   const [error, setError] = useState<string | null>(null)
   const isMounted = useRef(true)
@@ -172,8 +174,10 @@ export default function RelatoriosPage() {
           <DashboardResumo
             inscricoes={inscricoes}
             pedidos={pedidos}
-            filtroStatus="pago"
-            setFiltroStatus={() => {}}
+            filtroStatus={filtroStatus}
+            filtroInscricoes={filtroInscricoes}
+            setFiltroInscricoes={setFiltroInscricoes}
+            setFiltroStatus={setFiltroStatus}
             totalInscricoes={totalInscricoes}
             totalPedidos={totalPedidos}
           />

--- a/logs/DOC_LOG.md
+++ b/logs/DOC_LOG.md
@@ -576,3 +576,4 @@ na rota /loja/api/inscricoes e documentação atualizada. Lint e build executado
 ## [2025-07-07] Rota /api/recuperar-link passa a retornar `link_pagamento`. Documentação e testes atualizados. Lint e build executados.
 ## [2025-07-07] Recuperacao de link busca pedido pendente quando inscricao em aguardando_pagamento. Documentação e testes atualizados. Lint e build executados.
 ## [2025-07-07] Relatório do dashboard movido para util generateDashboardPdf com template editável. Lint e build executados.
+## [2025-07-08] Corrigido DashboardAnalytics e filtros do relatório. Lint e build executados.

--- a/logs/ERR_LOG.md
+++ b/logs/ERR_LOG.md
@@ -272,3 +272,4 @@
 ## [2025-07-07] Build falhou devido a 'Unexpected character' ao compilar template.md?raw - dev
 ## [2025-07-07] Erro ao criar pedido: TypeError: Cannot read properties of undefined (reading 'id') - test
 ## [2025-07-07] Erro ao gerar link de pagamento Asaas: TypeError: cobrancaResponse.clone is not a function - test
+## [2025-07-08] Erro no painel devido a código duplicado em DashboardAnalytics.tsx - dev - resolvido restaurando arquivo e tipagens.


### PR DESCRIPTION
## Summary
- restore DashboardAnalytics without duplicate code
- adjust chart ref typing
- add missing filters to reports page
- update error and doc logs

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_686c5dfe5cb0832cab6db5611dcde086