### PR TITLE
Fix Relatorio expand

### DIFF
--- a/app/admin/relatorio/page.tsx
+++ b/app/admin/relatorio/page.tsx
@@ -60,7 +60,7 @@ export default function RelatorioPage() {
         const params = new URLSearchParams({
           page: '1',
           perPage: '50',
-          expand: 'campo,produto',
+          expand: 'campo,produto,id_inscricao',
         })
         const baseUrl = `/api/pedidos?${params.toString()}`
         const res = await fetch(baseUrl, { credentials: 'include', signal })

--- a/logs/ERR_LOG.md
+++ b/logs/ERR_LOG.md
@@ -282,3 +282,4 @@
 ## [2025-08-18] ConsultaInscricao sobrescrevia CPF/email do lider ao logar, exibindo inscricao errada e redirecionando para home. Efeito ajustado para manter valores digitados. - dev - 3155a7a1
 ## [2025-08-19] EventForm buscava inscricoes pendentes de todo o campo para lider, exibindo inscricoes de subordinados e bloqueando prosseguimento. Lista agora filtrada para mostrar apenas as inscricoes do usuario logado. - dev - 7b24a941
 ## [2025-07-17] Lista de pedidos nao atualizava paginacao ao aplicar filtros. Paginas recalculadas e pagina atual redefinida. - dev - 04cd8656
+## [2025-07-17] Relatório não incluía expand id_inscricao na busca; adicionada no URLSearchParams - dev - 62e63764


### PR DESCRIPTION
## Summary
- include `id_inscricao` in `URLSearchParams` for the report page
- log the fix in `ERR_LOG.md`

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68793fd7aa04832c8133c98c75184ac4