### PR TITLE
Fix payment link generation for orders without subscription

### DIFF
--- a/app/api/asaas/route.ts
+++ b/app/api/asaas/route.ts
@@ -117,6 +117,16 @@ export async function POST(req: NextRequest) {
     }
 
     // Buscar inscrição vinculada
+    if (!pedido.id_inscricao) {
+      console.log(
+        '🔴 [POST /api/asaas] Pedido sem inscrição vinculada',
+      )
+      return NextResponse.json(
+        { error: 'Pedido sem inscrição vinculada' },
+        { status: 400 },
+      )
+    }
+
     const inscricao = await pb
       .collection('inscricoes')
       .getOne(pedido.id_inscricao)

--- a/logs/ERR_LOG.md
+++ b/logs/ERR_LOG.md
@@ -287,3 +287,4 @@
 ## [2025-07-18] Erro ao criar pedido avulso: ClientResponseError 400: Failed to create record. Ajustado para não enviar campos vazios. - dev - 1f72bca4
 ## [2025-08-22] Erro ao criar pedido avulso por tamanho indefinido; campo agora selecionável e genero preenchido via CPF. - dev - 8caa9780
 ## [2025-07-18] Erro ao criar pedido: TypeError: Cannot read properties of undefined (reading 'id') - test
+## [2025-08-24] Erro ao gerar link de pagamento Asaas: Missing required record id ao processar pedido avulso sem inscricao. Validacao adicionada para id_inscricao - dev - 40253017


### PR DESCRIPTION
## Summary
- handle orders without `id_inscricao` in `/api/asaas`
- log resolution in `ERR_LOG.md`

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_687bb24e7a00832c9f91b4e31a24f018