### PR TITLE
Add aguardando_pagamento filter

### DIFF
--- a/app/admin/inscricoes/page.tsx
+++ b/app/admin/inscricoes/page.tsx
@@ -670,6 +670,7 @@ export default function ListaInscricoesPage() {
         >
           <option value="">Todos os Status</option>
           <option value="pendente">Pendente</option>
+          <option value="aguardando_pagamento">Aguardando Pagamento</option>
           <option value="confirmado">Confirmado</option>
           <option value="cancelado">Cancelado</option>
         </select>


### PR DESCRIPTION
## Summary
- allow filtering inscriptions by the awaiting payment status

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_687ace135044832c823d808a96c99738