### PR TITLE
Fix avulso order payload and auto-fill gender

### DIFF
--- a/__tests__/PedidoAvulsoForm.test.tsx
+++ b/__tests__/PedidoAvulsoForm.test.tsx
@@ -21,6 +21,7 @@ vi.mock('@/lib/hooks/useProdutos', () => ({
         evento_id: 'e1',
         requer_inscricao_aprovada: true,
         preco_bruto: 55,
+        tamanhos: ['P', 'M'],
       },
     ],
     loading: false,
@@ -55,5 +56,6 @@ describe('PedidoAvulsoForm', () => {
     const body = JSON.parse(call[1].body)
     expect(body.canal).toBe('avulso')
     expect(body.paymentMethod).toBe('pix')
+    expect(body.tamanho).toBe('P')
   })
 })

--- a/__tests__/api/usuariosByCpfRoute.test.ts
+++ b/__tests__/api/usuariosByCpfRoute.test.ts
@@ -29,6 +29,7 @@ describe('GET /api/usuarios/by-cpf', () => {
       nome: 'Fulano',
       telefone: '11999999999',
       email: 'f@x.com',
+      genero: 'masculino',
     })
     const req = new Request('http://test/api/usuarios/by-cpf?cpf=52998224725')
     ;(req as any).nextUrl = new URL('http://test/api/usuarios/by-cpf?cpf=52998224725')
@@ -36,6 +37,7 @@ describe('GET /api/usuarios/by-cpf', () => {
     expect(res.status).toBe(200)
     const body = await res.json()
     expect(body.id).toBe('u1')
+    expect(body.genero).toBe('masculino')
     expect(getFirstMock).toHaveBeenCalled()
   })
 })

--- a/app/api/pedidos/route.ts
+++ b/app/api/pedidos/route.ts
@@ -231,7 +231,7 @@ export async function POST(req: NextRequest) {
       console.log('[PEDIDOS][POST] corTratada:', corTratada)
 
       const finalCampo = isAvulso ? user.campo : campoId
-      const payload: Record<string, unknown> = {
+      const payloadBase: Record<string, unknown> = {
         produto: produtoIds,
         tamanho,
         status: 'pendente',
@@ -246,6 +246,10 @@ export async function POST(req: NextRequest) {
         paymentMethod: body.paymentMethod ?? 'pix',
         canal: isAvulso ? 'avulso' : 'loja',
       }
+
+      const payload = Object.fromEntries(
+        Object.entries(payloadBase).filter(([, v]) => v !== undefined),
+      )
 
       if (!isAvulso) {
         payload.id_inscricao = inscricaoId || ''
@@ -349,7 +353,7 @@ export async function POST(req: NextRequest) {
     const valor = produtoRecord?.preco_bruto ?? 0
     console.log('[PEDIDOS][POST] Valor final do pedido:', valor)
 
-    const payload = {
+    const payloadBase = {
       id_inscricao: inscricaoId,
       valor,
       status: 'pendente',
@@ -377,6 +381,9 @@ export async function POST(req: NextRequest) {
       cliente: inscricao.cliente,
       canal: 'inscricao',
     }
+    const payload = Object.fromEntries(
+      Object.entries(payloadBase).filter(([, v]) => v !== undefined),
+    )
     console.log('[PEDIDOS][POST] Payload com inscrição:', payload)
 
     try {

--- a/app/api/usuarios/by-cpf/route.ts
+++ b/app/api/usuarios/by-cpf/route.ts
@@ -18,6 +18,7 @@ export async function GET(req: NextRequest) {
       nome: usuario.nome,
       telefone: usuario.telefone,
       email: usuario.email,
+      genero: usuario.genero,
     })
   } catch (err: unknown) {
     if (err instanceof ClientResponseError && err.status === 404) {

--- a/components/organisms/PedidoAvulsoForm.tsx
+++ b/components/organisms/PedidoAvulsoForm.tsx
@@ -23,18 +23,38 @@ export default function PedidoAvulsoForm() {
     telefone: '',
     email: '',
     produtoId: '',
+    tamanho: '',
+    genero: '',
     valor: '',
     vencimento: '',
     paymentMethod: 'pix',
   })
 
   const [produtoSel, setProdutoSel] = useState<Produto | undefined>(undefined)
+  const tamanhosDisponiveis = useMemo(() => {
+    if (!produtoSel) return [] as string[]
+    const list = Array.isArray(produtoSel.tamanhos)
+      ? produtoSel.tamanhos
+      : typeof produtoSel.tamanhos === 'string'
+        ? produtoSel.tamanhos.split(',').map((t) => t.trim())
+        : []
+    return list
+  }, [produtoSel])
 
   useEffect(() => {
     const prod = produtos.find((p) => p.id === form.produtoId)
     setProdutoSel(prod)
     if (prod) {
-      setForm((prev) => ({ ...prev, valor: String(prod.preco_bruto) }))
+      const tamanhos = Array.isArray(prod.tamanhos)
+        ? prod.tamanhos
+        : typeof prod.tamanhos === 'string'
+          ? prod.tamanhos.split(',').map((t: string) => t.trim())
+          : []
+      setForm((prev) => ({
+        ...prev,
+        valor: String(prod.preco_bruto),
+        tamanho: tamanhos[0] || '',
+      }))
     }
   }, [produtos, form.produtoId])
 
@@ -51,6 +71,7 @@ export default function PedidoAvulsoForm() {
             nome: prev.nome || data.nome || '',
             telefone: prev.telefone || data.telefone || '',
             email: prev.email || data.email || '',
+            genero: data.genero || prev.genero,
           }))
         }
       } catch {
@@ -109,6 +130,8 @@ export default function PedidoAvulsoForm() {
         credentials: 'include',
         body: JSON.stringify({
           produto: [form.produtoId],
+          tamanho: form.tamanho,
+          genero: form.genero,
           valor: Number(form.valor),
           email: form.email,
           vencimento: form.vencimento,
@@ -125,6 +148,8 @@ export default function PedidoAvulsoForm() {
           telefone: '',
           email: '',
           produtoId: '',
+          tamanho: '',
+          genero: '',
           valor: '',
           vencimento: '',
           paymentMethod: 'pix',
@@ -201,6 +226,24 @@ export default function PedidoAvulsoForm() {
           </p>
         )}
       </FormField>
+      {tamanhosDisponiveis.length > 0 && (
+        <FormField label="Tamanho" htmlFor="tamanho">
+          <select
+            id="tamanho"
+            name="tamanho"
+            value={form.tamanho}
+            onChange={handleChange}
+            className="input-base w-full"
+            required
+          >
+            {tamanhosDisponiveis.map((t) => (
+              <option key={t} value={t}>
+                {t}
+              </option>
+            ))}
+          </select>
+        </FormField>
+      )}
       <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
         <FormField label="Valor" htmlFor="valor">
           <TextField

--- a/logs/DOC_LOG.md
+++ b/logs/DOC_LOG.md
@@ -611,3 +611,4 @@ na rota /loja/api/inscricoes e documentação atualizada. Lint e build executado
 ## [2025-07-17] Normalizadas fontes e margens dos PDFs; rodapé agora usa fonte 9pt. Lint e build executados.
 ## [2025-07-18] Formulario avulso preenche dados pelo CPF. Lint e build executados.
 ## [2025-07-18] Mensagem de CPF/email duplicado removida no pedido avulso. Lint e build executados.
+## [2025-08-22] Pedido avulso permite selecionar tamanho e preenche gênero via CPF. Lint e build executados.

--- a/logs/ERR_LOG.md
+++ b/logs/ERR_LOG.md
@@ -285,3 +285,5 @@
 ## [2025-07-17] Pedidos buscavam apenas a primeira pagina; resultado incompleto e paginacao incorreta. Fetch atualizado para usar fetchAllPages e pagina resetada ao alterar filtros globais. - dev - a2bf8fc4
 ## [2025-07-17] Inscricoes buscavam paginas manualmente; fetchAllPages adotado e paginacao recalculada ao filtrar. - dev - ac1da4cd
 ## [2025-07-18] Erro ao criar pedido avulso: ClientResponseError 400: Failed to create record. Ajustado para não enviar campos vazios. - dev - 1f72bca4
+## [2025-08-22] Erro ao criar pedido avulso por tamanho indefinido; campo agora selecionável e genero preenchido via CPF. - dev - 8caa9780
+## [2025-07-18] Erro ao criar pedido: TypeError: Cannot read properties of undefined (reading 'id') - test


### PR DESCRIPTION
## Summary
- auto-fill gender when searching CPF
- add size selection to avulso orders
- send size and gender to backend
- ignore undefined fields when creating orders
- update by-cpf route and tests
- document fix in logs

## Testing
- `npm run lint`
- `npm run build`
- `npm test` *(fails: No "useSearchParams" export is defined on the "next/navigation" mock)*

------
https://chatgpt.com/codex/tasks/task_e_687add859974832cb9656db08a1ddc47