### PR TITLE
Remove unused email/canal filters from docs

### DIFF
--- a/docs/Documentacao_M24.md
+++ b/docs/Documentacao_M24.md
@@ -286,7 +286,7 @@ Para cada coleção, utilize a seguinte estrutura:
 
 | Rota                      | Métodos | Descrição                                              |
 | ------------------------- | ------- | ------------------------------------------------------ |
-| `GET  /api/pedidos`       | GET     | Lista pedidos (filtros por `status`, `email`, `canal`) |
+| `GET  /api/pedidos`       | GET     | Lista pedidos (filtros por `status`) |
 | `GET  /api/pedidos/:id`   | GET     | Detalha um pedido                                      |
 | `POST /api/pedidos`       | POST    | Cria novo pedido (fluxo de loja ou inscrição)          |
 | `PATCH /api/pedidos/:id`  | PATCH   | Atualiza status ou outros campos do pedido             |

--- a/logs/DOC_LOG.md
+++ b/logs/DOC_LOG.md
@@ -605,3 +605,4 @@ na rota /loja/api/inscricoes e documentação atualizada. Lint e build executado
 ## [2025-07-16] Relatorio admin permite ordenar por campo ou data e remove PDF de regras. Lint e build executados.
 ## [2025-07-17] Adicionado sentry.client.config.ts para coletar Feedback do Usuario via Sentry. Lint e build executados.
 ## [2025-07-17] Integrada Sentry Replay com mascaramento de texto e bloqueio de mídia. Lint e build executados.
+## [2025-07-17] Removida referência aos filtros `email` e `canal` no endpoint /api/pedidos em docs/Documentacao_M24.md. Lint e build executados.


### PR DESCRIPTION
## Summary
- update the pedidos endpoint docs to remove unused `email` and `canal` filters
- log documentation change

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_687936e1fa70832c8d0379c1040f3ed3