### PR TITLE
Melhora job de pedidos vencidos com retries

### DIFF
--- a/app/api/tasks/pedidos-vencidos/route.ts
+++ b/app/api/tasks/pedidos-vencidos/route.ts
@@ -1,0 +1,32 @@
+import { NextResponse } from 'next/server'
+import createPocketBase from '@/lib/pocketbase'
+import { pbRetry } from '@/lib/pbRetry'
+
+export const config = { runtime: 'nodejs' }
+
+export async function GET(): Promise<NextResponse> {
+  const pb = createPocketBase()
+  if (!pb.authStore.isValid) {
+    await pbRetry(() =>
+      pb.admins.authWithPassword(
+        process.env.PB_ADMIN_EMAIL!,
+        process.env.PB_ADMIN_PASSWORD!,
+      ),
+    )
+  }
+
+  const now = new Date().toISOString()
+  const pendentes = await pbRetry(() =>
+    pb.collection('pedidos').getFullList(200, {
+      filter: `status='pendente' && vencimento != '' && vencimento < "${now}"`,
+    }),
+  )
+
+  for (const pedido of pendentes) {
+    await pbRetry(() =>
+      pb.collection('pedidos').update(pedido.id, { status: 'vencido' }),
+    )
+  }
+
+  return NextResponse.json({ atualizados: pendentes.length })
+}

--- a/docs/regras-pedidos.md
+++ b/docs/regras-pedidos.md
@@ -44,6 +44,14 @@ um administrador pode gerar uma nova cobrança pelo botão **Gerar nova cobranç
 nos detalhes do pedido. O sistema envia a requisição para `/api/pedidos/[id]/nova-cobranca`,
 atualizando o `link_pagamento` e o `vencimento` com mais três dias.
 
+### Atualização automática de vencimento
+
+Um job agendado chama `/api/tasks/pedidos-vencidos` a cada hora.
+Ele verifica pedidos com `status = pendente` cujo `vencimento` já
+passou e atualiza para `vencido`.
+As operações de atualização utilizam `pbRetry` para prevenir perdas de
+conexão com o PocketBase.
+
 ## Edição de Pedido
 
 O líder pode ajustar campos como email ou tamanho do produto, mas **não** tem

--- a/logs/DOC_LOG.md
+++ b/logs/DOC_LOG.md
@@ -568,3 +568,5 @@ na rota /loja/api/inscricoes e documentação atualizada. Lint e build executado
 ## [2025-07-06] Adicionada nota sobre necessidade de logout para cadastrar outra pessoa em docs/regras-inscricoes.md. Lint e build executados.
 
 ## [2025-07-06] Líder não pode alterar status ao editar inscrição ou pedido. Documentação atualizada.
+## [2025-08-18] Criado job `/api/tasks/pedidos-vencidos` e documentado fluxo automático de vencimento. Lint e build executados.
+## [2025-08-19] Job de vencimento usa `pbRetry` para evitar perda de conexão com o PocketBase. Documentação atualizada. Lint e build executados.

--- a/vercel.json
+++ b/vercel.json
@@ -3,12 +3,20 @@
     "app/api/tasks/worker/route.ts": {
       "runtime": "vercel-node@2.20.0",
       "maxDuration": 300
+    },
+    "app/api/tasks/pedidos-vencidos/route.ts": {
+      "runtime": "vercel-node@2.20.0",
+      "maxDuration": 300
     }
   },
   "crons": [
     {
       "path": "/api/tasks/worker",
       "schedule": "*/1 * * * *"
+    },
+    {
+      "path": "/api/tasks/pedidos-vencidos",
+      "schedule": "0 * * * *"
     }
   ]
 }


### PR DESCRIPTION
## Summary
- usa `pbRetry` na autenticacao e na atualizacao dos pedidos vencidos
- documenta o uso de retry no job
- registra alteracao no `DOC_LOG.md`

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_686ae40fe59c832ca5a9b7e2b635275e