### PR TITLE
Fix event lookup in pdf utils

### DIFF
--- a/lib/utils/pdfUtils.ts
+++ b/lib/utils/pdfUtils.ts
@@ -119,11 +119,7 @@ export function getProdutoInfo(produtoId: string, produtos: Produto[]): string {
 // Função para obter nome do evento
 export function getEventoNome(produtoId: string, produtos: Produto[]): string {
   const produto = produtos.find(p => p.id === produtoId)
-  if (produto?.evento_id) {
-    // Aqui você pode buscar o evento real se necessário
-    return produto.evento_id.substring(0, 15)
-  }
-  return 'N/A'
+  return produto?.expand?.evento?.titulo || 'N/A'
 }
 
 // Função para obter CPF do cliente

--- a/types/index.ts
+++ b/types/index.ts
@@ -125,6 +125,7 @@ export type Produto = {
       id: string
       nome: string
     }
+    evento?: Evento
   }
 }
 


### PR DESCRIPTION
## Summary
- retrieve event title from expanded produto
- update Produto type to allow evento expansion

## Testing
- `npm run lint`
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_688a7fdd2648832c90937d2a6b2305b1