### PR TITLE
Remove any types and fix useEffect deps

### DIFF
--- a/services/catalog/src/database/connection.ts
+++ b/services/catalog/src/database/connection.ts
@@ -21,5 +21,6 @@ export async function setupRLS(client: PoolClient, tenantId: string): Promise<vo
   await client.query('SET app.tenant_id = $1', [tenantId])
 }
 
-export const query = (text: string, params?: any[]) => pool.query(text, params)
-export const getClient = () => pool.connect() 
+export const query = (text: string, params?: unknown[]) =>
+  pool.query(text, params as any[])
+export const getClient = () => pool.connect()

--- a/services/catalog/src/index.ts
+++ b/services/catalog/src/index.ts
@@ -59,7 +59,7 @@ app.use('/api/v1/products', productsRouter)
 app.use('/api/v1/categories', categoriesRouter)
 
 // Middleware de erro global
-app.use((err: any, req: express.Request, res: express.Response, next: express.NextFunction) => {
+app.use((err: Error, req: express.Request, res: express.Response, next: express.NextFunction) => {
   console.error('Erro não tratado:', err)
   
   res.status(500).json({

--- a/services/catalog/src/repositories/CategoryRepository.ts
+++ b/services/catalog/src/repositories/CategoryRepository.ts
@@ -39,7 +39,7 @@ export class CategoryRepository {
 
   async update(tenantId: string, id: string, categoryData: UpdateCategoryRequest): Promise<Category | null> {
     const fields: string[] = []
-    const values: any[] = []
+    const values: unknown[] = []
     let paramIndex = 1
 
     // Construir dinamicamente os campos a serem atualizados

--- a/services/catalog/src/repositories/ProductRepository.ts
+++ b/services/catalog/src/repositories/ProductRepository.ts
@@ -13,7 +13,7 @@ export class ProductRepository {
     } = filters
 
     let whereConditions: string[] = []
-    let params: any[] = []
+    let params: unknown[] = []
     let paramIndex = 1
 
     if (ativo !== undefined) {
@@ -120,7 +120,7 @@ export class ProductRepository {
 
   async update(tenantId: string, id: string, productData: UpdateProductRequest): Promise<Product | null> {
     const fields: string[] = []
-    const values: any[] = []
+    const values: unknown[] = []
     let paramIndex = 1
 
     // Construir dinamicamente os campos a serem atualizados
@@ -160,7 +160,7 @@ export class ProductRepository {
     const { ativo, categoria, search } = filters
 
     let whereConditions: string[] = []
-    let params: any[] = []
+    let params: unknown[] = []
     let paramIndex = 1
 
     if (ativo !== undefined) {

--- a/services/catalog/src/test/helpers/validation.ts
+++ b/services/catalog/src/test/helpers/validation.ts
@@ -1,6 +1,6 @@
 import { Product, Category } from '../../types'
 
-export const validateProduct = (product: any): product is Product => {
+export const validateProduct = (product: unknown): product is Product => {
   const requiredFields = [
     'id', 'nome', 'user_org', 'quantidade', 'preco', 
     'preco_bruto', 'ativo', 'slug', 'cliente'
@@ -9,7 +9,7 @@ export const validateProduct = (product: any): product is Product => {
   return requiredFields.every(field => product.hasOwnProperty(field))
 }
 
-export const validateCategory = (category: any): category is Category => {
+export const validateCategory = (category: unknown): category is Category => {
   const requiredFields = ['id', 'nome', 'slug', 'cliente']
 
   return requiredFields.every(field => category.hasOwnProperty(field))

--- a/services/catalog/src/types/index.ts
+++ b/services/catalog/src/types/index.ts
@@ -94,7 +94,7 @@ export type CommissionTransaction = {
   valor_bruto: number
   fee_fixed: number
   fee_percent: number
-  split: any
+  split: Record<string, unknown>
   payment_method: string
   installments?: number
   status: string

--- a/services/gateway/components/admin/ModalProdutoForm.tsx
+++ b/services/gateway/components/admin/ModalProdutoForm.tsx
@@ -1,6 +1,6 @@
 'use client'
 
-import { useEffect, useRef, useState } from 'react'
+import { useEffect, useRef, useState, useMemo } from 'react'
 import createPocketBase from '@/lib/pocketbase'
 import { getAuthHeaders } from '@/lib/authHeaders'
 import Image from 'next/image'
@@ -37,7 +37,7 @@ export default function ModalProdutoForm({
   initial = {},
 }: ModalProdutoFormProps) {
   const { showError } = useToast()
-  const pb = createPocketBase()
+  const pb = useMemo(() => createPocketBase(), [])
   const firstFieldRef = useRef<HTMLInputElement>(null)
   const [eventos, setEventos] = useState<Evento[]>([])
   const [preview, setPreview] = useState<string | null>(initial.imagem || null)

--- a/services/gateway/lib/apiAuth.ts
+++ b/services/gateway/lib/apiAuth.ts
@@ -9,7 +9,7 @@ type SupabaseUser = {
   role: string
   nome?: string
   cliente?: string
-  [key: string]: any
+  [key: string]: unknown
 }
 
 export type RequireRoleOk = {

--- a/services/gateway/lib/getUserFromHeaders.ts
+++ b/services/gateway/lib/getUserFromHeaders.ts
@@ -9,7 +9,7 @@ type SupabaseUser = {
   role: string
   nome?: string
   cliente?: string
-  [key: string]: any
+  [key: string]: unknown
 }
 
 type AuthOk = {

--- a/services/orders/src/commissionClient.ts
+++ b/services/orders/src/commissionClient.ts
@@ -2,7 +2,7 @@ import axios from 'axios';
 
 const COMMISSION_ENGINE_URL = process.env.COMMISSION_ENGINE_URL || 'http://commission:7000';
 
-export async function calcularComissao(payload: any) {
+export async function calcularComissao(payload: Record<string, unknown>) {
   const res = await axios.post(`${COMMISSION_ENGINE_URL}/calculate`, payload);
   return res.data;
-} 
+}

--- a/services/orders/src/index.ts
+++ b/services/orders/src/index.ts
@@ -12,7 +12,16 @@ app.use(cors());
 app.use(helmet());
 
 // Mock DB
-const orders: any[] = [];
+interface Order {
+  id: string
+  userId: string
+  items: Record<string, unknown>[]
+  total: number
+  status: string
+  createdAt: Date
+}
+
+const orders: Order[] = [];
 
 // Criar pedido
 app.post('/orders', (req, res) => {


### PR DESCRIPTION
## Summary
- replace `any` types in orders and catalog services
- use `unknown` for generic payloads and arrays
- stabilize pb instance with `useMemo`
- adjust catalog global error handler

## Testing
- `npm run lint` *(fails: context.getScope is not a function)*
- `npm run build` *(fails: context.getScope is not a function)*

------
https://chatgpt.com/codex/tasks/task_e_6875508b4214832c93d60a387173dc02