### PR TITLE
Atualiza logs e documentação de erros

### DIFF
--- a/logs/DOC_LOG.md
+++ b/logs/DOC_LOG.md
@@ -1,1 +1,3 @@
 - 2025-07-08: Finalizada Fase 1 de verificacao inicial. Docker compose nao pode ser executado por limitacoes do ambiente. Workflow ajustado para concluir lint, testes e build do servico auth.
+
+- 2025-07-10: Criado log de erros centralizado na raiz e atualizada documentação.

--- a/logs/ERR_LOG.md
+++ b/logs/ERR_LOG.md
@@ -1,0 +1,4 @@
+# Registro de Erros
+
+> Em ambiente local o log é gravado em `logs/ERR_LOG.md`. Em produção (por exemplo, na Vercel) o arquivo é salvo em `/tmp/ERR_LOG.md` ou enviado para o LogRocket (`4pjmeb/m24`). Baixe esse arquivo ou consulte o painel do LogRocket para visualizar os registros.
+

--- a/services/gateway/logs/ERR_LOG.md
+++ b/services/gateway/logs/ERR_LOG.md
@@ -2,7 +2,6 @@
 
 > Em ambiente local o log é gravado em `logs/ERR_LOG.md`. Em produção (por exemplo, na Vercel) o arquivo é salvo em `/tmp/ERR_LOG.md` ou enviado para o LogRocket (`4pjmeb/m24`). Baixe esse arquivo ou consulte o painel do LogRocket para visualizar os registros.
 
-# Registro de Erros
 
 > Em ambiente local o log é gravado em `logs/ERR_LOG.md`. Em produção (por exemplo, na Vercel) o arquivo é salvo em `/tmp/ERR_LOG.md` ou encaminhado para um serviço externo. Baixe esse arquivo ou acesse sua ferramenta de coleta para visualizar os registros.
 


### PR DESCRIPTION
## Summary
- remove cabeçalho duplicado de `services/gateway/logs/ERR_LOG.md`
- cria `logs/ERR_LOG.md` na raiz com instruções de uso
- registra no `DOC_LOG.md` a criação do log de erros centralizado

## Testing
- `npm run lint` *(fails: next not found)*
- `npm run build` *(fails: tsc cannot find modules)*

------
https://chatgpt.com/codex/tasks/task_e_686f0ab57800832cba62b95084146295