### PR TITLE
Fix product expansion for pedidos charts

### DIFF
--- a/app/admin/components/DashboardAnalytics.tsx
+++ b/app/admin/components/DashboardAnalytics.tsx
@@ -127,9 +127,13 @@ export default function DashboardAnalytics({
   const arrecadacaoRef = useRef<Chart<'bar'> | null>(null)
 
   const handleExportPDF = async () => {
+    const campoProdutoCanvas = document.getElementById(
+      'campoProdutoChart',
+    ) as HTMLCanvasElement | null
     const charts = {
       inscricoes: inscricoesRef.current?.toBase64Image(),
       pedidos: pedidosRef.current?.toBase64Image(),
+      campoProduto: campoProdutoCanvas?.toDataURL('image/png'),
       arrecadacao: mostrarFinanceiro
         ? arrecadacaoRef.current?.toBase64Image()
         : undefined,

--- a/app/admin/dashboard/page.tsx
+++ b/app/admin/dashboard/page.tsx
@@ -67,17 +67,23 @@ export default function DashboardPage() {
         }
 
         params.set('page', '1')
-        const pedRes = await fetch(`/api/pedidos?${params.toString()}`, {
-          credentials: 'include',
-          signal,
-        }).then((r) => r.json())
+        const pedRes = await fetch(
+          `/api/pedidos?${params.toString()}&expand=campo,produto`,
+          {
+            credentials: 'include',
+            signal,
+          },
+        ).then((r) => r.json())
         let rawPedidos = Array.isArray(pedRes.items) ? pedRes.items : pedRes
         for (let p = 2; p <= (pedRes.totalPages ?? 1); p++) {
           params.set('page', String(p))
-          const more = await fetch(`/api/pedidos?${params.toString()}`, {
-            credentials: 'include',
-            signal,
-          }).then((r) => r.json())
+          const more = await fetch(
+            `/api/pedidos?${params.toString()}&expand=campo,produto`,
+            {
+              credentials: 'include',
+              signal,
+            },
+          ).then((r) => r.json())
           rawPedidos = rawPedidos.concat(
             Array.isArray(more.items) ? more.items : more,
           )
@@ -135,6 +141,7 @@ export default function DashboardPage() {
           expand: {
             campo: r.expand?.campo,
             criado_por: r.expand?.criado_por,
+            produto: r.expand?.produto,
           },
         }))
 

--- a/app/admin/lider-painel/page.tsx
+++ b/app/admin/lider-painel/page.tsx
@@ -41,7 +41,7 @@ export default function LiderDashboardPage() {
             credentials: 'include',
             signal,
           }).then((r) => r.json()),
-          fetch(`/api/pedidos?${params.toString()}`, {
+          fetch(`/api/pedidos?${params.toString()}&expand=campo,produto`, {
             credentials: 'include',
             signal,
           }).then((r) => r.json()),
@@ -98,6 +98,7 @@ export default function LiderDashboardPage() {
           expand: {
             campo: r.expand?.campo,
             criado_por: r.expand?.criado_por,
+            produto: r.expand?.produto,
           },
         }))
 

--- a/app/admin/relatorios/page.tsx
+++ b/app/admin/relatorios/page.tsx
@@ -65,17 +65,23 @@ export default function RelatoriosPage() {
         }
 
         params.set('page', '1')
-        const pedRes = await fetch(`/api/pedidos?${params.toString()}`, {
-          credentials: 'include',
-          signal,
-        }).then((r) => r.json())
+        const pedRes = await fetch(
+          `/api/pedidos?${params.toString()}&expand=campo,produto`,
+          {
+            credentials: 'include',
+            signal,
+          },
+        ).then((r) => r.json())
         let rawPedidos = Array.isArray(pedRes.items) ? pedRes.items : pedRes
         for (let p = 2; p <= (pedRes.totalPages ?? 1); p++) {
           params.set('page', String(p))
-          const more = await fetch(`/api/pedidos?${params.toString()}`, {
-            credentials: 'include',
-            signal,
-          }).then((r) => r.json())
+          const more = await fetch(
+            `/api/pedidos?${params.toString()}&expand=campo,produto`,
+            {
+              credentials: 'include',
+              signal,
+            },
+          ).then((r) => r.json())
           rawPedidos = rawPedidos.concat(
             Array.isArray(more.items) ? more.items : more,
           )
@@ -128,6 +134,7 @@ export default function RelatoriosPage() {
           expand: {
             campo: r.expand?.campo,
             criado_por: r.expand?.criado_por,
+            produto: r.expand?.produto,
           },
         }))
 

--- a/lib/report/generateDashboardPdf.ts
+++ b/lib/report/generateDashboardPdf.ts
@@ -18,6 +18,7 @@ export interface Periodo {
 export interface ChartImages {
   inscricoes?: string
   pedidos?: string
+  campoProduto?: string
   arrecadacao?: string
 }
 
@@ -79,6 +80,11 @@ export async function generateDashboardPdf(
 
       if (charts.pedidos) {
         doc.addImage(charts.pedidos, 'PNG', 40, y, 520, 220)
+        y += 240
+      }
+
+      if (charts.campoProduto) {
+        doc.addImage(charts.campoProduto, 'PNG', 40, y, 520, 220)
         y += 240
       }
 


### PR DESCRIPTION
## Summary
- expand `produto` for dashboard requests
- include expanded product info when mapping pedidos

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6873dfdc4680832c90a0f4c8989385c2