### PR TITLE
Enable CPF autofill for manual orders

### DIFF
--- a/__tests__/api/usuariosByCpfRoute.test.ts
+++ b/__tests__/api/usuariosByCpfRoute.test.ts
@@ -1,0 +1,41 @@
+import { describe, it, expect, vi } from 'vitest'
+import { GET } from '../../app/api/usuarios/by-cpf/route'
+import { NextRequest } from 'next/server'
+import createPocketBaseMock from '../mocks/pocketbase'
+
+const pb = createPocketBaseMock()
+const getFirstMock = vi.fn()
+
+pb.collection.mockImplementation((name: string) => {
+  if (name === 'usuarios') {
+    return { getFirstListItem: getFirstMock }
+  }
+  return {}
+})
+
+vi.mock('../lib/pocketbase', () => ({ default: vi.fn(() => pb) }))
+
+describe('GET /api/usuarios/by-cpf', () => {
+  it('retorna 400 quando cpf invalido', async () => {
+    const req = new Request('http://test/api/usuarios/by-cpf?cpf=123')
+    ;(req as any).nextUrl = new URL('http://test/api/usuarios/by-cpf?cpf=123')
+    const res = await GET(req as unknown as NextRequest)
+    expect(res.status).toBe(400)
+  })
+
+  it('retorna dados quando encontrado', async () => {
+    getFirstMock.mockResolvedValueOnce({
+      id: 'u1',
+      nome: 'Fulano',
+      telefone: '11999999999',
+      email: 'f@x.com',
+    })
+    const req = new Request('http://test/api/usuarios/by-cpf?cpf=52998224725')
+    ;(req as any).nextUrl = new URL('http://test/api/usuarios/by-cpf?cpf=52998224725')
+    const res = await GET(req as unknown as NextRequest)
+    expect(res.status).toBe(200)
+    const body = await res.json()
+    expect(body.id).toBe('u1')
+    expect(getFirstMock).toHaveBeenCalled()
+  })
+})

--- a/app/api/usuarios/by-cpf/route.ts
+++ b/app/api/usuarios/by-cpf/route.ts
@@ -1,0 +1,34 @@
+import { NextRequest, NextResponse } from 'next/server'
+import createPocketBase from '@/lib/pocketbase'
+import { ClientResponseError } from 'pocketbase'
+
+export async function GET(req: NextRequest) {
+  const cpf = req.nextUrl.searchParams.get('cpf')?.replace(/\D/g, '') || ''
+  if (cpf.length !== 11) {
+    return NextResponse.json({ error: 'CPF inválido' }, { status: 400 })
+  }
+
+  const pb = createPocketBase(false)
+  try {
+    const usuario = await pb
+      .collection('usuarios')
+      .getFirstListItem(`cpf='${cpf}'`)
+    return NextResponse.json({
+      id: usuario.id,
+      nome: usuario.nome,
+      telefone: usuario.telefone,
+      email: usuario.email,
+    })
+  } catch (err: unknown) {
+    if (err instanceof ClientResponseError && err.status === 404) {
+      return NextResponse.json(
+        { error: 'Usuário não encontrado' },
+        { status: 404 },
+      )
+    }
+    return NextResponse.json(
+      { error: 'Erro ao buscar usuário' },
+      { status: 500 },
+    )
+  }
+}

--- a/docs/regras-pedidos.md
+++ b/docs/regras-pedidos.md
@@ -67,9 +67,9 @@ Esse fluxo cria um pedido sem vínculo a inscrição e utiliza `canal = 'avulso'
 O líder seleciona o produto e o valor é preenchido automaticamente conforme o
 preço do item, sem possibilidade de edição. Além disso informa o email do
 inscrito, data de vencimento e a forma de pagamento (`pix` ou `boleto`). O
-pedido sempre pertence ao mesmo campo do líder autenticado. Antes de enviar, o
-formulário verifica se o CPF ou e‑mail já estão cadastrados e avisa sobre
-duplicidades, mas essa checagem não bloqueia a criação do pedido.
+pedido sempre pertence ao mesmo campo do líder autenticado. Ao digitar o CPF o
+sistema consulta automaticamente a base e preenche nome, telefone e email se
+houver correspondência, agilizando o cadastro.
 Se o produto escolhido estiver vinculado a um evento, o formulário exibe um link
 para iniciar o fluxo de inscrição em `/inscricoes/lider/[liderId]/evento/[eventoId]`.
 Assim o líder pode cadastrar ou atualizar os dados do participante antes de gerar o pedido.

--- a/logs/DOC_LOG.md
+++ b/logs/DOC_LOG.md
@@ -609,3 +609,5 @@ na rota /loja/api/inscricoes e documentação atualizada. Lint e build executado
 ## [2025-07-17] Margens dos PDFs normalizadas para 20mm. Lint e build executados.
 ## [2025-07-17] Atualizadas rotinas de exportação nos relatórios para usar margens de 56.7pt e rodapé com data/hora. Lint e build executados.
 ## [2025-07-17] Normalizadas fontes e margens dos PDFs; rodapé agora usa fonte 9pt. Lint e build executados.
+## [2025-07-18] Formulario avulso preenche dados pelo CPF. Lint e build executados.
+## [2025-07-18] Mensagem de CPF/email duplicado removida no pedido avulso. Lint e build executados.


### PR DESCRIPTION
## Summary
- create `GET /api/usuarios/by-cpf` to retrieve user data by CPF
- autofill name, phone and email in `PedidoAvulsoForm` when CPF is typed
- validate form fields after state updates to avoid spurious invalid messages
- document the new behavior in pedido rules
- log the documentation update
- add unit test for the new route
- drop duplicate warnings during manual order creation

## Testing
- `npm run lint`
- `npm run build`
- `npm test` *(fails: see log)*

------
https://chatgpt.com/codex/tasks/task_e_687a7f019650832ca46796691f8dc603