### PR TITLE
Adjust PDF export margins and footer

### DIFF
--- a/app/admin/inscricoes/page.tsx
+++ b/app/admin/inscricoes/page.tsx
@@ -495,13 +495,14 @@ export default function ListaInscricoesPage() {
     useState<Inscricao | null>(null)
 
   const exportarPDF = () => {
+    const MARGINS = { top: 56.7, bottom: 56.7, left: 56.7, right: 56.7 }
     const doc = new jsPDF({ unit: 'pt', format: 'a4' })
     doc.setFontSize(16)
     doc.setFont('helvetica', 'bold')
     doc.text(
       'Relat\u00F3rio de Inscri\u00E7\u00F5es',
       doc.internal.pageSize.getWidth() / 2,
-      40,
+      MARGINS.top,
       {
         align: 'center',
       },
@@ -519,15 +520,18 @@ export default function ListaInscricoesPage() {
     ])
 
     autoTable(doc, {
-      startY: 60,
+      startY: MARGINS.top + 20,
       head: [['Nome', 'Telefone', 'Evento', 'Status', 'Campo', 'Criado em']],
       body: linhas,
       theme: 'striped',
       headStyles: { fillColor: [217, 217, 217], halign: 'center' },
       styles: { fontSize: 8 },
-      margin: { left: 20, right: 20 },
+      margin: MARGINS,
     })
 
+    const dataHora = new Date().toLocaleString('pt-BR', {
+      timeZone: 'America/Sao_Paulo',
+    })
     const pageCount = doc.getNumberOfPages()
     for (let i = 1; i <= pageCount; i++) {
       doc.setPage(i)
@@ -535,12 +539,18 @@ export default function ListaInscricoesPage() {
       doc.setFontSize(10)
       doc.text(
         'Desenvolvido por M24 Tecnologia <m24saude.com.br>',
-        40,
+        MARGINS.left,
         pageHeight - 20,
       )
       doc.text(
         `P\u00E1gina ${i} de ${pageCount}`,
-        doc.internal.pageSize.getWidth() - 40,
+        doc.internal.pageSize.getWidth() / 2,
+        pageHeight - 20,
+        { align: 'center' },
+      )
+      doc.text(
+        dataHora,
+        doc.internal.pageSize.getWidth() - MARGINS.right,
         pageHeight - 20,
         { align: 'right' },
       )

--- a/app/admin/pedidos/page.tsx
+++ b/app/admin/pedidos/page.tsx
@@ -193,13 +193,14 @@ export default function PedidosPage() {
       return ordem === 'asc' ? dataA - dataB : dataB - dataA
     })
 
+    const MARGINS = { top: 56.7, bottom: 56.7, left: 56.7, right: 56.7 }
     const doc = new jsPDF({ unit: 'pt', format: 'a4' })
     doc.setFontSize(16)
     doc.setFont('helvetica', 'bold')
     doc.text(
       'Relat\u00F3rio de Pedidos',
       doc.internal.pageSize.getWidth() / 2,
-      40,
+      MARGINS.top,
       {
         align: 'center',
       },
@@ -221,7 +222,7 @@ export default function PedidosPage() {
     ])
 
     autoTable(doc, {
-      startY: 60,
+      startY: MARGINS.top + 20,
       head: [
         [
           'Produto',
@@ -238,9 +239,12 @@ export default function PedidosPage() {
       theme: 'striped',
       headStyles: { fillColor: [217, 217, 217], halign: 'center' },
       styles: { fontSize: 8 },
-      margin: { left: 20, right: 20 },
+      margin: MARGINS,
     })
 
+    const dataHora = new Date().toLocaleString('pt-BR', {
+      timeZone: 'America/Sao_Paulo',
+    })
     const pageCount = doc.getNumberOfPages()
     for (let i = 1; i <= pageCount; i++) {
       doc.setPage(i)
@@ -248,12 +252,18 @@ export default function PedidosPage() {
       doc.setFontSize(10)
       doc.text(
         'Desenvolvido por M24 Tecnologia <m24saude.com.br>',
-        40,
+        MARGINS.left,
         pageHeight - 20,
       )
       doc.text(
         `P\u00E1gina ${i} de ${pageCount}`,
-        doc.internal.pageSize.getWidth() - 40,
+        doc.internal.pageSize.getWidth() / 2,
+        pageHeight - 20,
+        { align: 'center' },
+      )
+      doc.text(
+        dataHora,
+        doc.internal.pageSize.getWidth() - MARGINS.right,
         pageHeight - 20,
         { align: 'right' },
       )

--- a/logs/DOC_LOG.md
+++ b/logs/DOC_LOG.md
@@ -607,3 +607,4 @@ na rota /loja/api/inscricoes e documentação atualizada. Lint e build executado
 ## [2025-07-17] Integrada Sentry Replay com mascaramento de texto e bloqueio de mídia. Lint e build executados.
 ## [2025-07-17] Gráficos exportados em tons de cinza com padrões de hachura. Lint e build executados.
 ## [2025-07-17] Margens dos PDFs normalizadas para 20mm. Lint e build executados.
+## [2025-07-17] Atualizadas rotinas de exportação nos relatórios para usar margens de 56.7pt e rodapé com data/hora. Lint e build executados.


### PR DESCRIPTION
## Summary
- update `exportarPDF` in inscrições and pedidos pages to set uniform 56.7pt margins
- center page numbering and show timestamp on the right in São Paulo timezone
- log update regarding export routines

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68793faf0fec832cb2aca1c02d016193