### PR TITLE
Fix AddToCart check for leaders

### DIFF
--- a/app/loja/api/minhas-inscricoes/route.ts
+++ b/app/loja/api/minhas-inscricoes/route.ts
@@ -2,7 +2,7 @@ import { NextRequest, NextResponse } from 'next/server'
 import { requireRole } from '@/lib/apiAuth'
 
 export async function GET(req: NextRequest) {
-  const auth = requireRole(req, 'usuario')
+  const auth = requireRole(req, ['usuario', 'lider', 'coordenador'])
   if ('error' in auth) {
     return NextResponse.json({ error: auth.error }, { status: auth.status })
   }

--- a/lib/hooks/useInscricoes.ts
+++ b/lib/hooks/useInscricoes.ts
@@ -16,7 +16,7 @@ export default function useInscricoes() {
     if (!tenantId) return
     let active = true
     const headers = getAuthHeaders(pb)
-    fetch('/api/inscricoes', { headers, credentials: 'include' })
+    fetch('/loja/api/minhas-inscricoes', { headers, credentials: 'include' })
       .then((res) => (res.ok ? res.json() : Promise.reject()))
       .then((data) => {
         const items = Array.isArray(data)


### PR DESCRIPTION
## Summary
- fetch user's own inscriptions for cart checks
- allow leaders to access `/loja/api/minhas-inscricoes`

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6872849792e8832c99fcf69c6958473b