### PR TITLE
Fix profile editing auth headers

### DIFF
--- a/app/admin/perfil/components/ModalEditarPerfil.tsx
+++ b/app/admin/perfil/components/ModalEditarPerfil.tsx
@@ -1,11 +1,13 @@
 'use client'
 
-import { useState } from 'react'
+import { useState, useMemo } from 'react'
 import { motion, AnimatePresence } from 'framer-motion'
 import * as Dialog from '@radix-ui/react-dialog'
 import { useAuthContext } from '@/lib/context/AuthContext'
 import { useToast } from '@/lib/context/ToastContext'
 import { FormField, TextField, InputWithMask } from '@/components'
+import createPocketBase from '@/lib/pocketbase'
+import { getAuthHeaders } from '@/lib/authHeaders'
 
 export default function ModalEditarPerfil({
   onClose,
@@ -13,6 +15,7 @@ export default function ModalEditarPerfil({
   onClose: () => void
 }) {
   const { user } = useAuthContext()
+  const pb = useMemo(() => createPocketBase(), [])
   const [nome, setNome] = useState(String(user?.nome || ''))
   const [telefone, setTelefone] = useState(String(user?.telefone || ''))
   const [cpf, setCpf] = useState(String(user?.cpf || ''))
@@ -38,8 +41,10 @@ export default function ModalEditarPerfil({
       await fetch(`/api/usuarios/${user.id}`, {
         method: 'PATCH',
         headers: {
+          ...getAuthHeaders(pb),
           'Content-Type': 'application/json',
         },
+        credentials: 'include',
         body: JSON.stringify({
           nome: String(nome).trim(),
           telefone: String(telefone).trim(),

--- a/logs/ERR_LOG.md
+++ b/logs/ERR_LOG.md
@@ -275,3 +275,4 @@
 ## [2025-07-08] Erro no painel devido a código duplicado em DashboardAnalytics.tsx - dev - resolvido restaurando arquivo e tipagens.
 ## [2025-07-08] Líder não conseguia definir status "aguardando_pagamento" ao confirmar inscrição. PATCH /api/inscricoes/[id] agora permite esse valor. - dev
 ## [2025-07-08] Modal de edição excedia altura da tela no fluxo de inscrição, impedindo salvar ou cancelar. Adicionado overflow-y-auto e max-h-screen nos modais de edição. - prod - bca77d01a1630e5dd09ae4e9579e9a71d3341df3
+## [2025-07-11] ModalEditarPerfil não enviava cabeçalhos de autenticação, impedindo salvar perfil durante inscrição. Cabeçalhos adicionados. - dev - f969efa7


### PR DESCRIPTION
## Summary
- include PocketBase auth headers when saving profile changes
- log the fix in `ERR_LOG.md`

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_687196a075d8832ca34b8a07b76e0a6f