### PR TITLE
Fix ESLint root configs

### DIFF
--- a/services/auth/.eslintrc.js
+++ b/services/auth/.eslintrc.js
@@ -1,6 +1,7 @@
 module.exports = {
+  root: true,
   extends: ['next/core-web-vitals', 'next'],
   rules: {
     // Suas regras customizadas aqui
   },
-}; 
+};

--- a/services/catalog/.eslintrc.js
+++ b/services/catalog/.eslintrc.js
@@ -1,6 +1,7 @@
 module.exports = {
+  root: true,
   extends: ['next/core-web-vitals', 'next'],
   rules: {
     // Suas regras customizadas aqui
   },
-}; 
+};

--- a/services/commission/.eslintrc.js
+++ b/services/commission/.eslintrc.js
@@ -1,6 +1,7 @@
 module.exports = {
+  root: true,
   extends: ['next/core-web-vitals', 'next'],
   rules: {
     // Suas regras customizadas aqui
   },
-}; 
+};

--- a/services/gateway/.eslintrc.js
+++ b/services/gateway/.eslintrc.js
@@ -1,6 +1,7 @@
 module.exports = {
+  root: true,
   extends: ['next/core-web-vitals', 'next'],
   rules: {
     // Suas regras customizadas aqui
   },
-}; 
+};

--- a/services/gateway/package.json
+++ b/services/gateway/package.json
@@ -66,7 +66,6 @@
     "autoprefixer": "^10.4.21",
     "color-namer": "^1.4.0",
     "eslint": "^8.57.0",
-    "eslint-config-next": "15.3.2",
     "eslint-plugin-storybook": "^9.0.5",
     "husky": "^9.1.7",
     "jest-axe": "^10.0.0",

--- a/services/orders/.eslintrc.js
+++ b/services/orders/.eslintrc.js
@@ -1,6 +1,7 @@
 module.exports = {
+  root: true,
   extends: ['next/core-web-vitals', 'next'],
   rules: {
     // Suas regras customizadas aqui
   },
-}; 
+};


### PR DESCRIPTION
## Summary
- ensure each service sets `root: true` in `.eslintrc.js`
- remove duplicate `eslint-config-next` from gateway service

## Testing
- `pnpm install`
- `npm run lint` *(fails: Definition for rule '@typescript-eslint/no-unused-vars' was not found)*
- `npm run build` *(fails: Definition for rule '@typescript-eslint/no-unused-vars' was not found)*

------
https://chatgpt.com/codex/tasks/task_e_6877bb6d0a50832c8548b5fab48f77a7