### PR TITLE
Enable Sentry User Feedback

### DIFF
--- a/logs/DOC_LOG.md
+++ b/logs/DOC_LOG.md
@@ -603,3 +603,4 @@ na rota /loja/api/inscricoes e documentação atualizada. Lint e build executado
 ## [2025-07-16] Página /admin/relatorio limpa, apenas gráficos. Filtro de status e gráficos exportados no PDF das análises. Lint e build executados.
 ## [2025-07-16] Relatorio PDF exibe totais por produto. Lint e build executados.
 ## [2025-07-16] Relatorio admin permite ordenar por campo ou data e remove PDF de regras. Lint e build executados.
+## [2025-07-17] Adicionado sentry.client.config.ts para coletar Feedback do Usuario via Sentry. Lint e build executados.

--- a/logs/DOC_LOG.md
+++ b/logs/DOC_LOG.md
@@ -604,3 +604,4 @@ na rota /loja/api/inscricoes e documentação atualizada. Lint e build executado
 ## [2025-07-16] Relatorio PDF exibe totais por produto. Lint e build executados.
 ## [2025-07-16] Relatorio admin permite ordenar por campo ou data e remove PDF de regras. Lint e build executados.
 ## [2025-07-17] Adicionado sentry.client.config.ts para coletar Feedback do Usuario via Sentry. Lint e build executados.
+## [2025-07-17] Integrada Sentry Replay com mascaramento de texto e bloqueio de mídia. Lint e build executados.

--- a/sentry.client.config.ts
+++ b/sentry.client.config.ts
@@ -3,8 +3,15 @@ import * as Sentry from '@sentry/nextjs'
 Sentry.init({
   dsn: process.env.SENTRY_DSN,
   integrations: [
+    Sentry.replayIntegration({
+      maskAllText: true,
+      blockAllMedia: true,
+    }),
     Sentry.feedbackIntegration({
       colorScheme: 'system',
     }),
   ],
+  // Session Replay
+  replaysSessionSampleRate: 0.1,
+  replaysOnErrorSampleRate: 1.0,
 })

--- a/sentry.client.config.ts
+++ b/sentry.client.config.ts
@@ -1,0 +1,10 @@
+import * as Sentry from '@sentry/nextjs'
+
+Sentry.init({
+  dsn: process.env.SENTRY_DSN,
+  integrations: [
+    Sentry.feedbackIntegration({
+      colorScheme: 'system',
+    }),
+  ],
+})


### PR DESCRIPTION
## Summary
- add Sentry client config with User Feedback integration
- log documentation updates

## Testing
- `npm run lint`
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_687900522c70832c8838bfe3187caee5