### PR TITLE
Fix TypeScript build setup and CSS tokens

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -39,12 +39,21 @@ importers:
         specifier: ^9.0.2
         version: 9.0.2
     devDependencies:
+      '@types/body-parser':
+        specifier: ^1.19.5
+        version: 1.19.6
       '@types/express':
         specifier: ^4.17.17
         version: 4.17.23
+      '@types/express-serve-static-core':
+        specifier: ^4.19.6
+        version: 4.19.6
       '@types/jsonwebtoken':
         specifier: ^9.0.2
         version: 9.0.10
+      '@types/node':
+        specifier: ^20
+        version: 20.19.6
       '@types/supertest':
         specifier: ^2.0.12
         version: 2.0.16

--- a/services/auth/package.json
+++ b/services/auth/package.json
@@ -17,8 +17,11 @@
   "devDependencies": {
     "@types/express": "^4.17.17",
     "@types/jsonwebtoken": "^9.0.2",
+    "@types/express-serve-static-core": "^4.19.6",
+    "@types/body-parser": "^1.19.5",
     "supertest": "^6.3.3",
     "@types/supertest": "^2.0.12",
+    "@types/node": "^20",
     "vitest": "^1.5.0",
     "typescript": "^5"
   }

--- a/services/auth/src/index.ts
+++ b/services/auth/src/index.ts
@@ -1,4 +1,4 @@
-import express from 'express'
+import express, { type Request, type Response } from 'express'
 import jwt from 'jsonwebtoken'
 
 const app = express()
@@ -6,7 +6,7 @@ app.use(express.json())
 
 const SECRET = process.env.JWT_SECRET || 'secret'
 
-app.post('/login', (req, res) => {
+app.post('/login', (req: Request<Record<string, unknown>, any, { username: string }>, res: Response) => {
   const { username } = req.body
   if (!username) {
     return res.status(400).json({ error: 'username required' })

--- a/services/auth/tsconfig.json
+++ b/services/auth/tsconfig.json
@@ -6,7 +6,8 @@
     "esModuleInterop": true,
     "skipLibCheck": true,
     "forceConsistentCasingInFileNames": true,
-    "outDir": "dist"
+    "outDir": "dist",
+    "types": ["node", "express"]
   },
   "include": ["src"],
   "exclude": ["node_modules"]

--- a/services/gateway/app/globals.css
+++ b/services/gateway/app/globals.css
@@ -13,9 +13,9 @@
   --text-primary: theme('colors.neutral.900');
   --text-secondary: theme('colors.neutral.700');
   --text-header-primary: theme('colors.neutral.100');
-  --text-header-secondary: theme('colors.primary.600');
-  --accent: theme('colors.primary.600');
-  --accent-900: theme('colors.primary.900');
+  --text-header-secondary: theme('colors.purple.600');
+  --accent: theme('colors.purple.600');
+  --accent-900: theme('colors.purple.900');
   --color-secondary: theme('colors.neutral.900');
   /* Fontes padronizadas para evitar depend\u00eancia de downloads no build */
   --font-geist: system-ui, sans-serif;
@@ -37,8 +37,8 @@ html.dark {
   --text-secondary: theme('colors.neutral.400');
   --text-header-primary: theme('colors.neutral.200');
   --text-header-secondary: theme('colors.neutral.300');
-  --accent: theme('colors.primary.600');
-  --accent-900: theme('colors.primary.900');
+  --accent: theme('colors.purple.600');
+  --accent-900: theme('colors.purple.900');
   --color-secondary: theme('colors.neutral.200');
 }
 
@@ -138,19 +138,19 @@ p {
 }
 
 .btn-primary {
-  @apply bg-primary-500 text-white hover:bg-primary-500;
+  @apply bg-purple-600 text-white hover:bg-purple-700;
 }
 
 .btn-secondary {
-  @apply bg-primary-500 text-[var(--background)] hover:bg-primary-700 hover:text-white dark:hover:bg-primary-500;
+  @apply bg-purple-600 text-[var(--background)] hover:bg-purple-700 hover:text-white dark:hover:bg-purple-600;
 }
 
 .btn-danger {
-  @apply bg-error-600 text-white hover:bg-error-700;
+  @apply bg-red-600 text-white hover:bg-red-700;
 }
 
 .input-base {
-  @apply w-full px-4 py-3 rounded-lg border border-neutral-300 bg-neutral-50 text-sm text-neutral-900 focus:outline-none focus:ring-2 focus:ring-error-600 transition;
+  @apply w-full px-4 py-3 rounded-lg border border-neutral-300 bg-neutral-50 text-sm text-neutral-900 focus:outline-none focus:ring-2 focus:ring-red-600 transition;
 }
 
 /* Card e Tabela base */
@@ -207,9 +207,9 @@ p {
 .bg-animated {
   background: linear-gradient(
     270deg,
-    theme('colors.primary.900'),
-    theme('colors.primary.800'),
-    theme('colors.error.800')
+    theme('colors.purple.900'),
+    theme('colors.purple.800'),
+    theme('colors.red.800')
   );
   background-size: 400% 400%;
   animation: gradient-x 15s ease infinite;


### PR DESCRIPTION
## Summary
- add missing TypeScript types for Node and Express in auth service
- adjust Tailwind CSS tokens to use built‑in purple/red palette
- update auth login route types

## Testing
- `npm run lint` *(fails: context.getScope is not a function)*
- `npm run build` *(fails in gateway build due to type errors and ESLint)*

------
https://chatgpt.com/codex/tasks/task_e_68730a8f8fd8832caf54473695a5e718