### PR TITLE
Padroniza margens de PDFs

### DIFF
--- a/lib/report/generateAnalisePdf.ts
+++ b/lib/report/generateAnalisePdf.ts
@@ -15,16 +15,19 @@ export async function generateAnalisePdf(
     }, 5000)
 
     try {
+      const margin = { top: 56.7, bottom: 56.7, left: 56.7, right: 56.7 }
       const doc = new jsPDF({ unit: 'pt', format: 'a4' })
+      const pageWidth = doc.internal.pageSize.getWidth()
+      const contentWidth = pageWidth - margin.left - margin.right
       doc.setFontSize(16)
       doc.setFont('helvetica', 'bold')
-      doc.text(title, doc.internal.pageSize.getWidth() / 2, 40, {
+      doc.text(title, pageWidth / 2, margin.top, {
         align: 'center',
       })
 
-      let y = 60
+      let y = margin.top + 20
       if (chart) {
-        doc.addImage(chart, 'PNG', 40, y, 520, 220)
+        doc.addImage(chart, 'PNG', margin.left, y, contentWidth, 220)
         y += 240
       }
 
@@ -35,7 +38,7 @@ export async function generateAnalisePdf(
         theme: 'striped',
         headStyles: { fillColor: [217, 217, 217], halign: 'center' },
         styles: { fontSize: 10 },
-        margin: { left: 40, right: 40 },
+        margin,
       })
 
       if (totals && Object.keys(totals).length > 0) {
@@ -50,14 +53,14 @@ export async function generateAnalisePdf(
           theme: 'striped',
           headStyles: { fillColor: [217, 217, 217], halign: 'center' },
           styles: { fontSize: 10 },
-          margin: { left: 40, right: 40 },
+          margin,
         })
       }
 
       if (details && details.length > 0) {
         doc.addPage()
         autoTable(doc, {
-          startY: 40,
+          startY: margin.top,
           head: [
             [
               'Produto',
@@ -72,7 +75,7 @@ export async function generateAnalisePdf(
           theme: 'striped',
           headStyles: { fillColor: [217, 217, 217], halign: 'center' },
           styles: { fontSize: 8 },
-          margin: { left: 20, right: 20 },
+          margin,
         })
       }
 
@@ -85,13 +88,13 @@ export async function generateAnalisePdf(
         const date = new Date().toLocaleString('pt-BR', {
           timeZone: 'America/Sao_Paulo',
         })
-        doc.text(date, doc.internal.pageSize.getWidth() - 40, pageHeight - 20, {
+        doc.text(date, pageWidth - margin.right, pageHeight - 20, {
           align: 'right',
         })
 
         doc.text(
           `Página ${i} de ${pageCount}`,
-          doc.internal.pageSize.getWidth() / 2,
+          pageWidth / 2,
           pageHeight - 20,
           { align: 'center' },
         )

--- a/lib/report/generateRelatorioPdf.ts
+++ b/lib/report/generateRelatorioPdf.ts
@@ -8,26 +8,29 @@ export async function generateRelatorioPdf() {
     }, 5000)
 
     try {
+      const margin = { top: 56.7, bottom: 56.7, left: 56.7, right: 56.7 }
       const doc = new jsPDF({ unit: 'pt', format: 'a4' })
+      const pageWidth = doc.internal.pageSize.getWidth()
+      const contentWidth = pageWidth - margin.left - margin.right
       const lines = template.split('\n')
       const title = lines[0].replace(/^#\s*/, '')
       const body = lines.slice(1)
 
       doc.setFontSize(16)
       doc.setFont('helvetica', 'bold')
-      doc.text(title, doc.internal.pageSize.getWidth() / 2, 40, { align: 'center' })
+      doc.text(title, pageWidth / 2, margin.top, { align: 'center' })
 
       doc.setFontSize(12)
       doc.setFont('helvetica', 'normal')
 
-      let y = 70
+      let y = margin.top + 30
       body.forEach((line) => {
         if (!line.trim()) {
           y += 12
           return
         }
-        const splitted = doc.splitTextToSize(line, doc.internal.pageSize.getWidth() - 80)
-        doc.text(splitted, 40, y)
+        const splitted = doc.splitTextToSize(line, contentWidth)
+        doc.text(splitted, margin.left, y)
         y += splitted.length * 12 + 8
       })
 
@@ -40,13 +43,13 @@ export async function generateRelatorioPdf() {
         const date = new Date().toLocaleString('pt-BR', {
           timeZone: 'America/Sao_Paulo',
         })
-        doc.text(date, doc.internal.pageSize.getWidth() - 40, pageHeight - 20, {
+        doc.text(date, pageWidth - margin.right, pageHeight - 20, {
           align: 'right',
         })
 
         doc.text(
           `Página ${i} de ${pages}`,
-          doc.internal.pageSize.getWidth() / 2,
+          pageWidth / 2,
           pageHeight - 20,
           { align: 'center' },
         )

--- a/logs/DOC_LOG.md
+++ b/logs/DOC_LOG.md
@@ -606,3 +606,4 @@ na rota /loja/api/inscricoes e documentação atualizada. Lint e build executado
 ## [2025-07-17] Adicionado sentry.client.config.ts para coletar Feedback do Usuario via Sentry. Lint e build executados.
 ## [2025-07-17] Integrada Sentry Replay com mascaramento de texto e bloqueio de mídia. Lint e build executados.
 ## [2025-07-17] Gráficos exportados em tons de cinza com padrões de hachura. Lint e build executados.
+## [2025-07-17] Margens dos PDFs normalizadas para 20mm. Lint e build executados.


### PR DESCRIPTION
## Resumo
- ajusta funcoes de geracao para margem padrao de 20mm
- mantem grid nas tabelas e imagens
- registra atualizacao no log de documentacao

## Testes
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68793730f374832cb77ac83c95bb51a9