### PR TITLE
Fix rawInscricoes expand fields

### DIFF
--- a/app/admin/dashboard/page.tsx
+++ b/app/admin/dashboard/page.tsx
@@ -129,6 +129,8 @@ export default function DashboardPage() {
               campo: r.expand?.campo,
               criado_por: r.expand?.criado_por,
               pedido: r.expand?.pedido,
+              produto: r.expand?.produto,
+              evento: r.expand?.evento,
             },
           }),
         )

--- a/app/admin/relatorios/page.tsx
+++ b/app/admin/relatorios/page.tsx
@@ -397,6 +397,8 @@ export default function RelatoriosPage() {
               campo: r.expand?.campo,
               criado_por: r.expand?.criado_por,
               pedido: r.expand?.pedido,
+              produto: r.expand?.produto,
+              evento: r.expand?.evento,
             },
           }),
         )


### PR DESCRIPTION
## Summary
- include `produto` and `evento` in the mapped `expand` of `rawInscricoes`

## Testing
- `npm run lint`
- `npm run build` *(fails: Creating an optimized production build ...)*

------
https://chatgpt.com/codex/tasks/task_e_688ac27f7038832c851310a6c9748793