### PR TITLE
Fix campo expansion in inscricoes PDF

### DIFF
--- a/lib/services/pdfGenerator.ts
+++ b/lib/services/pdfGenerator.ts
@@ -251,7 +251,7 @@ export class PDFGenerator {
       inscricao.nome || 'Não informado',
       formatCpf(inscricao.cpf || inscricao.id),
       getEventoNome(inscricao.produto || '', produtos),
-      inscricao.campo || 'Não informado',
+      inscricao.expand?.campo?.nome || inscricao.campo || 'Não informado',
       getProdutoInfo(inscricao.produto || '', produtos),
       inscricao.status || 'Não informado',
     ])


### PR DESCRIPTION
## Summary
- fix campo name display in PDF inscricoes table so expanded data is used

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_688a8475104c832cab43ac178836e5c9