### PR TITLE
fix: include additional pedido expansions in Lider painel

### DIFF
--- a/app/admin/lider-painel/page.tsx
+++ b/app/admin/lider-painel/page.tsx
@@ -61,7 +61,7 @@ export default function LiderDashboardPage() {
 
         // Buscar primeira página de pedidos
         const pedRes = await fetch(
-          `/api/pedidos?${params.toString()}&expand=campo,produto`,
+          `/api/pedidos?${params.toString()}&expand=campo,produto,id_inscricao,responsavel`,
           {
             credentials: 'include',
             signal,
@@ -70,7 +70,7 @@ export default function LiderDashboardPage() {
 
         // Buscar todas as páginas restantes de pedidos
         const pedRest = await fetchAllPages<{ items?: Pedido[] } | Pedido>(
-          `/api/pedidos?${params.toString()}&expand=campo,produto`,
+          `/api/pedidos?${params.toString()}&expand=campo,produto,id_inscricao,responsavel`,
           pedRes.totalPages ?? 1,
           signal,
         )
@@ -130,6 +130,8 @@ export default function LiderDashboardPage() {
             campo: r.expand?.campo,
             criado_por: r.expand?.criado_por,
             produto: r.expand?.produto,
+            id_inscricao: r.expand?.id_inscricao,
+            responsavel: r.expand?.responsavel,
           },
         }))
 


### PR DESCRIPTION
## Summary
- fetch `id_inscricao` and `responsavel` when loading pedidos
- keep `expand.id_inscricao` and `expand.responsavel` on mapped `Pedido`

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_688a8245e4d8832c8afc281bd4a2ef2c