### PR TITLE
Ajusta paginação de inscrições

### DIFF
--- a/logs/ERR_LOG.md
+++ b/logs/ERR_LOG.md
@@ -283,3 +283,4 @@
 ## [2025-08-19] EventForm buscava inscricoes pendentes de todo o campo para lider, exibindo inscricoes de subordinados e bloqueando prosseguimento. Lista agora filtrada para mostrar apenas as inscricoes do usuario logado. - dev - 7b24a941
 ## [2025-07-17] Lista de pedidos nao atualizava paginacao ao aplicar filtros. Paginas recalculadas e pagina atual redefinida. - dev - 04cd8656
 ## [2025-07-17] Pedidos buscavam apenas a primeira pagina; resultado incompleto e paginacao incorreta. Fetch atualizado para usar fetchAllPages e pagina resetada ao alterar filtros globais. - dev - a2bf8fc4
+## [2025-07-17] Inscricoes buscavam paginas manualmente; fetchAllPages adotado e paginacao recalculada ao filtrar. - dev - ac1da4cd


### PR DESCRIPTION
## Resumo
- adiciona `PER_PAGE` e estados de paginação na página de inscrições
- usa `fetchAllPages` para obter todas as páginas de inscrições
- recalcula total de páginas ao filtrar inscrições
- reinclui UI de paginação
- registra ajuste no `ERR_LOG`

## Testes
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_687948ae4734832cb794987603624d8b