### PR TITLE
Implement stacked chart for pedidos

### DIFF
--- a/app/admin/components/DashboardAnalytics.tsx
+++ b/app/admin/components/DashboardAnalytics.tsx
@@ -127,9 +127,13 @@ export default function DashboardAnalytics({
   const arrecadacaoRef = useRef<Chart<'bar'> | null>(null)
 
   const handleExportPDF = async () => {
+    const campoProdutoCanvas = document.getElementById(
+      'campoProdutoChart',
+    ) as HTMLCanvasElement | null
     const charts = {
       inscricoes: inscricoesRef.current?.toBase64Image(),
       pedidos: pedidosRef.current?.toBase64Image(),
+      campoProduto: campoProdutoCanvas?.toDataURL('image/png'),
       arrecadacao: mostrarFinanceiro
         ? arrecadacaoRef.current?.toBase64Image()
         : undefined,

--- a/app/admin/relatorios/page.tsx
+++ b/app/admin/relatorios/page.tsx
@@ -65,17 +65,23 @@ export default function RelatoriosPage() {
         }
 
         params.set('page', '1')
-        const pedRes = await fetch(`/api/pedidos?${params.toString()}`, {
-          credentials: 'include',
-          signal,
-        }).then((r) => r.json())
+        const pedRes = await fetch(
+          `/api/pedidos?${params.toString()}&expand=campo,produto`,
+          {
+            credentials: 'include',
+            signal,
+          },
+        ).then((r) => r.json())
         let rawPedidos = Array.isArray(pedRes.items) ? pedRes.items : pedRes
         for (let p = 2; p <= (pedRes.totalPages ?? 1); p++) {
           params.set('page', String(p))
-          const more = await fetch(`/api/pedidos?${params.toString()}`, {
-            credentials: 'include',
-            signal,
-          }).then((r) => r.json())
+          const more = await fetch(
+            `/api/pedidos?${params.toString()}&expand=campo,produto`,
+            {
+              credentials: 'include',
+              signal,
+            },
+          ).then((r) => r.json())
           rawPedidos = rawPedidos.concat(
             Array.isArray(more.items) ? more.items : more,
           )

--- a/lib/report/generateDashboardPdf.ts
+++ b/lib/report/generateDashboardPdf.ts
@@ -18,6 +18,7 @@ export interface Periodo {
 export interface ChartImages {
   inscricoes?: string
   pedidos?: string
+  campoProduto?: string
   arrecadacao?: string
 }
 
@@ -79,6 +80,11 @@ export async function generateDashboardPdf(
 
       if (charts.pedidos) {
         doc.addImage(charts.pedidos, 'PNG', 40, y, 520, 220)
+        y += 240
+      }
+
+      if (charts.campoProduto) {
+        doc.addImage(charts.campoProduto, 'PNG', 40, y, 520, 220)
         y += 240
       }
 


### PR DESCRIPTION
## Summary
- include expand `campo,produto` when fetching pedidos in reports
- visualize pedidos by campo and produto in dashboard
- add campo+produto chart export
- support extra chart in PDF generation

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6873dfdc4680832c90a0f4c8989385c2