### PR TITLE
Add CPF duplication warning without blocking orders

### DIFF
--- a/__tests__/PedidoAvulsoForm.test.tsx
+++ b/__tests__/PedidoAvulsoForm.test.tsx
@@ -13,26 +13,47 @@ vi.mock('@/lib/context/ToastContext', () => ({
 }))
 
 vi.mock('@/lib/hooks/useProdutos', () => ({
-  default: () => ({ produtos: [{ id: 'p1', nome: 'Prod 1' }], loading: false }),
+  default: () => ({
+    produtos: [
+      {
+        id: 'p1',
+        nome: 'Prod 1',
+        evento_id: 'e1',
+        requer_inscricao_aprovada: true,
+        preco_bruto: 55,
+      },
+    ],
+    loading: false,
+  }),
 }))
 
 describe('PedidoAvulsoForm', () => {
   it('envia dados com canal avulso', async () => {
-    global.fetch = vi.fn().mockResolvedValue({ ok: true, json: () => Promise.resolve({}) })
+    global.fetch = vi
+      .fn()
+      .mockResolvedValueOnce({ ok: true, json: () => Promise.resolve({}) })
+      .mockResolvedValueOnce({ ok: true, json: () => Promise.resolve({}) })
     render(<PedidoAvulsoForm />)
     fireEvent.change(screen.getByLabelText('Nome'), { target: { value: 'Fulano' } })
     fireEvent.change(screen.getByLabelText('CPF'), { target: { value: '52998224725' } })
     fireEvent.change(screen.getByLabelText('Telefone'), { target: { value: '11999999999' } })
     fireEvent.change(screen.getByLabelText('E-mail'), { target: { value: 'f@x.com' } })
     fireEvent.change(screen.getByLabelText('Produto'), { target: { value: 'p1' } })
-    fireEvent.change(screen.getByLabelText('Valor'), { target: { value: '10' } })
+    expect(
+      screen.getByRole('link', { name: /iniciar inscrição/i }),
+    ).toBeInTheDocument()
+    const valorField = screen.getByLabelText('Valor')
+    expect(valorField).toHaveValue(55)
+    expect(valorField).toHaveAttribute('readonly')
     fireEvent.change(screen.getByLabelText('Vencimento'), { target: { value: '2025-12-31' } })
+    fireEvent.change(screen.getByLabelText('Forma de Pagamento'), { target: { value: 'pix' } })
     fireEvent.click(screen.getByRole('button', { name: /criar pedido/i }))
 
     await waitFor(() => expect(global.fetch).toHaveBeenCalled())
-    const call = (global.fetch as any).mock.calls[0]
+    const call = (global.fetch as any).mock.calls[1]
     expect(call[0]).toBe('/api/pedidos')
     const body = JSON.parse(call[1].body)
     expect(body.canal).toBe('avulso')
+    expect(body.paymentMethod).toBe('pix')
   })
 })

--- a/app/api/pedidos/route.ts
+++ b/app/api/pedidos/route.ts
@@ -246,6 +246,7 @@ export async function POST(req: NextRequest) {
         email,
         valor: Number(valor) || 0,
         vencimento,
+        paymentMethod: body.paymentMethod ?? 'pix',
         canal: isAvulso ? 'avulso' : 'loja',
       }
       console.log('[PEDIDOS][POST] Payload para criação:', payload)

--- a/components/organisms/PedidoAvulsoForm.tsx
+++ b/components/organisms/PedidoAvulsoForm.tsx
@@ -1,6 +1,8 @@
 'use client'
-import { useMemo, useState } from 'react'
+import { useMemo, useState, useEffect } from 'react'
+import Link from 'next/link'
 import { FormField, TextField, InputWithMask } from '@/components'
+import type { Produto } from '@/types'
 import LoadingOverlay from './LoadingOverlay'
 import { useToast } from '@/lib/context/ToastContext'
 import { useAuthContext } from '@/lib/context/AuthContext'
@@ -23,10 +25,36 @@ export default function PedidoAvulsoForm() {
     produtoId: '',
     valor: '',
     vencimento: '',
+    paymentMethod: 'pix',
   })
+
+  const [produtoSel, setProdutoSel] = useState<Produto | undefined>(undefined)
+
+  useEffect(() => {
+    const prod = produtos.find((p) => p.id === form.produtoId)
+    setProdutoSel(prod)
+    if (prod) {
+      setForm((prev) => ({ ...prev, valor: String(prod.preco_bruto) }))
+    }
+  }, [produtos, form.produtoId])
 
   const [errors, setErrors] = useState<{ cpf?: string; email?: string; telefone?: string }>({})
   const [loading, setLoading] = useState(false)
+
+  async function checkExists() {
+    const params = new URLSearchParams()
+    if (form.email) params.append('email', form.email)
+    if (form.cpf) params.append('cpf', form.cpf.replace(/\D/g, ''))
+    if ([...params].length === 0) return {}
+    const res = await fetch(`/api/usuarios/exists?${params.toString()}`)
+    if (!res.ok) return {}
+    const data = await res.json()
+    const errs: { cpf?: string; email?: string } = {}
+    if (data.cpf) errs.cpf = 'CPF já cadastrado'
+    if (data.email) errs.email = 'E-mail já cadastrado'
+    setErrors((prev) => ({ ...prev, ...errs }))
+    return errs
+  }
 
   const validate = () => {
     const err: { cpf?: string; email?: string; telefone?: string } = {}
@@ -39,12 +67,23 @@ export default function PedidoAvulsoForm() {
 
   const handleChange = (e: React.ChangeEvent<HTMLInputElement | HTMLSelectElement>) => {
     const { name, value } = e.target
-    setForm((prev) => ({ ...prev, [name]: value }))
+    if (name === 'produtoId') {
+      const prod = produtos.find((p) => p.id === value)
+      setProdutoSel(prod)
+      setForm((prev) => ({
+        ...prev,
+        produtoId: value,
+        valor: prod ? String(prod.preco_bruto) : '',
+      }))
+    } else {
+      setForm((prev) => ({ ...prev, [name]: value }))
+    }
   }
 
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault()
     if (!validate()) return
+    await checkExists()
     if (!user?.campo) {
       showError('Campo do líder não encontrado.')
       return
@@ -61,13 +100,23 @@ export default function PedidoAvulsoForm() {
           valor: Number(form.valor),
           email: form.email,
           vencimento: form.vencimento,
+          paymentMethod: form.paymentMethod,
           canal: 'avulso',
           campoId: user.campo,
         }),
       })
       if (res.ok) {
         showSuccess('Pedido criado!')
-        setForm({ nome: '', cpf: '', telefone: '', email: '', produtoId: '', valor: '', vencimento: '' })
+        setForm({
+          nome: '',
+          cpf: '',
+          telefone: '',
+          email: '',
+          produtoId: '',
+          valor: '',
+          vencimento: '',
+          paymentMethod: 'pix',
+        })
       } else {
         const data = await res.json().catch(() => null)
         showError(data?.erro || data?.error || 'Erro ao criar pedido.')
@@ -81,7 +130,7 @@ export default function PedidoAvulsoForm() {
 
   return (
     <form onSubmit={handleSubmit} className="space-y-4 max-w-lg">
-      <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
+      <div className="grid grid-cols-1 md:grid-cols-3 gap-4">
         <FormField label="Nome" htmlFor="nome">
           <TextField id="nome" name="nome" value={form.nome} onChange={handleChange} required />
         </FormField>
@@ -98,19 +147,49 @@ export default function PedidoAvulsoForm() {
       <FormField label="Produto" htmlFor="produtoId">
         <select id="produtoId" name="produtoId" value={form.produtoId} onChange={handleChange} className="input-base w-full" required>
           <option value="">Selecione</option>
-          {produtos.map((p) => (
-            <option key={p.id} value={p.id}>
-              {p.nome}
-            </option>
-          ))}
+      {produtos.map((p) => (
+        <option key={p.id} value={p.id}>
+          {p.nome}
+        </option>
+      ))}
         </select>
+        {produtoSel?.evento_id && (
+          <p className="text-sm mt-2">
+            Produto vinculado a evento.{' '}
+            <Link
+              href={`/inscricoes/lider/${user?.id}/evento/${produtoSel.evento_id}?cpf=${form.cpf}&email=${form.email}`}
+              className="text-primary underline"
+            >
+              Iniciar inscrição
+            </Link>
+          </p>
+        )}
       </FormField>
       <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
         <FormField label="Valor" htmlFor="valor">
-          <TextField id="valor" name="valor" type="number" value={form.valor} onChange={handleChange} required />
+          <TextField
+            id="valor"
+            name="valor"
+            type="number"
+            value={form.valor}
+            readOnly
+            required
+          />
         </FormField>
         <FormField label="Vencimento" htmlFor="vencimento">
           <TextField id="vencimento" name="vencimento" type="date" value={form.vencimento} onChange={handleChange} required />
+        </FormField>
+        <FormField label="Forma de Pagamento" htmlFor="paymentMethod">
+          <select
+            id="paymentMethod"
+            name="paymentMethod"
+            value={form.paymentMethod}
+            onChange={handleChange}
+            className="input-base w-full"
+          >
+            <option value="pix">Pix</option>
+            <option value="boleto">Boleto</option>
+          </select>
         </FormField>
       </div>
       <button type="submit" className="btn btn-primary" disabled={loading}>

--- a/docs/regras-pedidos.md
+++ b/docs/regras-pedidos.md
@@ -64,5 +64,12 @@ restrita aos coordenadores.
 
 Líderes podem registrar pedidos manuais acessando `/admin/pedidos/novo`.
 Esse fluxo cria um pedido sem vínculo a inscrição e utiliza `canal = 'avulso'`.
-O líder seleciona o produto, informa o valor, email do inscrito e data de
-vencimento. O pedido sempre pertence ao mesmo campo do líder autenticado.
+O líder seleciona o produto e o valor é preenchido automaticamente conforme o
+preço do item, sem possibilidade de edição. Além disso informa o email do
+inscrito, data de vencimento e a forma de pagamento (`pix` ou `boleto`). O
+pedido sempre pertence ao mesmo campo do líder autenticado. Antes de enviar, o
+formulário verifica se o CPF ou e‑mail já estão cadastrados e avisa sobre
+duplicidades, mas essa checagem não bloqueia a criação do pedido.
+Se o produto escolhido estiver vinculado a um evento, o formulário exibe um link
+para iniciar o fluxo de inscrição em `/inscricoes/lider/[liderId]/evento/[eventoId]`.
+Assim o líder pode cadastrar ou atualizar os dados do participante antes de gerar o pedido.

--- a/logs/DOC_LOG.md
+++ b/logs/DOC_LOG.md
@@ -591,3 +591,7 @@ na rota /loja/api/inscricoes e documentação atualizada. Lint e build executado
 ## [2025-07-15] Recuperacao de link busca pedido pendente ou vencido quando inscricao aguardando_pagamento. Lint e build executados.
 ## [2025-07-15] fetchAllPages acelera carregamento de dashboard e relatórios. Lint e build executados.
 ## [2025-08-20] Adicionada criação de pedido avulso por líderes e documentação atualizada. Lint e build executados.
+## [2025-07-16] Formulário de pedido avulso agora sugere inscrição quando o produto pertence a evento. Documentação atualizada. Lint e build executados.
+## [2025-07-16] Pedido avulso recebe campo de forma de pagamento e checagem de CPF duplicado. Lint e build executados.
+## [2025-07-16] Valor do pedido avulso agora é preenchido automaticamente com o preço do produto, sem edição manual. Lint e build executados.
+## [2025-07-16] Checagem de CPF/Email em pedido avulso não bloqueia geração de cobrança. Lint e build executados.

--- a/types/index.ts
+++ b/types/index.ts
@@ -60,6 +60,7 @@ export type Pedido = {
   campo?: string
   email: string
   canal: 'loja' | 'inscricao'
+  paymentMethod?: 'pix' | 'boleto'
   created?: string
   valor: string
   /** URL gerada pelo Asaas */


### PR DESCRIPTION
## Summary
- avoid blocking manual order submission when CPF/email already exist
- note in docs that duplicate data won't stop leaders from creating pedidos
- log documentation update

## Testing
- `npm run lint`
- `npm run build`
- `npm test` *(fails: out-of-memory and mocked exports errors)*
- `npm run a11y` *(fails: no test files found)*

------
https://chatgpt.com/codex/tasks/task_e_687795d83bf0832cbc9c27ac0b26d4e8