### PR TITLE
Add sign-up hint on manual order form

### DIFF
--- a/__tests__/PedidoAvulsoForm.test.tsx
+++ b/__tests__/PedidoAvulsoForm.test.tsx
@@ -13,7 +13,12 @@ vi.mock('@/lib/context/ToastContext', () => ({
 }))
 
 vi.mock('@/lib/hooks/useProdutos', () => ({
-  default: () => ({ produtos: [{ id: 'p1', nome: 'Prod 1' }], loading: false }),
+  default: () => ({
+    produtos: [
+      { id: 'p1', nome: 'Prod 1', evento_id: 'e1', requer_inscricao_aprovada: true },
+    ],
+    loading: false,
+  }),
 }))
 
 describe('PedidoAvulsoForm', () => {
@@ -25,6 +30,9 @@ describe('PedidoAvulsoForm', () => {
     fireEvent.change(screen.getByLabelText('Telefone'), { target: { value: '11999999999' } })
     fireEvent.change(screen.getByLabelText('E-mail'), { target: { value: 'f@x.com' } })
     fireEvent.change(screen.getByLabelText('Produto'), { target: { value: 'p1' } })
+    expect(
+      screen.getByRole('link', { name: /iniciar inscrição/i }),
+    ).toBeInTheDocument()
     fireEvent.change(screen.getByLabelText('Valor'), { target: { value: '10' } })
     fireEvent.change(screen.getByLabelText('Vencimento'), { target: { value: '2025-12-31' } })
     fireEvent.click(screen.getByRole('button', { name: /criar pedido/i }))

--- a/components/organisms/PedidoAvulsoForm.tsx
+++ b/components/organisms/PedidoAvulsoForm.tsx
@@ -1,6 +1,8 @@
 'use client'
-import { useMemo, useState } from 'react'
+import { useMemo, useState, useEffect } from 'react'
+import Link from 'next/link'
 import { FormField, TextField, InputWithMask } from '@/components'
+import type { Produto } from '@/types'
 import LoadingOverlay from './LoadingOverlay'
 import { useToast } from '@/lib/context/ToastContext'
 import { useAuthContext } from '@/lib/context/AuthContext'
@@ -25,6 +27,13 @@ export default function PedidoAvulsoForm() {
     vencimento: '',
   })
 
+  const [produtoSel, setProdutoSel] = useState<Produto | undefined>(undefined)
+
+  useEffect(() => {
+    const prod = produtos.find((p) => p.id === form.produtoId)
+    setProdutoSel(prod)
+  }, [produtos, form.produtoId])
+
   const [errors, setErrors] = useState<{ cpf?: string; email?: string; telefone?: string }>({})
   const [loading, setLoading] = useState(false)
 
@@ -40,6 +49,10 @@ export default function PedidoAvulsoForm() {
   const handleChange = (e: React.ChangeEvent<HTMLInputElement | HTMLSelectElement>) => {
     const { name, value } = e.target
     setForm((prev) => ({ ...prev, [name]: value }))
+    if (name === 'produtoId') {
+      const prod = produtos.find((p) => p.id === value)
+      setProdutoSel(prod)
+    }
   }
 
   const handleSubmit = async (e: React.FormEvent) => {
@@ -98,12 +111,23 @@ export default function PedidoAvulsoForm() {
       <FormField label="Produto" htmlFor="produtoId">
         <select id="produtoId" name="produtoId" value={form.produtoId} onChange={handleChange} className="input-base w-full" required>
           <option value="">Selecione</option>
-          {produtos.map((p) => (
-            <option key={p.id} value={p.id}>
-              {p.nome}
-            </option>
-          ))}
+      {produtos.map((p) => (
+        <option key={p.id} value={p.id}>
+          {p.nome}
+        </option>
+      ))}
         </select>
+        {produtoSel?.evento_id && (
+          <p className="text-sm mt-2">
+            Produto vinculado a evento.{' '}
+            <Link
+              href={`/inscricoes/lider/${user?.id}/evento/${produtoSel.evento_id}?cpf=${form.cpf}&email=${form.email}`}
+              className="text-primary underline"
+            >
+              Iniciar inscrição
+            </Link>
+          </p>
+        )}
       </FormField>
       <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
         <FormField label="Valor" htmlFor="valor">

--- a/docs/regras-pedidos.md
+++ b/docs/regras-pedidos.md
@@ -66,3 +66,6 @@ Líderes podem registrar pedidos manuais acessando `/admin/pedidos/novo`.
 Esse fluxo cria um pedido sem vínculo a inscrição e utiliza `canal = 'avulso'`.
 O líder seleciona o produto, informa o valor, email do inscrito e data de
 vencimento. O pedido sempre pertence ao mesmo campo do líder autenticado.
+Se o produto escolhido estiver vinculado a um evento, o formulário exibe um link
+para iniciar o fluxo de inscrição em `/inscricoes/lider/[liderId]/evento/[eventoId]`.
+Assim o líder pode cadastrar ou atualizar os dados do participante antes de gerar o pedido.

--- a/logs/DOC_LOG.md
+++ b/logs/DOC_LOG.md
@@ -591,3 +591,4 @@ na rota /loja/api/inscricoes e documentação atualizada. Lint e build executado
 ## [2025-07-15] Recuperacao de link busca pedido pendente ou vencido quando inscricao aguardando_pagamento. Lint e build executados.
 ## [2025-07-15] fetchAllPages acelera carregamento de dashboard e relatórios. Lint e build executados.
 ## [2025-08-20] Adicionada criação de pedido avulso por líderes e documentação atualizada. Lint e build executados.
+## [2025-07-16] Formulário de pedido avulso agora sugere inscrição quando o produto pertence a evento. Documentação atualizada. Lint e build executados.


### PR DESCRIPTION
## Summary
- show event sign-up link on Pedido Avulso form
- update unit test to expect sign-up link
- document new flow

## Testing
- `npm run lint`
- `npm run build`
- `npm test` *(fails: Worker terminated due to reaching memory limit)*

------
https://chatgpt.com/codex/tasks/task_e_687795d83bf0832cbc9c27ac0b26d4e8