### PR TITLE
Fix PDF autoTable import and await export

### DIFF
--- a/app/admin/dashboard/components/DashboardResumo.tsx
+++ b/app/admin/dashboard/components/DashboardResumo.tsx
@@ -61,7 +61,7 @@ export default function DashboardResumo({
     exportPedidosToExcel(pedidos)
   }
 
-  const handleExportPDF = () => {
+  const handleExportPDF = async () => {
     // Verificar se estamos no navegador
     if (typeof window === 'undefined') {
       console.error('PDF só pode ser gerado no navegador')
@@ -75,8 +75,11 @@ export default function DashboardResumo({
       button.disabled = true
     }
 
-    // Gerar PDF usando o serviço
-    generatePDF(inscricoes, pedidos, produtos, valorTotalConfirmado)
+    try {
+      await generatePDF(inscricoes, pedidos, produtos, valorTotalConfirmado)
+    } catch (error) {
+      console.error(error)
+    }
   }
 
   // Verificar se há dados para exibir

--- a/lib/services/pdfGenerator.ts
+++ b/lib/services/pdfGenerator.ts
@@ -1,6 +1,7 @@
 import type { Inscricao, Pedido, Produto } from '@/types'
 import type { jsPDF } from 'jspdf'
-import autoTable from 'jspdf-autotable'
+
+let autoTable: any
 import {
   PDF_CONSTANTS,
   formatCpf,
@@ -576,6 +577,7 @@ export async function generatePDF(
   valorTotal: number
 ) {
   const { default: jsPDF } = await import('jspdf')
+  autoTable = (await import('jspdf-autotable')).default
   const doc = new jsPDF({ format: 'a4', unit: 'mm' })
   const generator = new PDFGenerator(doc)
 

--- a/logs/ERR_LOG.md
+++ b/logs/ERR_LOG.md
@@ -311,3 +311,4 @@
 ## [2025-08-25] Ajuste na rota /api/asaas para permitir pedidos avulsos sem inscricao quando produto nao requer inscricao. Dados do usuario usados para criar cliente - dev - 74680867
 
 ## [2025-07-22] Erro ao acessar searchParams sincronamente na rota /login; login falhava com aviso 'searchParams should be awaited'. Função atualizada para async e parâmetros aguardados. - dev - c203c6d
+## [2025-07-30] Erro "getFontSize" ao gerar PDF; carregamento dinamico do jspdf-autotable resolveu o problema - dev - a7f139bd


### PR DESCRIPTION
## Summary
- lazy load `jspdf-autotable` within generatePDF
- await pdf generation in DashboardResumo
- log PDF `getFontSize` error

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_688a70bbd888832c828e63f138841ca4