### PR TITLE
Atualiza cálculo de Valor Total em relatórios

### DIFF
--- a/app/admin/dashboard/components/DashboardResumo.tsx
+++ b/app/admin/dashboard/components/DashboardResumo.tsx
@@ -22,14 +22,11 @@ export default function DashboardResumo({
   const totalInscricoesFiltradas = totalInscricoes || inscricoes.length
   const totalPedidosFiltrados = totalPedidos || pedidos.length
 
-  const valorTotalConfirmado = inscricoes.reduce((total, i) => {
-    const pedido = i.expand?.pedido
-    const confirmado =
-      i.status === 'confirmado' || i.confirmado_por_lider === true
-    const pago = pedido?.status === 'pago'
-    const valor = Number(pedido?.valor ?? 0)
+  const valorTotalPago = pedidos.reduce((total, pedido) => {
+    const pago = pedido.status === 'pago'
+    const valor = Number(pedido.valor ?? 0)
 
-    if (confirmado && pago && !isNaN(valor)) {
+    if (pago && !isNaN(valor)) {
       return total + valor
     }
 
@@ -60,7 +57,7 @@ export default function DashboardResumo({
         <ResumoCards
           totalInscricoes={totalInscricoesFiltradas}
           totalPedidos={totalPedidosFiltrados}
-          valorTotal={valorTotalConfirmado}
+          valorTotal={valorTotalPago}
         />
       </div>
     </div>

--- a/app/admin/dashboard/components/ResumoCards.tsx
+++ b/app/admin/dashboard/components/ResumoCards.tsx
@@ -60,7 +60,7 @@ export default function ResumoCards({
           <h3 className="text-sm font-bold text-gray-700 dark:text-gray-200">
             Valor Total
           </h3>
-          <Tippy content="Soma dos pedidos pagos com inscrições confirmadas, filtrados conforme os critérios aplicados.">
+          <Tippy content="Soma dos pedidos pagos, filtrados conforme os critérios aplicados.">
             <span>
               <Info className="w-4 h-4 text-yellow-600 dark:text-yellow-400" />
             </span>


### PR DESCRIPTION
## Summary
- soma apenas os pedidos pagos no dashboard de relatórios
- ajusta tooltip do card de valor total

## Testing
- `npm run lint`
- `npm run build` *(falhou por limite de recursos)*

------
https://chatgpt.com/codex/tasks/task_e_688bad6ddf84832c92c183a3b8c781ea