### PR TITLE
Fix Relatorio expand

### DIFF
--- a/app/admin/relatorio/page.tsx
+++ b/app/admin/relatorio/page.tsx
@@ -60,7 +60,7 @@ export default function RelatorioPage() {
         const params = new URLSearchParams({
           page: '1',
           perPage: '50',
-          expand: 'campo,produto',
+          expand: 'campo,produto,id_inscricao',
         })
         const baseUrl = `/api/pedidos?${params.toString()}`
         const res = await fetch(baseUrl, { credentials: 'include', signal })

--- a/app/admin/relatorio/page.tsx
+++ b/app/admin/relatorio/page.tsx
@@ -60,7 +60,7 @@ export default function RelatorioPage() {
         const params = new URLSearchParams({
           page: '1',
           perPage: '50',
-          expand: 'campo,produto,id_inscricao',
+          expand: 'campo,produto,id_inscricao,responsavel',
         })
         const baseUrl = `/api/pedidos?${params.toString()}`
         const res = await fetch(baseUrl, { credentials: 'include', signal })
@@ -279,7 +279,9 @@ export default function RelatorioPage() {
                         (Array.isArray(p.produto)
                           ? p.produto.join(', ')
                           : p.produto ?? ''),
-                    p.expand?.id_inscricao?.nome || '',
+                    p.expand?.id_inscricao?.nome ||
+                      p.expand?.responsavel?.nome ||
+                      '',
                     p.tamanho || '',
                     p.expand?.campo?.nome || '',
                     (p as unknown as { formaPagamento?: string }).formaPagamento ||

--- a/logs/ERR_LOG.md
+++ b/logs/ERR_LOG.md
@@ -283,3 +283,4 @@
 ## [2025-08-19] EventForm buscava inscricoes pendentes de todo o campo para lider, exibindo inscricoes de subordinados e bloqueando prosseguimento. Lista agora filtrada para mostrar apenas as inscricoes do usuario logado. - dev - 7b24a941
 ## [2025-07-17] Lista de pedidos nao atualizava paginacao ao aplicar filtros. Paginas recalculadas e pagina atual redefinida. - dev - 04cd8656
 ## [2025-07-17] Relatório não incluía expand id_inscricao na busca; adicionada no URLSearchParams - dev - 2b383b28
+## [2025-07-17] Relatório buscava apenas inscricao, mas alguns pedidos sem id_inscricao ficavam sem nome. Agora utiliza nome do responsavel se necessario. - dev - 99cf75a8

--- a/logs/ERR_LOG.md
+++ b/logs/ERR_LOG.md
@@ -282,3 +282,4 @@
 ## [2025-08-18] ConsultaInscricao sobrescrevia CPF/email do lider ao logar, exibindo inscricao errada e redirecionando para home. Efeito ajustado para manter valores digitados. - dev - 3155a7a1
 ## [2025-08-19] EventForm buscava inscricoes pendentes de todo o campo para lider, exibindo inscricoes de subordinados e bloqueando prosseguimento. Lista agora filtrada para mostrar apenas as inscricoes do usuario logado. - dev - 7b24a941
 ## [2025-07-17] Lista de pedidos nao atualizava paginacao ao aplicar filtros. Paginas recalculadas e pagina atual redefinida. - dev - 04cd8656
+## [2025-07-17] Relatório não incluía expand id_inscricao na busca; adicionada no URLSearchParams - dev - 2b383b28

--- a/types/index.ts
+++ b/types/index.ts
@@ -86,6 +86,10 @@ export type Pedido = {
       telefone?: string
       cpf?: string
     }
+    responsavel?: {
+      id: string
+      nome: string
+    }
     evento?: Evento
     /** Produto associado ao pedido */
     produto?: Produto | Produto[]


### PR DESCRIPTION
## Summary
- include `id_inscricao` in `URLSearchParams` for the report page
- update error log entry with correct commit hash

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68793fd7aa04832c8133c98c75184ac4