### PR TITLE
Add detailed rows to relatório PDF

### DIFF
--- a/app/admin/relatorio/page.tsx
+++ b/app/admin/relatorio/page.tsx
@@ -1,0 +1,308 @@
+'use client'
+
+import LayoutWrapperAdmin from '@/components/templates/LayoutWrapperAdmin'
+import { useAuthGuard } from '@/lib/hooks/useAuthGuard'
+import { generateRelatorioPdf } from '@/lib/report/generateRelatorioPdf'
+import { generateAnalisePdf } from '@/lib/report/generateAnalisePdf'
+import { useToast } from '@/lib/context/ToastContext'
+import { useEffect, useState, useRef } from 'react'
+import type { Pedido, Produto } from '@/types'
+import { fetchAllPages } from '@/lib/utils/fetchAllPages'
+import dynamic from 'next/dynamic'
+import { setupCharts } from '@/lib/chartSetup'
+import twColors from '@/utils/twColors'
+import colors from 'tailwindcss/colors'
+import type { Chart, ChartData } from 'chart.js'
+
+const BarChart = dynamic(() => import('react-chartjs-2').then((m) => m.Bar), {
+  ssr: false,
+})
+
+export default function RelatorioPage() {
+  const { user, authChecked } = useAuthGuard(['coordenador', 'lider'])
+  const { showError, showSuccess } = useToast()
+  const [pedidos, setPedidos] = useState<Pedido[]>([])
+  const [analysis, setAnalysis] = useState<'produtoCampo' | 'produtoCanalCampo'>(
+    'produtoCampo',
+  )
+  const [statusFilter, setStatusFilter] = useState('todos')
+  const [rows, setRows] = useState<(string | number)[][]>([])
+  const [chartData, setChartData] = useState<ChartData<'bar'>>({
+    labels: [],
+    datasets: [],
+  })
+  const chartRef = useRef<Chart<'bar'> | null>(null)
+
+  useEffect(() => {
+    setupCharts()
+  }, [])
+
+  useEffect(() => {
+    if (!authChecked || !user) return
+    const controller = new AbortController()
+    const signal = controller.signal
+    const fetchData = async () => {
+      try {
+        const params = new URLSearchParams({
+          page: '1',
+          perPage: '50',
+          expand: 'campo,produto',
+        })
+        const baseUrl = `/api/pedidos?${params.toString()}`
+        const res = await fetch(baseUrl, { credentials: 'include', signal })
+        if (!res.ok) throw new Error('Erro ao obter pedidos')
+        const data = await res.json()
+        const rest = await fetchAllPages<
+          { items?: Pedido[] } | Pedido
+        >(baseUrl, data.totalPages ?? 1, signal)
+        let lista: Pedido[] = Array.isArray(data.items)
+          ? (data.items as Pedido[])
+          : (data as Pedido[])
+        lista = lista.concat(
+          rest.flatMap((r) =>
+            Array.isArray((r as { items?: Pedido[] }).items)
+              ? ((r as { items: Pedido[] }).items)
+              : (r as Pedido),
+          ),
+        )
+        if (user.role === 'lider') {
+          lista = lista.filter((p: Pedido) => p.expand?.campo?.id === user.campo)
+        }
+        setPedidos(lista)
+      } catch (err) {
+        console.error('Erro ao carregar pedidos', err)
+        showError('Erro ao carregar pedidos')
+      }
+    }
+    fetchData()
+    return () => controller.abort()
+  }, [authChecked, user, showError])
+
+  useEffect(() => {
+    const filtered =
+      statusFilter === 'todos'
+        ? pedidos
+        : pedidos.filter((p) => p.status === statusFilter)
+    const rowsCalc: (string | number)[][] = []
+    let labels: string[] = []
+    let datasets: ChartData<'bar'>['datasets'] = []
+
+    if (analysis === 'produtoCampo') {
+      const count: Record<string, Record<string, number>> = {}
+      filtered.forEach((p) => {
+        const campo = p.expand?.campo?.nome || 'Sem campo'
+        const produtosData = Array.isArray(p.expand?.produto)
+          ? (p.expand?.produto as Produto[])
+          : p.expand?.produto
+            ? [(p.expand.produto as Produto)]
+            : []
+        if (produtosData.length === 0) {
+          count[campo] = count[campo] || {}
+          count[campo]['Sem produto'] = (count[campo]['Sem produto'] || 0) + 1
+        } else {
+          produtosData.forEach((pr: Produto) => {
+            const nome = pr?.nome || 'Sem produto'
+            count[campo] = count[campo] || {}
+            count[campo][nome] = (count[campo][nome] || 0) + 1
+          })
+        }
+      })
+      labels = Object.keys(count)
+      const produtos = Array.from(
+        new Set(labels.flatMap((c) => Object.keys(count[c])))
+      )
+      const palette = [
+        twColors.primary600,
+        twColors.error600,
+        twColors.blue500,
+        colors.emerald[500],
+        colors.amber[500],
+        colors.violet[500],
+      ]
+      datasets = produtos.map((prod, idx) => {
+        labels.forEach((campo) => {
+          const total = count[campo][prod]
+          if (total !== undefined) rowsCalc.push([campo, prod, total])
+        })
+        return {
+          label: prod,
+          data: labels.map((c) => count[c][prod] || 0),
+          backgroundColor: palette[idx % palette.length],
+          stack: 'stack',
+        }
+      })
+    } else {
+      const count: Record<string, Record<string, Record<string, number>>> = {}
+      filtered.forEach((p) => {
+        const campo = p.expand?.campo?.nome || 'Sem campo'
+        const canal = p.canal || 'indefinido'
+        const produtosData = Array.isArray(p.expand?.produto)
+          ? (p.expand?.produto as Produto[])
+          : p.expand?.produto
+            ? [(p.expand.produto as Produto)]
+            : []
+        if (produtosData.length === 0) {
+          count[campo] = count[campo] || {}
+          count[campo]['Sem produto'] = count[campo]['Sem produto'] || {}
+          count[campo]['Sem produto'][canal] =
+            (count[campo]['Sem produto'][canal] || 0) + 1
+        } else {
+          produtosData.forEach((pr: Produto) => {
+            const nome = pr?.nome || 'Sem produto'
+            count[campo] = count[campo] || {}
+            count[campo][nome] = count[campo][nome] || {}
+            count[campo][nome][canal] =
+              (count[campo][nome][canal] || 0) + 1
+          })
+        }
+      })
+      labels = Object.keys(count)
+      const combos = Array.from(
+        new Set(
+          labels.flatMap((c) =>
+            Object.keys(count[c]).flatMap((prod) =>
+              Object.keys(count[c][prod]).map((canal) => `${prod} (${canal})`),
+            ),
+          ),
+        ),
+      )
+      const palette = [
+        twColors.primary600,
+        twColors.error600,
+        twColors.blue500,
+        colors.emerald[500],
+        colors.amber[500],
+        colors.violet[500],
+      ]
+      datasets = combos.map((combo, idx) => {
+        const match = combo.match(/^(.*) \((.*)\)$/)
+        const prod = match?.[1] || ''
+        const canal = match?.[2] || ''
+        labels.forEach((campo) => {
+          const total = count[campo][prod]?.[canal]
+          if (total !== undefined) rowsCalc.push([campo, prod, canal, total])
+        })
+        return {
+          label: combo,
+          data: labels.map((c) => count[c][prod]?.[canal] || 0),
+          backgroundColor: palette[idx % palette.length],
+          stack: prod,
+        }
+      })
+    }
+
+    setRows(rowsCalc)
+    setChartData({ labels, datasets })
+  }, [analysis, pedidos, statusFilter])
+
+  const handleDownload = async () => {
+    try {
+      await generateRelatorioPdf()
+      showSuccess('PDF gerado com sucesso.')
+    } catch (err) {
+      console.error('Erro ao gerar PDF', err)
+      const message =
+        err instanceof Error && err.message.includes('Tempo')
+          ? 'Tempo esgotado ao gerar PDF.'
+          : 'Não foi possível gerar o PDF. Tente novamente.'
+      showError(message)
+    }
+  }
+
+  return (
+    <LayoutWrapperAdmin>
+      <div className="max-w-4xl mx-auto px-6 py-10 space-y-6">
+        <h1 className="text-3xl font-bold">Relatório</h1>
+
+        <button onClick={handleDownload} className="btn btn-primary px-3 py-1">
+          Baixar Regras (PDF)
+        </button>
+
+        <section>
+          <h2 className="text-2xl font-semibold mt-4">Análises</h2>
+          <div className="flex flex-wrap items-center gap-2 mt-2">
+            <select
+              value={analysis}
+              onChange={(e) =>
+                setAnalysis(
+                  e.target.value as 'produtoCampo' | 'produtoCanalCampo',
+                )
+              }
+              className="border rounded px-2 py-1"
+            >
+              <option value="produtoCampo">Produto x Campo</option>
+              <option value="produtoCanalCampo">Produto x Canal x Campo</option>
+            </select>
+            <select
+              value={statusFilter}
+              onChange={(e) => setStatusFilter(e.target.value)}
+              className="border rounded px-2 py-1"
+            >
+              <option value="todos">Todos</option>
+              <option value="pago">Pago</option>
+              <option value="pendente">Pendente</option>
+              <option value="vencido">Vencido</option>
+              <option value="cancelado">Cancelado</option>
+            </select>
+            <button
+              onClick={async () => {
+                try {
+                  const detailRows = pedidos.map((p) => [
+                    Array.isArray(p.expand?.produto)
+                      ? p.expand.produto
+                          .map((prod: Produto) => prod.nome)
+                          .join(', ')
+                      : (p.expand?.produto as Produto | undefined)?.nome ||
+                        (Array.isArray(p.produto)
+                          ? p.produto.join(', ')
+                          : p.produto ?? ''),
+                    p.expand?.id_inscricao?.nome || '',
+                    p.tamanho || '',
+                    p.expand?.campo?.nome || '',
+                    (p as unknown as { formaPagamento?: string }).formaPagamento ||
+                      '',
+                    p.created?.split('T')[0] || '',
+                  ])
+
+                  await generateAnalisePdf(
+                    analysis === 'produtoCampo'
+                      ? 'Análise Produto x Campo'
+                      : 'Análise Produto x Canal x Campo',
+                    analysis === 'produtoCampo'
+                      ? ['Campo', 'Produto', 'Total']
+                      : ['Campo', 'Produto', 'Canal', 'Total'],
+                    rows,
+                    detailRows,
+                    chartRef.current?.toBase64Image(),
+                  )
+                  showSuccess('PDF gerado com sucesso.')
+                } catch (err) {
+                  console.error('Erro ao gerar PDF', err)
+                  const message =
+                    err instanceof Error && err.message.includes('Tempo')
+                      ? 'Tempo esgotado ao gerar PDF.'
+                      : 'Não foi possível gerar o PDF. Tente novamente.'
+                  showError(message)
+                }
+              }}
+              className="btn btn-primary px-3 py-1"
+            >
+              Gerar PDF
+            </button>
+          </div>
+          <div className="mt-4 aspect-video">
+            <BarChart
+              ref={chartRef}
+              data={chartData}
+              options={{
+                responsive: true,
+                maintainAspectRatio: false,
+                scales: { x: { stacked: true }, y: { stacked: true } },
+              }}
+            />
+          </div>
+        </section>
+      </div>
+    </LayoutWrapperAdmin>
+  )
+}

--- a/components/templates/HeaderAdmin.tsx
+++ b/components/templates/HeaderAdmin.tsx
@@ -64,7 +64,7 @@ export default function Header() {
     { href: '/loja', label: 'Ver loja' },
   ]
 
-  const relatoriosLinks = [{ href: '/admin/relatorios', label: 'Relatório Geral' }]
+  const relatoriosLinks = [{ href: '/admin/relatorio', label: 'Relatório Geral' }]
 
   const gerenciamentoLinks =
     user?.role === 'lider'
@@ -590,7 +590,7 @@ export default function Header() {
               Relatórios
             </span>
             <Link
-              href="/admin/relatorios"
+              href="/admin/relatorio"
               onClick={() => setMenuAberto(false)}
               className="px-4 py-2 text-sm hover:bg-[var(--background)] hover:text-[var(--foreground)] rounded-md"
             >

--- a/lib/report/generateAnalisePdf.ts
+++ b/lib/report/generateAnalisePdf.ts
@@ -1,0 +1,82 @@
+import jsPDF from 'jspdf'
+import autoTable from 'jspdf-autotable'
+
+export async function generateAnalisePdf(
+  title: string,
+  headers: string[],
+  rows: (string | number)[][],
+  details?: (string | number)[][],
+  chart?: string,
+) {
+  return new Promise<void>((resolve, reject) => {
+    const timeout = setTimeout(() => {
+      reject(new Error('Tempo esgotado ao gerar PDF.'))
+    }, 5000)
+
+    try {
+      const doc = new jsPDF({ unit: 'pt', format: 'a4' })
+      doc.setFontSize(16)
+      doc.setFont('helvetica', 'bold')
+      doc.text(title, doc.internal.pageSize.getWidth() / 2, 40, {
+        align: 'center',
+      })
+
+      let y = 60
+      if (chart) {
+        doc.addImage(chart, 'PNG', 40, y, 520, 220)
+        y += 240
+      }
+
+      autoTable(doc, {
+        startY: y,
+        head: [headers],
+        body: rows,
+        theme: 'striped',
+        headStyles: { fillColor: [217, 217, 217], halign: 'center' },
+        styles: { fontSize: 10 },
+        margin: { left: 40, right: 40 },
+      })
+
+      if (details && details.length > 0) {
+        doc.addPage()
+        autoTable(doc, {
+          startY: 40,
+          head: [
+            [
+              'Produto',
+              'Nome',
+              'Tamanho',
+              'Campo',
+              'Forma de pagamento',
+              'Data',
+            ],
+          ],
+          body: details,
+          theme: 'striped',
+          headStyles: { fillColor: [217, 217, 217], halign: 'center' },
+          styles: { fontSize: 8 },
+          margin: { left: 20, right: 20 },
+        })
+      }
+
+      const pageCount = doc.getNumberOfPages()
+      for (let i = 1; i <= pageCount; i++) {
+        doc.setPage(i)
+        doc.setFontSize(10)
+        doc.text(
+          `Página ${i} de ${pageCount}`,
+          doc.internal.pageSize.getWidth() - 40,
+          doc.internal.pageSize.getHeight() - 20,
+          { align: 'right' },
+        )
+      }
+
+      doc.save('analise.pdf')
+      clearTimeout(timeout)
+      resolve()
+    } catch (err) {
+      clearTimeout(timeout)
+      reject(err)
+    }
+  })
+}

--- a/lib/report/generateRelatorioPdf.ts
+++ b/lib/report/generateRelatorioPdf.ts
@@ -1,0 +1,54 @@
+import jsPDF from 'jspdf'
+import template from './templateRelatorio.md'
+
+export async function generateRelatorioPdf() {
+  return new Promise<void>((resolve, reject) => {
+    const timeout = setTimeout(() => {
+      reject(new Error('Tempo esgotado ao gerar PDF.'))
+    }, 5000)
+
+    try {
+      const doc = new jsPDF({ unit: 'pt', format: 'a4' })
+      const lines = template.split('\n')
+      const title = lines[0].replace(/^#\s*/, '')
+      const body = lines.slice(1)
+
+      doc.setFontSize(16)
+      doc.setFont('helvetica', 'bold')
+      doc.text(title, doc.internal.pageSize.getWidth() / 2, 40, { align: 'center' })
+
+      doc.setFontSize(12)
+      doc.setFont('helvetica', 'normal')
+
+      let y = 70
+      body.forEach((line) => {
+        if (!line.trim()) {
+          y += 12
+          return
+        }
+        const splitted = doc.splitTextToSize(line, doc.internal.pageSize.getWidth() - 80)
+        doc.text(splitted, 40, y)
+        y += splitted.length * 12 + 8
+      })
+
+      const pages = doc.getNumberOfPages()
+      for (let i = 1; i <= pages; i++) {
+        doc.setPage(i)
+        doc.setFontSize(10)
+        doc.text(
+          `Página ${i} de ${pages}`,
+          doc.internal.pageSize.getWidth() - 40,
+          doc.internal.pageSize.getHeight() - 20,
+          { align: 'right' },
+        )
+      }
+
+      doc.save('relatorio.pdf')
+      clearTimeout(timeout)
+      resolve()
+    } catch (err) {
+      clearTimeout(timeout)
+      reject(err)
+    }
+  })
+}

--- a/lib/report/templateRelatorio.md
+++ b/lib/report/templateRelatorio.md
@@ -1,0 +1,19 @@
+# Relatório de Regras
+
+O sistema possui três formas principais de criação de pedidos e produtos. Este documento resume as orientações essenciais.
+
+## Pedidos
+- Coordenadores visualizam todos os pedidos, líderes apenas os do seu campo e usuários somente os próprios.
+- Os pedidos surgem pelo checkout da loja ou pela aprovação de inscrições. Em ambos, começam como `pendente` e mudam para `pago` após confirmação do Asaas.
+- Quando `confirma_inscricoes` está ativo, a inscrição precisa ser aprovada antes de gerar o pedido.
+- Cada pedido pode conter vários produtos e registra valor, status, vencimento e `canal`.
+
+## Produtos
+- **Independente** – vendido diretamente na loja (canal `loja`).
+- **Vinculado a evento sem aprovação** – cria pedido automático com canal `inscricao`.
+- **Vinculado a evento com aprovação** – exige inscrição aprovada para liberar a compra.
+
+## Campo `canal`
+- Indica a origem do pedido (`loja`, `inscricao` ou `avulso`). Pedidos avulsos são criados manualmente por líderes.
+
+Desenvolvido por M24 Tecnologia <m24saude.com.br>

--- a/logs/DOC_LOG.md
+++ b/logs/DOC_LOG.md
@@ -591,3 +591,8 @@ na rota /loja/api/inscricoes e documentação atualizada. Lint e build executado
 ## [2025-07-15] Recuperacao de link busca pedido pendente ou vencido quando inscricao aguardando_pagamento. Lint e build executados.
 ## [2025-07-15] fetchAllPages acelera carregamento de dashboard e relatórios. Lint e build executados.
 ## [2025-08-20] Adicionada criação de pedido avulso por líderes e documentação atualizada. Lint e build executados.
+## [2025-08-21] Criada rota /admin/relatorio com resumo das regras e exportação em PDF. Lint e build executados.
+
+## [2025-07-16] Relatorio admin apresenta analises por produto e canal com filtro de campo e exportacao em PDF. Lint e build executados.
+## [2025-07-16] PDF das análises inclui tabela detalhada de pedidos com forma de pagamento. Lint e build executados.
+## [2025-07-16] Página /admin/relatorio limpa, apenas gráficos. Filtro de status e gráficos exportados no PDF das análises. Lint e build executados.


### PR DESCRIPTION
## Summary
- gerar tabela detalhada em `generateAnalisePdf`
- incluir detalhes de pedidos ao exportar PDF de análises
- registrar atualização no `DOC_LOG`

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6877e1f7d174832cb5f0cbe3d5c44897