### PR TITLE
Add status filters to dashboard charts

### DIFF
--- a/app/admin/components/DashboardAnalytics.tsx
+++ b/app/admin/components/DashboardAnalytics.tsx
@@ -21,6 +21,10 @@ const BarChart = dynamic(() => import('react-chartjs-2').then((m) => m.Bar), {
 interface DashboardAnalyticsProps {
   inscricoes: Inscricao[]
   pedidos: Pedido[]
+  statusInscricao: string
+  statusPedido: string
+  onStatusInscricaoChange: (status: string) => void
+  onStatusPedidoChange: (status: string) => void
   mostrarFinanceiro?: boolean
 }
 
@@ -48,6 +52,10 @@ function groupByDate(
 export default function DashboardAnalytics({
   inscricoes,
   pedidos,
+  statusInscricao,
+  statusPedido,
+  onStatusInscricaoChange,
+  onStatusPedidoChange,
   mostrarFinanceiro = true,
 }: DashboardAnalyticsProps) {
   const [startDate, setStartDate] = useState<string>('')
@@ -367,6 +375,40 @@ export default function DashboardAnalytics({
             onChange={(e) => setEndDate(e.target.value)}
             className="border rounded px-2 py-1"
           />
+        </div>
+        <div className="flex items-center gap-2">
+          <label className="text-sm dark:text-gray-100" htmlFor="statusInscricao">
+            Status Inscrição:
+          </label>
+          <select
+            id="statusInscricao"
+            value={statusInscricao}
+            onChange={(e) => onStatusInscricaoChange(e.target.value)}
+            className="border rounded px-2 py-1 bg-white"
+          >
+            <option value="">Todos</option>
+            <option value="pendente">Pendente</option>
+            <option value="aguardando_pagamento">Aguardando Pagamento</option>
+            <option value="confirmado">Confirmado</option>
+            <option value="cancelado">Cancelado</option>
+          </select>
+        </div>
+        <div className="flex items-center gap-2">
+          <label className="text-sm dark:text-gray-100" htmlFor="statusPedido">
+            Status Pedido:
+          </label>
+          <select
+            id="statusPedido"
+            value={statusPedido}
+            onChange={(e) => onStatusPedidoChange(e.target.value)}
+            className="border rounded px-2 py-1 bg-white"
+          >
+            <option value="">Todos</option>
+            <option value="pendente">Pendente</option>
+            <option value="pago">Pago</option>
+            <option value="vencido">Vencido</option>
+            <option value="cancelado">Cancelado</option>
+          </select>
         </div>
         <button onClick={handleExportPDF} className="btn btn-primary px-3 py-1">
           PDF Geral

--- a/app/admin/dashboard/page.tsx
+++ b/app/admin/dashboard/page.tsx
@@ -19,6 +19,8 @@ export default function DashboardPage() {
   const [page, setPage] = useState(1)
   const [totalPages, setTotalPages] = useState(1)
   const [error, setError] = useState<string | null>(null)
+  const [statusInscricao, setStatusInscricao] = useState<string>('')
+  const [statusPedido, setStatusPedido] = useState<string>('')
   const isMounted = useRef(true)
 
   useEffect(() => {
@@ -208,7 +210,22 @@ export default function DashboardPage() {
             totalInscricoes={totalInscricoes}
             totalPedidos={totalPedidos}
           />
-          <DashboardAnalytics inscricoes={inscricoes} pedidos={pedidos} />
+          <DashboardAnalytics
+            inscricoes={
+              statusInscricao === ''
+                ? inscricoes
+                : inscricoes.filter((i) => i.status === statusInscricao)
+            }
+            pedidos={
+              statusPedido === ''
+                ? pedidos
+                : pedidos.filter((p) => p.status === statusPedido)
+            }
+            statusInscricao={statusInscricao}
+            onStatusInscricaoChange={setStatusInscricao}
+            statusPedido={statusPedido}
+            onStatusPedidoChange={setStatusPedido}
+          />
           <div className="flex justify-center items-center gap-4 mt-4">
             <button
               className="btn btn-primary px-3 py-1"

--- a/app/admin/lider-painel/page.tsx
+++ b/app/admin/lider-painel/page.tsx
@@ -17,6 +17,9 @@ export default function LiderDashboardPage() {
     pedidos: { pendente: 0, pago: 0, cancelado: 0, valorTotal: 0 },
   })
 
+  const [statusInscricao, setStatusInscricao] = useState<string>('')
+  const [statusPedido, setStatusPedido] = useState<string>('')
+
   const [loading, setLoading] = useState(true)
   const isMounted = useRef(true)
 
@@ -138,24 +141,7 @@ export default function LiderDashboardPage() {
         setInscricoes(allInscricoes)
         setPedidos(allPedidos)
 
-        const resumoPedidos = {
-          pendente: allPedidos.filter((p) => p.status === 'pendente').length,
-          pago: allPedidos.filter((p) => p.status === 'pago').length,
-          cancelado: allPedidos.filter((p) => p.status === 'cancelado').length,
-          valorTotal: allPedidos
-            .filter((p) => p.status === 'pago')
-            .reduce((acc, p) => acc + Number(p.valor || 0), 0),
-        }
-
-        const resumoInscricoes = {
-          pendente: allInscricoes.filter((i) => i.status === 'pendente').length,
-          confirmado: allInscricoes.filter((i) => i.status === 'confirmado')
-            .length,
-          cancelado: allInscricoes.filter((i) => i.status === 'cancelado')
-            .length,
-        }
-
-        setTotais({ inscricoes: resumoInscricoes, pedidos: resumoPedidos })
+        // Totais serão calculados separadamente após o carregamento
       } catch (err) {
         console.error('Erro ao carregar dados:', err)
       } finally {
@@ -169,6 +155,36 @@ export default function LiderDashboardPage() {
       controller.abort()
     }
   }, [authChecked, user])
+
+  useEffect(() => {
+    const inscricoesFiltradas =
+      statusInscricao === ''
+        ? inscricoes
+        : inscricoes.filter((i) => i.status === statusInscricao)
+    const pedidosFiltrados =
+      statusPedido === ''
+        ? pedidos
+        : pedidos.filter((p) => p.status === statusPedido)
+
+    const resumoPedidos = {
+      pendente: pedidosFiltrados.filter((p) => p.status === 'pendente').length,
+      pago: pedidosFiltrados.filter((p) => p.status === 'pago').length,
+      cancelado: pedidosFiltrados.filter((p) => p.status === 'cancelado').length,
+      valorTotal: pedidosFiltrados
+        .filter((p) => p.status === 'pago')
+        .reduce((acc, p) => acc + Number(p.valor || 0), 0),
+    }
+
+    const resumoInscricoes = {
+      pendente: inscricoesFiltradas.filter((i) => i.status === 'pendente').length,
+      confirmado: inscricoesFiltradas.filter((i) => i.status === 'confirmado')
+        .length,
+      cancelado: inscricoesFiltradas.filter((i) => i.status === 'cancelado')
+        .length,
+    }
+
+    setTotais({ inscricoes: resumoInscricoes, pedidos: resumoPedidos })
+  }, [inscricoes, pedidos, statusInscricao, statusPedido])
 
   if (loading) {
     return <LoadingOverlay show={true} text="Carregando dashboard..." />
@@ -209,8 +225,20 @@ export default function LiderDashboardPage() {
       </div>
       
       <DashboardAnalytics
-        inscricoes={inscricoes}
-        pedidos={pedidos}
+        inscricoes={
+          statusInscricao === ''
+            ? inscricoes
+            : inscricoes.filter((i) => i.status === statusInscricao)
+        }
+        pedidos={
+          statusPedido === ''
+            ? pedidos
+            : pedidos.filter((p) => p.status === statusPedido)
+        }
+        statusInscricao={statusInscricao}
+        onStatusInscricaoChange={setStatusInscricao}
+        statusPedido={statusPedido}
+        onStatusPedidoChange={setStatusPedido}
         mostrarFinanceiro={false}
       />
     </main>


### PR DESCRIPTION
## Summary
- allow selecting status filters for dashboard analytics
- compute resumo totals using filtered arrays
- pass selected statuses to analytics component

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_688a99c8de30832c9e9bd6635f902f66