### PR TITLE
Fix modal overflow in signup flow

### DIFF
--- a/app/admin/inscricoes/componentes/ModalEdit.tsx
+++ b/app/admin/inscricoes/componentes/ModalEdit.tsx
@@ -59,7 +59,7 @@ export default function ModalEditarInscricao({
 
   return (
     <div className="fixed inset-0 bg-black/40 backdrop-blur-sm flex justify-center items-center z-50">
-      <div className="bg-white p-6 rounded shadow-md w-full max-w-md">
+      <div className="bg-white p-6 rounded shadow-md w-full max-w-md max-h-screen overflow-y-auto">
         <h3 className="text-lg font-bold mb-4">Editar Inscrição</h3>
         <form onSubmit={handleSubmit} className="space-y-3">
           <Input name="nome" label="Nome" defaultValue={inscricao.nome} />

--- a/app/admin/inscricoes/componentes/ModalVisualizarPedido.tsx
+++ b/app/admin/inscricoes/componentes/ModalVisualizarPedido.tsx
@@ -154,7 +154,7 @@ export default function ModalVisualizarPedido({ pedidoId, onClose }: Props) {
 
   return (
     <div className="fixed inset-0 z-50 bg-black bg-opacity-30 flex items-center justify-center px-2">
-      <div className="bg-white rounded-lg shadow-xl p-6 w-full max-w-md relative">
+      <div className="bg-white rounded-lg shadow-xl p-6 w-full max-w-md relative max-h-screen overflow-y-auto">
         <button
           onClick={onClose}
           className="absolute top-3 right-3 text-gray-500"

--- a/app/admin/pedidos/componentes/ModalEditarPedido.tsx
+++ b/app/admin/pedidos/componentes/ModalEditarPedido.tsx
@@ -46,7 +46,7 @@ export default function ModalEditarPedido({
 
   return (
     <div className="fixed inset-0 bg-black/40 backdrop-blur-sm flex justify-center items-center z-50">
-      <div className="bg-white p-6 rounded shadow-md w-full max-w-md">
+      <div className="bg-white p-6 rounded shadow-md w-full max-w-md max-h-screen overflow-y-auto">
         <h3 className="text-lg font-bold mb-4">Editar Pedido</h3>
         <form onSubmit={handleSubmit} className="space-y-3">
           <Input

--- a/app/admin/perfil/components/ModalEditarPerfil.tsx
+++ b/app/admin/perfil/components/ModalEditarPerfil.tsx
@@ -80,7 +80,7 @@ export default function ModalEditarPerfil({
                   initial={{ opacity: 0, scale: 0.95 }}
                   animate={{ opacity: 1, scale: 1 }}
                   exit={{ opacity: 0, scale: 0.95 }}
-                  className="bg-white dark:bg-zinc-900 text-black dark:text-white p-6 rounded-xl shadow-xl w-full max-w-md space-y-5"
+                  className="bg-white dark:bg-zinc-900 text-black dark:text-white p-6 rounded-xl shadow-xl w-full max-w-md space-y-5 max-h-screen overflow-y-auto"
                 >
                   <Dialog.Description className="sr-only">
                     Formulário de perfil

--- a/logs/ERR_LOG.md
+++ b/logs/ERR_LOG.md
@@ -274,3 +274,4 @@
 ## [2025-07-07] Erro ao gerar link de pagamento Asaas: TypeError: cobrancaResponse.clone is not a function - test
 ## [2025-07-08] Erro no painel devido a código duplicado em DashboardAnalytics.tsx - dev - resolvido restaurando arquivo e tipagens.
 ## [2025-07-08] Líder não conseguia definir status "aguardando_pagamento" ao confirmar inscrição. PATCH /api/inscricoes/[id] agora permite esse valor. - dev
+## [2025-07-08] Modal de edição excedia altura da tela no fluxo de inscrição, impedindo salvar ou cancelar. Adicionado overflow-y-auto e max-h-screen nos modais de edição. - prod - bca77d01a1630e5dd09ae4e9579e9a71d3341df3


### PR DESCRIPTION
## Summary
- ensure edit modals scroll when content exceeds screen
- record fix in error log

## Testing
- `npm run lint` *(fails: next not found)*
- `npm run build` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_686d4ee63e18832c96512da9e081901a