### PR TITLE
Fix expanded data fetching in relatorios

### DIFF
--- a/app/admin/relatorios/page.tsx
+++ b/app/admin/relatorios/page.tsx
@@ -295,15 +295,18 @@ export default function RelatoriosPage() {
           filter: filtroCliente,
         })
 
-        // Fetch inscricoes
-        const insRes = await fetch(`/api/inscricoes?${params.toString()}`, {
-          credentials: 'include',
-          signal,
-        }).then((r) => r.json())
+        // Fetch inscricoes com campos expandidos
+        const insRes = await fetch(
+          `/api/inscricoes?${params.toString()}&expand=produto,evento,campo`,
+          {
+            credentials: 'include',
+            signal,
+          },
+        ).then((r) => r.json())
         const insRest = await fetchAllPages<
           { items?: Inscricao[] } | Inscricao
         >(
-          `/api/inscricoes?${params.toString()}`,
+          `/api/inscricoes?${params.toString()}&expand=produto,evento,campo`,
           insRes.totalPages ?? 1,
           signal,
         )
@@ -319,14 +322,14 @@ export default function RelatoriosPage() {
         // Fetch pedidos
         params.set('page', '1')
         const pedRes = await fetch(
-          `/api/pedidos?${params.toString()}&expand=campo,produto`,
+          `/api/pedidos?${params.toString()}&expand=campo,produto,id_inscricao,responsavel`,
           {
             credentials: 'include',
             signal,
           },
         ).then((r) => r.json())
         const pedRest = await fetchAllPages<{ items?: Pedido[] } | Pedido>(
-          `/api/pedidos?${params.toString()}&expand=campo,produto`,
+          `/api/pedidos?${params.toString()}&expand=campo,produto,id_inscricao,responsavel`,
           pedRes.totalPages ?? 1,
           signal,
         )


### PR DESCRIPTION
## Summary
- ensure `inscricoes` fetch requests include `expand=produto,evento,campo`
- ensure `pedidos` fetch requests include `expand=campo,produto,id_inscricao,responsavel`
- confirm helper functions use expanded fields

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_688a654e2080832c916afca2197c79a4