### PR TITLE
Add gateway build

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,3 +12,4 @@ jobs:
       - run: pnpm lint
       - run: pnpm test
       - run: pnpm build --filter services/auth
+      - run: pnpm build --filter services/gateway

--- a/logs/DOC_LOG.md
+++ b/logs/DOC_LOG.md
@@ -1,1 +1,2 @@
 - 2025-07-08: Finalizada Fase 1 de verificacao inicial. Docker compose nao pode ser executado por limitacoes do ambiente. Workflow ajustado para concluir lint, testes e build do servico auth.
+- 2025-07-09: Ajustado pipeline de CI para compilar o gateway apos o auth e atualizado script de build na raiz para incluir ambos os servicos.

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "private": true,
   "scripts": {
     "dev": "pnpm --filter gateway dev",
-    "build": "pnpm --filter auth build",
+    "build": "pnpm --filter auth build && pnpm --filter gateway build",
     "start": "pnpm --filter gateway start",
     "lint": "pnpm --filter gateway lint",
     "test": "pnpm --filter gateway exec vitest run --run none --passWithNoTests && pnpm --filter auth exec vitest run --run none --passWithNoTests",


### PR DESCRIPTION
## Summary
- run `pnpm build --filter services/gateway` in CI
- build gateway in workspace build script
- log documentation update

## Testing
- `npm run lint`
- `npm run build` *(fails: bg-primary-500 class does not exist)*

------
https://chatgpt.com/codex/tasks/task_e_686f0ac287fc832c99348b3e9786ebe2