### PR TITLE
Improve export sorting

### DIFF
--- a/app/admin/dashboard/components/DashboardResumo.tsx
+++ b/app/admin/dashboard/components/DashboardResumo.tsx
@@ -47,6 +47,7 @@ export default function DashboardResumo({
     exportToExcel({
       inscricoes,
       pedidos,
+      produtos,
       totalInscricoes: totalInscricoesFiltradas,
       totalPedidos: totalPedidosFiltrados,
       valorTotal: valorTotalConfirmado,
@@ -54,11 +55,11 @@ export default function DashboardResumo({
   }
 
   const handleExportInscricoes = () => {
-    exportInscricoesToExcel(inscricoes)
+    exportInscricoesToExcel(inscricoes, produtos)
   }
 
   const handleExportPedidos = () => {
-    exportPedidosToExcel(pedidos)
+    exportPedidosToExcel(pedidos, produtos)
   }
 
   const handleExportPDF = async () => {

--- a/lib/services/pdfGenerator.ts
+++ b/lib/services/pdfGenerator.ts
@@ -335,7 +335,11 @@ export class PDFGenerator {
     this.doc.setFontSize(PDF_CONSTANTS.FONT_SIZES.HEADER)
     this.doc.text('Inscrições Detalhadas', this.margin, 75)
 
-    const rows = inscricoes.map(inscricao => [
+    const sortedInscricoes = [...inscricoes].sort((a, b) =>
+      (a.nome || '').localeCompare(b.nome || '', 'pt-BR'),
+    )
+
+    const rows = sortedInscricoes.map(inscricao => [
       inscricao.nome || 'Não informado',
       formatCpf(inscricao.cpf || inscricao.id),
       getEventoNome(inscricao.produto || '', produtos),
@@ -399,7 +403,11 @@ export class PDFGenerator {
     this.doc.setFontSize(PDF_CONSTANTS.FONT_SIZES.HEADER)
     this.doc.text('Pedidos Detalhados', this.margin, 75)
 
-    const rows = pedidos.map(pedido => [
+    const sortedPedidos = [...pedidos].sort((a, b) =>
+      getNomeCliente(a).localeCompare(getNomeCliente(b), 'pt-BR'),
+    )
+
+    const rows = sortedPedidos.map(pedido => [
       getNomeCliente(pedido),
       formatCpf(getCpfCliente(pedido)),
       pedido.expand?.campo?.nome || pedido.campo || 'Não informado',


### PR DESCRIPTION
## Summary
- sort rows alphabetically in PDF tables
- sync Excel columns with PDF and remove IDs
- include product data when exporting and sort

## Testing
- `npm run lint`
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_688ac955c020832cb0f50625136b146e