### PR TITLE
Adiciona padrões em cinza nos gráficos

### DIFF
--- a/app/admin/relatorio/page.tsx
+++ b/app/admin/relatorio/page.tsx
@@ -9,8 +9,7 @@ import type { Pedido, Produto } from '@/types'
 import { fetchAllPages } from '@/lib/utils/fetchAllPages'
 import dynamic from 'next/dynamic'
 import { setupCharts } from '@/lib/chartSetup'
-import twColors from '@/utils/twColors'
-import colors from 'tailwindcss/colors'
+import { createPattern, PatternType } from '@/utils/chartPatterns'
 import type { Chart, ChartData } from 'chart.js'
 
 const BarChart = dynamic(() => import('react-chartjs-2').then((m) => m.Bar), {
@@ -130,13 +129,11 @@ export default function RelatorioPage() {
       const produtos = Array.from(
         new Set(labels.flatMap((c) => Object.keys(count[c])))
       )
-      const palette = [
-        twColors.primary600,
-        twColors.error600,
-        twColors.blue500,
-        colors.emerald[500],
-        colors.amber[500],
-        colors.violet[500],
+      const patterns: PatternType[] = [
+        'diagonal',
+        'dots',
+        'cross',
+        'reverseDiagonal',
       ]
       datasets = produtos.map((prod, idx) => {
         labels.forEach((campo) => {
@@ -146,7 +143,11 @@ export default function RelatorioPage() {
         return {
           label: prod,
           data: labels.map((c) => count[c][prod] || 0),
-          backgroundColor: palette[idx % palette.length],
+          backgroundColor: createPattern(
+            patterns[idx % patterns.length],
+            '#666',
+          ),
+          borderColor: '#000',
           stack: 'stack',
         }
       })
@@ -187,13 +188,11 @@ export default function RelatorioPage() {
           ),
         ),
       )
-      const palette = [
-        twColors.primary600,
-        twColors.error600,
-        twColors.blue500,
-        colors.emerald[500],
-        colors.amber[500],
-        colors.violet[500],
+      const patterns: PatternType[] = [
+        'diagonal',
+        'dots',
+        'cross',
+        'reverseDiagonal',
       ]
       datasets = combos.map((combo, idx) => {
         const match = combo.match(/^(.*) \((.*)\)$/)
@@ -206,7 +205,11 @@ export default function RelatorioPage() {
         return {
           label: combo,
           data: labels.map((c) => count[c][prod]?.[canal] || 0),
-          backgroundColor: palette[idx % palette.length],
+          backgroundColor: createPattern(
+            patterns[idx % patterns.length],
+            '#666',
+          ),
+          borderColor: '#000',
           stack: prod,
         }
       })

--- a/docs/Relatorios/padronizacao_relatorios.txt
+++ b/docs/Relatorios/padronizacao_relatorios.txt
@@ -49,6 +49,7 @@ Este documento define as diretrizes para criação de relatórios em PDF estáti
 
 - **Uso**: Comparativo de totais por região.
 - **Texturas**: Hachuras (linhas diagonais, pontos, listras verticais) para cada região.
+- **Implementação**: Nos gráficos gerados via Chart.js utilize padrões em tons de cinza para cada dataset (diagonal, pontos, cruzado).
 - **Eixos**: Eixo X na base; rótulos externos.
 - **Legenda**: À direita, com amostra da textura e nome da região.
 

--- a/lib/report/generateDashboardPdf.ts
+++ b/lib/report/generateDashboardPdf.ts
@@ -2,6 +2,32 @@ import jsPDF from 'jspdf'
 import autoTable from 'jspdf-autotable'
 import template from './template.md'
 
+async function toGrayscale(src: string): Promise<string> {
+  return new Promise((resolve) => {
+    const img = new Image()
+    img.onload = () => {
+      const canvas = document.createElement('canvas')
+      canvas.width = img.width
+      canvas.height = img.height
+      const ctx = canvas.getContext('2d')!
+      ctx.drawImage(img, 0, 0)
+      const data = ctx.getImageData(0, 0, canvas.width, canvas.height)
+      for (let i = 0; i < data.data.length; i += 4) {
+        const r = data.data[i]
+        const g = data.data[i + 1]
+        const b = data.data[i + 2]
+        const gray = r * 0.3 + g * 0.59 + b * 0.11
+        data.data[i] = gray
+        data.data[i + 1] = gray
+        data.data[i + 2] = gray
+      }
+      ctx.putImageData(data, 0, 0)
+      resolve(canvas.toDataURL('image/png'))
+    }
+    img.src = src
+  })
+}
+
 export interface DashboardMetrics {
   labels: string[]
   inscricoes: number[]
@@ -33,7 +59,7 @@ export async function generateDashboardPdf(
   periodo: Periodo,
   charts: ChartImages = {},
 ) {
-  return new Promise<void>((resolve, reject) => {
+  return new Promise<void>(async (resolve, reject) => {
     const timeout = setTimeout(() => {
       reject(new Error('Tempo esgotado ao gerar PDF.'))
     }, 10_000)
@@ -74,22 +100,26 @@ export async function generateDashboardPdf(
       y += 20
 
       if (charts.inscricoes) {
-        doc.addImage(charts.inscricoes, 'PNG', 40, y, 520, 220)
+        const img = await toGrayscale(charts.inscricoes)
+        doc.addImage(img, 'PNG', 40, y, 520, 220)
         y += 240
       }
 
       if (charts.pedidos) {
-        doc.addImage(charts.pedidos, 'PNG', 40, y, 520, 220)
+        const img = await toGrayscale(charts.pedidos)
+        doc.addImage(img, 'PNG', 40, y, 520, 220)
         y += 240
       }
 
       if (charts.campoProduto) {
-        doc.addImage(charts.campoProduto, 'PNG', 40, y, 520, 220)
+        const img = await toGrayscale(charts.campoProduto)
+        doc.addImage(img, 'PNG', 40, y, 520, 220)
         y += 240
       }
 
       if (charts.arrecadacao) {
-        doc.addImage(charts.arrecadacao, 'PNG', 40, y, 520, 220)
+        const img = await toGrayscale(charts.arrecadacao)
+        doc.addImage(img, 'PNG', 40, y, 520, 220)
         y += 240
       }
 

--- a/logs/DOC_LOG.md
+++ b/logs/DOC_LOG.md
@@ -605,3 +605,4 @@ na rota /loja/api/inscricoes e documentação atualizada. Lint e build executado
 ## [2025-07-16] Relatorio admin permite ordenar por campo ou data e remove PDF de regras. Lint e build executados.
 ## [2025-07-17] Adicionado sentry.client.config.ts para coletar Feedback do Usuario via Sentry. Lint e build executados.
 ## [2025-07-17] Integrada Sentry Replay com mascaramento de texto e bloqueio de mídia. Lint e build executados.
+## [2025-07-17] Gráficos exportados em tons de cinza com padrões de hachura. Lint e build executados.

--- a/utils/chartPatterns.ts
+++ b/utils/chartPatterns.ts
@@ -1,0 +1,40 @@
+export type PatternType = 'diagonal' | 'dots' | 'cross' | 'reverseDiagonal'
+
+export function createPattern(type: PatternType, color = '#000'): CanvasPattern {
+  const size = 8
+  const canvas = document.createElement('canvas')
+  canvas.width = size
+  canvas.height = size
+  const ctx = canvas.getContext('2d')!
+  ctx.strokeStyle = color
+  ctx.fillStyle = color
+  switch (type) {
+    case 'diagonal':
+      ctx.beginPath()
+      ctx.moveTo(0, size)
+      ctx.lineTo(size, 0)
+      ctx.stroke()
+      break
+    case 'reverseDiagonal':
+      ctx.beginPath()
+      ctx.moveTo(0, 0)
+      ctx.lineTo(size, size)
+      ctx.stroke()
+      break
+    case 'cross':
+      ctx.beginPath()
+      ctx.moveTo(0, 0)
+      ctx.lineTo(size, size)
+      ctx.moveTo(size, 0)
+      ctx.lineTo(0, size)
+      ctx.stroke()
+      break
+    case 'dots':
+    default:
+      ctx.beginPath()
+      ctx.arc(size / 2, size / 2, 1.5, 0, Math.PI * 2)
+      ctx.fill()
+      break
+  }
+  return ctx.createPattern(canvas, 'repeat')!
+}


### PR DESCRIPTION
## Summary
- cria `chartPatterns` para gerar texturas básicas
- converte imagens do dashboard para tons de cinza
- aplica padrões hachurados nos gráficos do relatório
- documenta uso de padrões no guia de relatórios
- registra alteração em `DOC_LOG`

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_687930202510832c91cfc63e4f678401