### PR TITLE
Padroniza margens e fontes em PDFs

### DIFF
--- a/app/admin/financeiro/saldo/page.tsx
+++ b/app/admin/financeiro/saldo/page.tsx
@@ -8,6 +8,12 @@ import LoadingOverlay from '@/components/organisms/LoadingOverlay'
 import * as XLSX from 'xlsx'
 import jsPDF from 'jspdf'
 import autoTable from 'jspdf-autotable'
+import {
+  PDF_MARGINS,
+  FONT_SIZE_TITLE,
+  FONT_SIZE_BODY,
+  FONT_SIZE_FOOTER,
+} from '@/lib/report/constants'
 import { useAuthGuard } from '@/lib/hooks/useAuthGuard'
 import { DateRangePicker } from '@/components/molecules'
 import { useTenant } from '@/lib/context/TenantContext'
@@ -171,20 +177,20 @@ export default function SaldoPage() {
     }
 
     if (imgData) {
-      doc.addImage(imgData, 'PNG', 40, 40, 60, 30)
+      doc.addImage(imgData, 'PNG', PDF_MARGINS.left, PDF_MARGINS.top - 16, 60, 30)
     }
 
-    doc.setFontSize(16)
+    doc.setFontSize(FONT_SIZE_TITLE)
     doc.setFont('helvetica', 'bold')
     doc.text(
       'Extrato de Movimentações',
       doc.internal.pageSize.getWidth() / 2,
-      60,
+      PDF_MARGINS.top,
       {
         align: 'center',
       },
     )
-    doc.setFontSize(11)
+    doc.setFontSize(FONT_SIZE_BODY)
     doc.setFont('helvetica', 'normal')
 
     const startText = range.start
@@ -194,7 +200,7 @@ export default function SaldoPage() {
       ? new Date(range.end).toLocaleDateString('pt-BR')
       : ''
     const period = `Período: ${startText} – ${endText}`
-    doc.text(period, doc.internal.pageSize.getWidth() - 40, 80, {
+    doc.text(period, doc.internal.pageSize.getWidth() - PDF_MARGINS.right, PDF_MARGINS.top + 20, {
       align: 'right',
     })
 
@@ -205,7 +211,7 @@ export default function SaldoPage() {
     ])
 
     autoTable(doc, {
-      startY: 100,
+      startY: PDF_MARGINS.top + 40,
       head: [['Data', 'Descrição', 'Valor (R$)']],
       body: rows,
       theme: 'striped',
@@ -216,22 +222,22 @@ export default function SaldoPage() {
         1: { cellWidth: 340 },
         2: { cellWidth: 80, halign: 'right' },
       },
-      margin: { left: 40, right: 40 },
+      margin: { left: PDF_MARGINS.left, right: PDF_MARGINS.right },
     })
 
     const pageCount = doc.getNumberOfPages()
     for (let i = 1; i <= pageCount; i++) {
       doc.setPage(i)
       const pageHeight = doc.internal.pageSize.getHeight()
-      doc.setFontSize(10)
+      doc.setFontSize(FONT_SIZE_FOOTER)
       doc.text(
         'Desenvolvido por M24 Tecnologia <m24saude.com.br>',
-        40,
+        PDF_MARGINS.left,
         pageHeight - 20,
       )
       doc.text(
         `Página ${i} de ${pageCount}`,
-        doc.internal.pageSize.getWidth() - 40,
+        doc.internal.pageSize.getWidth() - PDF_MARGINS.right,
         pageHeight - 20,
         { align: 'right' },
       )

--- a/app/admin/inscricoes/page.tsx
+++ b/app/admin/inscricoes/page.tsx
@@ -7,6 +7,12 @@ import { getAuthHeaders } from '@/lib/authHeaders'
 import { Copy } from 'lucide-react'
 import jsPDF from 'jspdf'
 import autoTable from 'jspdf-autotable'
+import {
+  PDF_MARGINS,
+  FONT_SIZE_TITLE,
+  FONT_SIZE_BODY,
+  FONT_SIZE_FOOTER,
+} from '@/lib/report/constants'
 import LoadingOverlay from '@/components/organisms/LoadingOverlay'
 import ModalEditarInscricao from './componentes/ModalEdit'
 import ModalVisualizarPedido from './componentes/ModalVisualizarPedido'
@@ -505,19 +511,18 @@ export default function ListaInscricoesPage() {
     useState<Inscricao | null>(null)
 
   const exportarPDF = () => {
-    const MARGINS = { top: 56.7, bottom: 56.7, left: 56.7, right: 56.7 }
     const doc = new jsPDF({ unit: 'pt', format: 'a4' })
-    doc.setFontSize(16)
+    doc.setFontSize(FONT_SIZE_TITLE)
     doc.setFont('helvetica', 'bold')
     doc.text(
       'Relat\u00F3rio de Inscri\u00E7\u00F5es',
       doc.internal.pageSize.getWidth() / 2,
-      MARGINS.top,
+      PDF_MARGINS.top,
       {
         align: 'center',
       },
     )
-    doc.setFontSize(11)
+    doc.setFontSize(FONT_SIZE_BODY)
     doc.setFont('helvetica', 'normal')
 
     const linhas = inscricoes.map((i) => [
@@ -530,13 +535,13 @@ export default function ListaInscricoesPage() {
     ])
 
     autoTable(doc, {
-      startY: MARGINS.top + 20,
+      startY: PDF_MARGINS.top + 20,
       head: [['Nome', 'Telefone', 'Evento', 'Status', 'Campo', 'Criado em']],
       body: linhas,
       theme: 'striped',
       headStyles: { fillColor: [217, 217, 217], halign: 'center' },
       styles: { fontSize: 8 },
-      margin: MARGINS,
+      margin: PDF_MARGINS,
     })
 
     const dataHora = new Date().toLocaleString('pt-BR', {
@@ -546,10 +551,10 @@ export default function ListaInscricoesPage() {
     for (let i = 1; i <= pageCount; i++) {
       doc.setPage(i)
       const pageHeight = doc.internal.pageSize.getHeight()
-      doc.setFontSize(10)
+      doc.setFontSize(FONT_SIZE_FOOTER)
       doc.text(
         'Desenvolvido por M24 Tecnologia <m24saude.com.br>',
-        MARGINS.left,
+        PDF_MARGINS.left,
         pageHeight - 20,
       )
       doc.text(
@@ -560,7 +565,7 @@ export default function ListaInscricoesPage() {
       )
       doc.text(
         dataHora,
-        doc.internal.pageSize.getWidth() - MARGINS.right,
+        doc.internal.pageSize.getWidth() - PDF_MARGINS.right,
         pageHeight - 20,
         { align: 'right' },
       )

--- a/app/admin/pedidos/page.tsx
+++ b/app/admin/pedidos/page.tsx
@@ -6,6 +6,12 @@ import { useAuthGuard } from '@/lib/hooks/useAuthGuard'
 import type { Pedido, Produto } from '@/types'
 import jsPDF from 'jspdf'
 import autoTable from 'jspdf-autotable'
+import {
+  PDF_MARGINS,
+  FONT_SIZE_TITLE,
+  FONT_SIZE_BODY,
+  FONT_SIZE_FOOTER,
+} from '@/lib/report/constants'
 import LoadingOverlay from '@/components/organisms/LoadingOverlay'
 import ModalEditarPedido from './componentes/ModalEditarPedido'
 import { useToast } from '@/lib/context/ToastContext'
@@ -214,19 +220,18 @@ export default function PedidosPage() {
       return ordem === 'asc' ? dataA - dataB : dataB - dataA
     })
 
-    const MARGINS = { top: 56.7, bottom: 56.7, left: 56.7, right: 56.7 }
     const doc = new jsPDF({ unit: 'pt', format: 'a4' })
-    doc.setFontSize(16)
+    doc.setFontSize(FONT_SIZE_TITLE)
     doc.setFont('helvetica', 'bold')
     doc.text(
       'Relat\u00F3rio de Pedidos',
       doc.internal.pageSize.getWidth() / 2,
-      MARGINS.top,
+      PDF_MARGINS.top,
       {
         align: 'center',
       },
     )
-    doc.setFontSize(11)
+    doc.setFontSize(FONT_SIZE_BODY)
     doc.setFont('helvetica', 'normal')
 
     const linhas = pedidosOrdenadosPdf.map((p) => [
@@ -243,7 +248,7 @@ export default function PedidosPage() {
     ])
 
     autoTable(doc, {
-      startY: MARGINS.top + 20,
+      startY: PDF_MARGINS.top + 20,
       head: [
         [
           'Produto',
@@ -260,7 +265,7 @@ export default function PedidosPage() {
       theme: 'striped',
       headStyles: { fillColor: [217, 217, 217], halign: 'center' },
       styles: { fontSize: 8 },
-      margin: MARGINS,
+      margin: PDF_MARGINS,
     })
 
     const dataHora = new Date().toLocaleString('pt-BR', {
@@ -270,10 +275,10 @@ export default function PedidosPage() {
     for (let i = 1; i <= pageCount; i++) {
       doc.setPage(i)
       const pageHeight = doc.internal.pageSize.getHeight()
-      doc.setFontSize(10)
+      doc.setFontSize(FONT_SIZE_FOOTER)
       doc.text(
         'Desenvolvido por M24 Tecnologia <m24saude.com.br>',
-        MARGINS.left,
+        PDF_MARGINS.left,
         pageHeight - 20,
       )
       doc.text(
@@ -284,7 +289,7 @@ export default function PedidosPage() {
       )
       doc.text(
         dataHora,
-        doc.internal.pageSize.getWidth() - MARGINS.right,
+        doc.internal.pageSize.getWidth() - PDF_MARGINS.right,
         pageHeight - 20,
         { align: 'right' },
       )

--- a/lib/report/constants.ts
+++ b/lib/report/constants.ts
@@ -1,0 +1,7 @@
+export const PDF_MARGINS = { top: 56.7, bottom: 56.7, left: 56.7, right: 56.7 } as const
+
+export const FONT_SIZE_TITLE = 24
+export const FONT_SIZE_SUBTITLE = 18
+export const FONT_SIZE_BODY = 11
+export const FONT_SIZE_SMALL = 10
+export const FONT_SIZE_FOOTER = 9

--- a/lib/report/generateAnalisePdf.ts
+++ b/lib/report/generateAnalisePdf.ts
@@ -1,5 +1,10 @@
 import jsPDF from 'jspdf'
 import autoTable from 'jspdf-autotable'
+import {
+  PDF_MARGINS,
+  FONT_SIZE_TITLE,
+  FONT_SIZE_FOOTER,
+} from './constants'
 
 export async function generateAnalisePdf(
   title: string,
@@ -15,11 +20,11 @@ export async function generateAnalisePdf(
     }, 5000)
 
     try {
-      const margin = { top: 56.7, bottom: 56.7, left: 56.7, right: 56.7 }
+      const margin = PDF_MARGINS
       const doc = new jsPDF({ unit: 'pt', format: 'a4' })
       const pageWidth = doc.internal.pageSize.getWidth()
       const contentWidth = pageWidth - margin.left - margin.right
-      doc.setFontSize(16)
+      doc.setFontSize(FONT_SIZE_TITLE)
       doc.setFont('helvetica', 'bold')
       doc.text(title, pageWidth / 2, margin.top, {
         align: 'center',
@@ -83,7 +88,7 @@ export async function generateAnalisePdf(
       for (let i = 1; i <= pageCount; i++) {
         doc.setPage(i)
         const pageHeight = doc.internal.pageSize.getHeight()
-        doc.setFontSize(10)
+        doc.setFontSize(FONT_SIZE_FOOTER)
 
         const date = new Date().toLocaleString('pt-BR', {
           timeZone: 'America/Sao_Paulo',

--- a/lib/report/generateDashboardPdf.ts
+++ b/lib/report/generateDashboardPdf.ts
@@ -1,5 +1,11 @@
 import jsPDF from 'jspdf'
 import autoTable from 'jspdf-autotable'
+import {
+  PDF_MARGINS,
+  FONT_SIZE_TITLE,
+  FONT_SIZE_BODY,
+  FONT_SIZE_FOOTER,
+} from './constants'
 import template from './template.md'
 
 async function toGrayscale(src: string): Promise<string> {
@@ -65,7 +71,7 @@ export async function generateDashboardPdf(
     }, 10_000)
 
     try {
-      const margin = { top: 56.7, bottom: 56.7, left: 56.7, right: 56.7 }
+      const margin = PDF_MARGINS
       const doc = new jsPDF({ unit: 'pt', format: 'a4' })
       const pageWidth = doc.internal.pageSize.getWidth()
       const contentWidth = pageWidth - margin.left - margin.right
@@ -75,10 +81,10 @@ export async function generateDashboardPdf(
       const periodLine = content[1].replace('{{period}}', formatPeriod(periodo))
       const footer = content[2]
 
-      doc.setFontSize(16)
+      doc.setFontSize(FONT_SIZE_TITLE)
       doc.setFont('helvetica', 'bold')
       doc.text(title, pageWidth / 2, margin.top, { align: 'center' })
-      doc.setFontSize(11)
+      doc.setFontSize(FONT_SIZE_BODY)
       doc.setFont('helvetica', 'normal')
       doc.text(periodLine, pageWidth - margin.right, margin.top + 20, { align: 'right' })
 
@@ -130,7 +136,7 @@ export async function generateDashboardPdf(
       for (let i = 1; i <= pageCount; i++) {
         doc.setPage(i)
         const pageHeight = doc.internal.pageSize.getHeight()
-        doc.setFontSize(10)
+        doc.setFontSize(FONT_SIZE_FOOTER)
         doc.text(footer, margin.left, pageHeight - 20)
 
         const date = new Date().toLocaleString('pt-BR', {

--- a/lib/report/generateRelatorioPdf.ts
+++ b/lib/report/generateRelatorioPdf.ts
@@ -1,5 +1,11 @@
 import jsPDF from 'jspdf'
 import template from './templateRelatorio.md'
+import {
+  PDF_MARGINS,
+  FONT_SIZE_TITLE,
+  FONT_SIZE_BODY,
+  FONT_SIZE_FOOTER,
+} from './constants'
 
 export async function generateRelatorioPdf() {
   return new Promise<void>((resolve, reject) => {
@@ -8,7 +14,7 @@ export async function generateRelatorioPdf() {
     }, 5000)
 
     try {
-      const margin = { top: 56.7, bottom: 56.7, left: 56.7, right: 56.7 }
+      const margin = PDF_MARGINS
       const doc = new jsPDF({ unit: 'pt', format: 'a4' })
       const pageWidth = doc.internal.pageSize.getWidth()
       const contentWidth = pageWidth - margin.left - margin.right
@@ -16,11 +22,11 @@ export async function generateRelatorioPdf() {
       const title = lines[0].replace(/^#\s*/, '')
       const body = lines.slice(1)
 
-      doc.setFontSize(16)
+      doc.setFontSize(FONT_SIZE_TITLE)
       doc.setFont('helvetica', 'bold')
       doc.text(title, pageWidth / 2, margin.top, { align: 'center' })
 
-      doc.setFontSize(12)
+      doc.setFontSize(FONT_SIZE_BODY)
       doc.setFont('helvetica', 'normal')
 
       let y = margin.top + 30
@@ -38,7 +44,7 @@ export async function generateRelatorioPdf() {
       for (let i = 1; i <= pages; i++) {
         doc.setPage(i)
         const pageHeight = doc.internal.pageSize.getHeight()
-        doc.setFontSize(10)
+        doc.setFontSize(FONT_SIZE_FOOTER)
 
         const date = new Date().toLocaleString('pt-BR', {
           timeZone: 'America/Sao_Paulo',

--- a/logs/DOC_LOG.md
+++ b/logs/DOC_LOG.md
@@ -608,3 +608,4 @@ na rota /loja/api/inscricoes e documentação atualizada. Lint e build executado
 ## [2025-07-17] Gráficos exportados em tons de cinza com padrões de hachura. Lint e build executados.
 ## [2025-07-17] Margens dos PDFs normalizadas para 20mm. Lint e build executados.
 ## [2025-07-17] Atualizadas rotinas de exportação nos relatórios para usar margens de 56.7pt e rodapé com data/hora. Lint e build executados.
+## [2025-07-17] Normalizadas fontes e margens dos PDFs; rodapé agora usa fonte 9pt. Lint e build executados.


### PR DESCRIPTION
## Summary
- extrai constantes de margens e tamanhos de fonte de PDF
- aplica margens e fontes padrão nas páginas do admin
- usa fontes menores no rodapé dos PDFs
- registra ajuste no DOC_LOG

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_687950740008832c86a67f0dea9ce2e3