### PR TITLE
Fix leader confirm inscription flow

### DIFF
--- a/services/gateway/app/api/inscricoes/[id]/route.ts
+++ b/services/gateway/app/api/inscricoes/[id]/route.ts
@@ -78,7 +78,13 @@ export async function PATCH(req: NextRequest) {
     const data = await req.json()
     const payload = { ...data }
     if (user.role === 'lider') {
-      delete (payload as Record<string, unknown>).status
+      const allowed = ['aguardando_pagamento', 'cancelado']
+      if (
+        'status' in payload &&
+        !allowed.includes((payload as { status?: string }).status ?? '')
+      ) {
+        delete (payload as Record<string, unknown>).status
+      }
     }
     const updated = await pbRetry(() =>
       pb.collection('inscricoes').update(id, payload),

--- a/services/gateway/logs/ERR_LOG.md
+++ b/services/gateway/logs/ERR_LOG.md
@@ -277,3 +277,4 @@
 ## [2025-07-07] Erro ao gerar link de pagamento Asaas: TypeError: cobrancaResponse.clone is not a function - test
 
 ## [2025-07-08] Erro no painel devido a código duplicado em DashboardAnalytics.tsx - dev - resolvido restaurando arquivo e tipagens.
+## [2025-07-08] Ajustado PATCH de inscrição para permitir alteração de status pelo líder para 'aguardando_pagamento' ou 'cancelado' - dev - 5499c4b0


### PR DESCRIPTION
## Summary
- allow leaders to update status when confirming inscription
- log the patch fix in ERR_LOG

## Testing
- `npm run lint` *(fails: Cannot read config "next/core-web-vitals")*
- `npm run build` *(fails: Module not found '@/lib/context/ToastContext')*

------
https://chatgpt.com/codex/tasks/task_e_686d1c56a6dc832ca7057810000d2f79