### PR TITLE
Implement admin profile edit page

### DIFF
--- a/app/admin/perfil/editar/page.tsx
+++ b/app/admin/perfil/editar/page.tsx
@@ -1,0 +1,225 @@
+'use client'
+
+import { useEffect, useState } from 'react'
+import { useRouter } from 'next/navigation'
+import { useAuthGuard } from '@/lib/hooks/useAuthGuard'
+import { useToast } from '@/lib/context/ToastContext'
+import { FormField, TextField, InputWithMask } from '@/components'
+
+export default function EditarPerfilPage() {
+  const { user, authChecked } = useAuthGuard(['coordenador', 'lider'])
+  const { showSuccess, showError } = useToast()
+  const router = useRouter()
+
+  const [nome, setNome] = useState('')
+  const [telefone, setTelefone] = useState('')
+  const [cpf, setCpf] = useState('')
+  const [dataNascimento, setDataNascimento] = useState('')
+  const [endereco, setEndereco] = useState('')
+  const [bairro, setBairro] = useState('')
+  const [numero, setNumero] = useState('')
+  const [estado, setEstado] = useState('')
+  const [cep, setCep] = useState('')
+  const [cidade, setCidade] = useState('')
+
+  useEffect(() => {
+    if (user) {
+      setNome(String(user.nome ?? ''))
+      setTelefone(String(user.telefone ?? ''))
+      setCpf(String(user.cpf ?? ''))
+      setDataNascimento(String(user.data_nascimento ?? ''))
+      setEndereco(String(user.endereco ?? ''))
+      setBairro(String(user.bairro ?? ''))
+      setNumero(String(user.numero ?? ''))
+      setEstado(String(user.estado ?? ''))
+      setCep(String(user.cep ?? ''))
+      setCidade(String(user.cidade ?? ''))
+    }
+  }, [user])
+
+  async function handleSave(e: React.FormEvent) {
+    e.preventDefault()
+    if (!user?.id) {
+      showError('Sess\u00e3o inv\u00e1lida.')
+      return
+    }
+    try {
+      await fetch(`/api/usuarios/${user.id}`, {
+        method: 'PATCH',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          nome: nome.trim(),
+          telefone: telefone.trim(),
+          cpf: cpf.trim(),
+          data_nascimento: dataNascimento,
+          endereco: endereco.trim(),
+          bairro: bairro.trim(),
+          numero: numero.trim(),
+          estado: estado.trim(),
+          cep: cep.trim(),
+          cidade: cidade.trim(),
+        }),
+      })
+      showSuccess('Perfil atualizado com sucesso.')
+      router.push('/admin/perfil')
+    } catch (err) {
+      console.error(err)
+      showError('Erro ao atualizar perfil. Verifique os dados.')
+    }
+  }
+
+  if (!authChecked) return null
+
+  const inputStyle =
+    'w-full border border-gray-300 dark:border-zinc-700 bg-white dark:bg-zinc-800 p-2 rounded'
+
+  return (
+    <form
+      onSubmit={handleSave}
+      className="max-w-md mx-auto mt-10 p-6 bg-white dark:bg-zinc-900 rounded-xl shadow space-y-5"
+    >
+      <h1 className="text-xl font-semibold text-center">Editar Perfil</h1>
+
+      <FormField label="Nome completo" htmlFor="perfil-nome">
+        <TextField
+          id="perfil-nome"
+          type="text"
+          placeholder="Nome completo"
+          className={inputStyle}
+          value={nome}
+          onChange={(e) => setNome(e.target.value)}
+        />
+      </FormField>
+
+      <FormField label="Telefone" htmlFor="perfil-telefone">
+        <InputWithMask
+          id="perfil-telefone"
+          type="text"
+          mask="telefone"
+          placeholder="Telefone"
+          className={inputStyle}
+          value={telefone}
+          onChange={(e) => setTelefone(e.target.value)}
+        />
+      </FormField>
+
+      <FormField label="CPF" htmlFor="perfil-cpf">
+        <InputWithMask
+          id="perfil-cpf"
+          type="text"
+          mask="cpf"
+          placeholder="CPF"
+          className={inputStyle}
+          value={cpf}
+          onChange={(e) => setCpf(e.target.value)}
+        />
+      </FormField>
+
+      <FormField label="Data de nascimento" htmlFor="perfil-data">
+        <TextField
+          id="perfil-data"
+          type="date"
+          className={inputStyle}
+          value={dataNascimento}
+          onChange={(e) => setDataNascimento(e.target.value)}
+        />
+      </FormField>
+
+      <FormField label="Endere\u00e7o" htmlFor="perfil-endereco">
+        <TextField
+          id="perfil-endereco"
+          type="text"
+          placeholder="Endere\u00e7o"
+          className={inputStyle}
+          value={endereco}
+          onChange={(e) => setEndereco(e.target.value)}
+        />
+      </FormField>
+
+      <FormField label="Bairro" htmlFor="perfil-bairro">
+        <TextField
+          id="perfil-bairro"
+          type="text"
+          placeholder="Bairro"
+          className={inputStyle}
+          value={bairro}
+          onChange={(e) => setBairro(e.target.value)}
+        />
+      </FormField>
+
+      <FormField label="N\u00famero" htmlFor="perfil-numero">
+        <TextField
+          id="perfil-numero"
+          type="text"
+          placeholder="N\u00famero"
+          className={inputStyle}
+          value={numero}
+          onChange={(e) => setNumero(e.target.value)}
+        />
+      </FormField>
+
+      <FormField label="Estado" htmlFor="perfil-estado">
+        <TextField
+          id="perfil-estado"
+          type="text"
+          placeholder="Estado"
+          className={inputStyle}
+          value={estado}
+          onChange={(e) => setEstado(e.target.value)}
+        />
+      </FormField>
+
+      <FormField label="CEP" htmlFor="perfil-cep">
+        <TextField
+          id="perfil-cep"
+          type="text"
+          placeholder="CEP"
+          className={inputStyle}
+          value={cep}
+          onChange={(e) => setCep(e.target.value)}
+        />
+      </FormField>
+
+      <FormField label="Cidade" htmlFor="perfil-cidade">
+        <TextField
+          id="perfil-cidade"
+          type="text"
+          placeholder="Cidade"
+          className={inputStyle}
+          value={cidade}
+          onChange={(e) => setCidade(e.target.value)}
+        />
+      </FormField>
+
+      <FormField label="E-mail" htmlFor="perfil-email" className="opacity-60">
+        <TextField
+          id="perfil-email"
+          type="email"
+          disabled
+          value={String(user?.email || '')}
+          className={`${inputStyle} cursor-not-allowed`}
+        />
+        <p className="text-xs text-zinc-500 dark:text-zinc-400 mt-1">
+          O e-mail n\u00e3o pode ser alterado. Para mudan\u00e7as, entre em contato com o suporte.
+        </p>
+      </FormField>
+
+      <div className="flex justify-end gap-2 pt-2">
+        <button
+          type="button"
+          className="text-sm text-gray-600 dark:text-gray-300"
+          onClick={() => router.push('/admin/perfil')}
+        >
+          Cancelar
+        </button>
+        <button
+          type="submit"
+          className="bg-black dark:bg-white text-white dark:text-black text-sm px-4 py-2 rounded-lg"
+        >
+          Salvar
+        </button>
+      </div>
+    </form>
+  )
+}
+

--- a/app/admin/perfil/page.tsx
+++ b/app/admin/perfil/page.tsx
@@ -1,8 +1,8 @@
 'use client'
 
 import { useEffect, useMemo, useState } from 'react'
+import Link from 'next/link'
 import { useAuthGuard } from '@/lib/hooks/useAuthGuard'
-import ModalEditarPerfil from './components/ModalEditarPerfil'
 import createPocketBase from '@/lib/pocketbase'
 
 interface UsuarioAuthModel {
@@ -35,7 +35,6 @@ export default function PerfilPage() {
   const [usuario, setUsuario] = useState<UsuarioAuthModel | null>(
     usuarioGuard as UsuarioAuthModel | null,
   )
-  const [mostrarModal, setMostrarModal] = useState(false)
 
   useEffect(() => {
     if (usuarioGuard) {
@@ -43,11 +42,6 @@ export default function PerfilPage() {
     }
   }, [usuarioGuard])
 
-  // Atualiza local após edição
-  const atualizarDados = () => {
-    const model = pb.authStore.model as unknown as UsuarioAuthModel
-    setUsuario(model)
-  }
 
   if (!authChecked) {
     return (
@@ -79,22 +73,13 @@ export default function PerfilPage() {
       </div>
 
       <div className="flex justify-end">
-        <button
-          onClick={() => setMostrarModal(true)}
+        <Link
+          href="/admin/perfil/editar"
           className="bg-black dark:bg-white text-white dark:text-black px-4 py-2 rounded-lg hover:opacity-90"
         >
           Editar Perfil
-        </button>
+        </Link>
       </div>
-
-      {mostrarModal && (
-        <ModalEditarPerfil
-          onClose={() => {
-            setMostrarModal(false)
-            atualizarDados()
-          }}
-        />
-      )}
     </div>
   )
 }


### PR DESCRIPTION
## Summary
- remove profile modal usage from admin profile
- add dedicated admin edit profile page

## Testing
- `npm run lint` *(fails: `next` not found)*
- `npm run build` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_686c8280fa78832c8ccde6c98a192bcb