### PR TITLE
Add WhatsApp broadcast queue and admin page

### DIFF
--- a/app/admin/whatsapp/mensagem-broadcast/page.tsx
+++ b/app/admin/whatsapp/mensagem-broadcast/page.tsx
@@ -1,0 +1,140 @@
+'use client'
+
+import { useEffect, useRef, useState } from 'react'
+import { useAuthGuard } from '@/lib/hooks/useAuthGuard'
+import { useToast } from '@/lib/context/ToastContext'
+import LoadingOverlay from '@/components/organisms/LoadingOverlay'
+
+interface Stats {
+  total: number
+  sent: number
+  failed: number
+  pending: number
+}
+
+export default function BroadcastPage() {
+  const { authChecked } = useAuthGuard(['coordenador'])
+  const { showSuccess, showError } = useToast()
+
+  const [alvo, setAlvo] = useState<'lideres' | 'inscritos' | 'pendentes'>('lideres')
+  const [mensagem, setMensagem] = useState('')
+  const [loading, setLoading] = useState(false)
+  const [stats, setStats] = useState<Stats | null>(null)
+  const intervalRef = useRef<NodeJS.Timeout>()
+
+  async function fetchStats() {
+    try {
+      const res = await fetch('/api/chats/message/broadcast')
+      if (res.ok) {
+        const data = await res.json()
+        setStats(data)
+        if (data.pending === 0 && intervalRef.current) {
+          clearInterval(intervalRef.current)
+          intervalRef.current = undefined
+        }
+      }
+    } catch {
+      /* ignore */
+    }
+  }
+
+  async function iniciar() {
+    if (!mensagem.trim()) {
+      showError('Mensagem obrigatória')
+      return
+    }
+    setLoading(true)
+    try {
+      const res = await fetch('/api/chats/message/broadcast', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ target: alvo, message: mensagem }),
+      })
+      const data = await res.json()
+      if (res.ok) {
+        showSuccess('Mensagens enfileiradas')
+        setStats(data)
+        if (!intervalRef.current) {
+          intervalRef.current = setInterval(fetchStats, 2000)
+        }
+      } else {
+        showError(data.error || 'Erro ao iniciar')
+      }
+    } catch {
+      showError('Erro ao iniciar')
+    } finally {
+      setLoading(false)
+    }
+  }
+
+  async function cancelar() {
+    try {
+      await fetch('/api/chats/message/broadcast', { method: 'DELETE' })
+      showSuccess('Broadcast cancelado')
+      if (intervalRef.current) clearInterval(intervalRef.current)
+      intervalRef.current = undefined
+      fetchStats()
+    } catch {
+      showError('Erro ao cancelar')
+    }
+  }
+
+  useEffect(() => {
+    fetchStats()
+    intervalRef.current = setInterval(fetchStats, 2000)
+    return () => {
+      if (intervalRef.current) clearInterval(intervalRef.current)
+    }
+  }, [])
+
+  if (!authChecked) return <LoadingOverlay show text="Carregando" />
+
+  return (
+    <div className="p-4 max-w-xl">
+      <h1 className="text-xl font-semibold mb-4">Broadcast WhatsApp</h1>
+      <div className="flex flex-col gap-3">
+        <select
+          className="border p-2 rounded"
+          value={alvo}
+          onChange={(e) =>
+            setAlvo(e.target.value as 'lideres' | 'inscritos' | 'pendentes')
+          }
+        >
+          <option value="lideres">Líderes</option>
+          <option value="inscritos">Inscritos</option>
+          <option value="pendentes">Pendentes</option>
+        </select>
+        <textarea
+          className="border rounded p-2"
+          rows={4}
+          value={mensagem}
+          onChange={(e) => setMensagem(e.target.value)}
+        />
+        <button
+          className="bg-blue-600 text-white px-4 py-2 rounded"
+          onClick={iniciar}
+          disabled={loading}
+        >
+          Enviar
+        </button>
+        {stats && (
+          <div className="mt-4 flex flex-col gap-1">
+            <span>Total: {stats.total}</span>
+            <span>Enviadas: {stats.sent}</span>
+            <span>Falhas: {stats.failed}</span>
+            <span>Pendentes: {stats.pending}</span>
+            {stats.pending > 0 && (
+              <button
+                className="mt-2 bg-red-600 text-white px-4 py-2 rounded"
+                onClick={cancelar}
+              >
+                Cancelar
+              </button>
+            )}
+          </div>
+        )}
+      </div>
+      <LoadingOverlay show={loading} />
+    </div>
+  )
+}

--- a/app/api/chats/message/broadcast/route.ts
+++ b/app/api/chats/message/broadcast/route.ts
@@ -1,0 +1,96 @@
+import { NextRequest, NextResponse } from 'next/server'
+import createPocketBase from '@/lib/pocketbase'
+import { queueTextMessage } from '@/lib/server/chats'
+import { broadcastManager } from '@/lib/server/flows/whatsapp'
+
+export async function POST(req: NextRequest) {
+  const tenant = req.headers.get('x-tenant-id')
+  if (!tenant) {
+    return NextResponse.json({ error: 'Tenant ausente' }, { status: 400 })
+  }
+
+  let body: { target?: string; message?: string }
+  try {
+    body = (await req.json()) as { target?: string; message?: string }
+  } catch {
+    return NextResponse.json({ error: 'JSON inválido' }, { status: 400 })
+  }
+
+  const { target, message } = body
+  if (!target || !message) {
+    return NextResponse.json({ error: 'Dados inválidos' }, { status: 400 })
+  }
+
+  const pb = createPocketBase()
+  if (!pb.authStore.isValid) {
+    await pb.admins.authWithPassword(
+      process.env.PB_ADMIN_EMAIL!,
+      process.env.PB_ADMIN_PASSWORD!,
+    )
+  }
+
+  const cfgList = await pb
+    .collection('whatsapp_clientes')
+    .getFullList({ filter: `cliente="${tenant}"`, limit: 1 })
+  if (cfgList.length === 0) {
+    return NextResponse.json({ error: 'configuração não encontrada' }, { status: 404 })
+  }
+  const cfg = cfgList[0]
+
+  let records: { telefone?: string }[] = []
+  if (target === 'lideres') {
+    records = await pb.collection('usuarios').getFullList({
+      filter: `cliente='${tenant}' && role='lider' && telefone != ''`,
+      fields: 'telefone',
+    })
+  } else if (target === 'inscritos') {
+    records = await pb.collection('inscricoes').getFullList({
+      filter: `cliente='${tenant}' && telefone != ''`,
+      fields: 'telefone',
+    })
+  } else if (target === 'pendentes') {
+    records = await pb.collection('inscricoes').getFullList({
+      filter: `cliente='${tenant}' && status='pendente' && telefone != ''`,
+      fields: 'telefone',
+    })
+  } else {
+    return NextResponse.json({ error: 'Target inválido' }, { status: 400 })
+  }
+
+  const phones = Array.from(
+    new Set(records.map((r) => r.telefone).filter(Boolean) as string[]),
+  )
+
+  for (const phone of phones) {
+    queueTextMessage(
+      {
+        tenant,
+        instanceName: cfg.instanceName,
+        apiKey: cfg.apiKey,
+        to: phone,
+        message,
+      },
+      false,
+    )
+  }
+
+  return NextResponse.json({ message: 'mensagens enfileiradas', total: phones.length })
+}
+
+export async function GET(req: NextRequest) {
+  const tenant = req.headers.get('x-tenant-id')
+  if (!tenant) {
+    return NextResponse.json({ error: 'Tenant ausente' }, { status: 400 })
+  }
+  const stats = broadcastManager.getStats(tenant)
+  return NextResponse.json(stats)
+}
+
+export async function DELETE(req: NextRequest) {
+  const tenant = req.headers.get('x-tenant-id')
+  if (!tenant) {
+    return NextResponse.json({ error: 'Tenant ausente' }, { status: 400 })
+  }
+  broadcastManager.cancel(tenant)
+  return NextResponse.json({ message: 'fila cancelada' })
+}

--- a/lib/server/flows/whatsapp/broadcastManager.ts
+++ b/lib/server/flows/whatsapp/broadcastManager.ts
@@ -26,11 +26,32 @@ class BroadcastManager {
   }
 
   getAllStats() {
-    const stats: Record<string, { pending: number }> = {}
+    const stats: Record<string, { pending: number; total: number; sent: number; failed: number }> = {}
     for (const [tenant, q] of this.queues.entries()) {
-      stats[tenant] = { pending: q.pending }
+      stats[tenant] = {
+        pending: q.pending,
+        total: q.total,
+        sent: q.sent,
+        failed: q.failed,
+      }
     }
     return stats
+  }
+
+  getStats(tenant: string) {
+    const q = this.queues.get(tenant)
+    if (!q) return { total: 0, sent: 0, failed: 0, pending: 0 }
+    return {
+      total: q.total,
+      sent: q.sent,
+      failed: q.failed,
+      pending: q.pending,
+    }
+  }
+
+  cancel(tenant: string) {
+    const q = this.queues.get(tenant)
+    if (q) q.cancel()
   }
 }
 


### PR DESCRIPTION
## Summary
- implement POST/GET/DELETE `/api/chats/message/broadcast`
- extend BroadcastQueue with counters and cancel method
- update BroadcastManager to expose per-tenant stats and cancel
- create admin broadcast page with progress and cancel option

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_687d521b60c8832cab98269508a264ee