### PR TITLE
Add Vercel Speed Insights

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -9,6 +9,7 @@ import { generatePrimaryShades } from '@/utils/primaryShades'
 import { fetchTenantConfig } from '@/lib/fetchTenantConfig'
 import { CartProvider } from '@/lib/context/CartContext'
 import LogRocketInit from '@/components/utils/LogRocketInit'
+import { SpeedInsights } from '@vercel/speed-insights/next'
 
 export const metadata = {
   icons: {
@@ -59,6 +60,7 @@ export default async function RootLayout({
             </AuthProvider>
           </ThemeProvider>
         </TenantProvider>
+        <SpeedInsights />
       </body>
     </html>
   )

--- a/package-lock.json
+++ b/package-lock.json
@@ -17,6 +17,7 @@
         "@tiptap/extension-link": "^2.14.0",
         "@tiptap/react": "^2.14.0",
         "@tiptap/starter-kit": "^2.14.0",
+        "@vercel/speed-insights": "^1.2.0",
         "chart.js": "^4.4.9",
         "color-name": "^2.0.0",
         "file-saver": "^2.0.5",
@@ -6184,6 +6185,41 @@
       "os": [
         "win32"
       ]
+    },
+    "node_modules/@vercel/speed-insights": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@vercel/speed-insights/-/speed-insights-1.2.0.tgz",
+      "integrity": "sha512-y9GVzrUJ2xmgtQlzFP2KhVRoCglwfRQgjyfY607aU0hh0Un6d0OUyrJkjuAlsV18qR4zfoFPs/BiIj9YDS6Wzw==",
+      "hasInstallScript": true,
+      "license": "Apache-2.0",
+      "peerDependencies": {
+        "@sveltejs/kit": "^1 || ^2",
+        "next": ">= 13",
+        "react": "^18 || ^19 || ^19.0.0-rc",
+        "svelte": ">= 4",
+        "vue": "^3",
+        "vue-router": "^4"
+      },
+      "peerDependenciesMeta": {
+        "@sveltejs/kit": {
+          "optional": true
+        },
+        "next": {
+          "optional": true
+        },
+        "react": {
+          "optional": true
+        },
+        "svelte": {
+          "optional": true
+        },
+        "vue": {
+          "optional": true
+        },
+        "vue-router": {
+          "optional": true
+        }
+      }
     },
     "node_modules/@vitejs/plugin-react": {
       "version": "4.5.2",

--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
     "@tiptap/extension-link": "^2.14.0",
     "@tiptap/react": "^2.14.0",
     "@tiptap/starter-kit": "^2.14.0",
+    "@vercel/speed-insights": "^1.2.0",
     "chart.js": "^4.4.9",
     "color-name": "^2.0.0",
     "file-saver": "^2.0.5",


### PR DESCRIPTION
## Summary
- install `@vercel/speed-insights`
- load SpeedInsights in the root layout

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_686e84e2b654832ca12c3236b374d77c